### PR TITLE
Add TRITONBACKEND_ModelConfigSerializedToString

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -27,6 +27,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string>
 #include "triton/core/tritonserver.h"
 
 #ifdef __cplusplus
@@ -716,6 +717,15 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelConfig(
     TRITONBACKEND_Model* model, const uint32_t config_version,
     TRITONSERVER_Message** model_config);
 
+/// Get the model configuration as a serialized string.
+///
+/// \param model The model.
+/// \param serialized_config Returns the model configuration as a serialized
+/// string. \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
+TRITONBACKEND_ModelConfigSerializedToString(
+    TRITONBACKEND_Model* model, std::string* serialized_config);
+
 /// Whether the backend should attempt to auto-complete the model configuration.
 /// If true, the model should fill the inputs, outputs, and max batch size in
 /// the model configuration if incomplete. If the model configuration is
@@ -990,8 +1000,8 @@ TRITONBACKEND_ISPEC TRITONSERVER_Error* TRITONBACKEND_ModelFinalize(
 ///
 /// \param instance The model instance.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONBACKEND_ISPEC TRITONSERVER_Error*
-TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance);
+TRITONBACKEND_ISPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceInitialize(
+    TRITONBACKEND_ModelInstance* instance);
 
 /// Finalize for a model instance. This function is optional, a
 /// backend is not required to implement it. This function is called
@@ -1002,8 +1012,8 @@ TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance);
 ///
 /// \param instance The model instance.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONBACKEND_ISPEC TRITONSERVER_Error*
-TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance);
+TRITONBACKEND_ISPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceFinalize(
+    TRITONBACKEND_ModelInstance* instance);
 
 /// Execute a batch of one or more requests on a model instance. This
 /// function is required. Triton will not perform multiple
@@ -1023,8 +1033,7 @@ TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance);
 /// \param requests The requests.
 /// \param request_count The number of requests in the batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONBACKEND_ISPEC TRITONSERVER_Error*
-TRITONBACKEND_ModelInstanceExecute(
+TRITONBACKEND_ISPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceExecute(
     TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** requests,
     const uint32_t request_count);
 


### PR DESCRIPTION
Needed by custom backend to correctly load using the serialized model config