### PR TITLE
Add the Optimization Profile APIs for TRT backend

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -90,7 +90,7 @@ struct TRITONBACKEND_ModelInstance;
 ///   }
 ///
 #define TRITONBACKEND_API_VERSION_MAJOR 1
-#define TRITONBACKEND_API_VERSION_MINOR 1
+#define TRITONBACKEND_API_VERSION_MINOR 2
 
 /// Get the TRITONBACKEND API version supported by Triton. This value
 /// can be compared against the TRITONBACKEND_API_VERSION_MAJOR and

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -825,6 +825,29 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceDeviceId(
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceIsPassive(
     TRITONBACKEND_ModelInstance* instance, bool* is_passive);
 
+/// Get the number of optimization profiles to be loaded for the instance. 
+///
+/// \param instance The model instance.
+/// \param count Returns the number of optimization profiles.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceProfileCount(
+    TRITONBACKEND_ModelInstance* instance, uint32_t* count);
+
+/// Get the name of optimization profile. The caller does not own
+/// the returned string and must not modify or delete it. The lifetime
+/// of the returned string extends only as long as 'instance'.
+///
+/// \param instance The model instance.
+/// \param index The index of the optimization profile. Must be 0
+/// <= index < count, where count is the value returned by
+/// TRITONBACKEND_ModelInstanceProfileCount.
+/// \param profile_name Returns the name of the optimization profile
+/// corresponding to the index.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelInstanceProfileName(
+    TRITONBACKEND_ModelInstance* instance, const uint32_t index,
+    const char** profile_name);
+
 /// Get the model associated with a model instance.
 ///
 /// \param instance The model instance.

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -630,6 +630,14 @@ TRITONBACKEND_ModelInstanceIsPassive()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceProfileCount()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceProfileName()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONBACKEND_ModelInstanceModel()
 {
 }


### PR DESCRIPTION
I have separated this change in a separate PR from tanmay-dev as it can go for now. I have tested it for TRT backend repo and it passes L0_infer_variable.
This will prevent frequent rebases.
Linked PR on server : https://github.com/triton-inference-server/server/pull/2859