### PR TITLE
Add allocator query APIs

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -91,7 +91,7 @@ struct TRITONBACKEND_ModelInstance;
 ///   }
 ///
 #define TRITONBACKEND_API_VERSION_MAJOR 1
-#define TRITONBACKEND_API_VERSION_MINOR 6
+#define TRITONBACKEND_API_VERSION_MINOR 7
 
 /// Get the TRITONBACKEND API version supported by Triton. This value
 /// can be compared against the TRITONBACKEND_API_VERSION_MAJOR and

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -594,6 +594,28 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseOutput(
     const char* name, const TRITONSERVER_DataType datatype,
     const int64_t* shape, const uint32_t dims_count);
 
+/// Query the response allocator for the preferred memory type and memory
+/// type ID, which will be the attributes of the allocated
+/// buffers if explicitly requested in the sequential call of
+/// TRITONBACKEND_OutputBuffer. 'byte_size' is an optional parameter to
+/// provide more information to the allocator. Note that if 'byte_size' is not
+/// provided, the returned values may not match the attributes of the allocated
+/// buffer even if explicitly requested, as the allocator may allocate
+/// buffers differently based on the requested byte size.
+///
+/// \param response The response.
+/// \param byte_size The expected size of the buffer. This is optional
+/// and it should be set to nullptr to indicate that the byte size has
+/// not determined.
+/// \param memory_type The allocator preferred type of memory.
+/// \param memory_type_id The allocator preferred ID of the memory.
+/// \return a TRITONSERVER_Error object if a failure occurs.
+/// A TRITONSERVER_ERROR_UNAVAILABLE error indicates that the allocator
+/// doesn't provide query functionality.
+TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseAllocatorQuery(
+    TRITONBACKEND_Response* response, size_t* byte_size,
+    TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
+
 /// Send a response. Calling this function transfers ownership of the
 /// response object to Triton. The caller must not access or delete
 /// the response object after calling this function.

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -604,6 +604,9 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseOutput(
 /// buffers differently based on the requested byte size.
 ///
 /// \param response The response.
+/// \param name The name of the output tensor. This is optional
+/// and it should be set to nullptr to indicate that the tensor name has
+/// not determined.
 /// \param byte_size The expected size of the buffer. This is optional
 /// and it should be set to nullptr to indicate that the byte size has
 /// not determined.
@@ -613,7 +616,7 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseOutput(
 /// A TRITONSERVER_ERROR_UNAVAILABLE error indicates that the allocator
 /// doesn't provide query functionality.
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseAllocatorQuery(
-    TRITONBACKEND_Response* response, size_t* byte_size,
+    TRITONBACKEND_Response* response, const char* name,  size_t* byte_size,
     TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
 
 /// Send a response. Calling this function transfers ownership of the

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -452,8 +452,12 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_RequestOutputName(
 /// \param byte_size The expected size of the buffer. This is optional
 /// and it should be set to nullptr to indicate that the byte size has
 /// not determined.
-/// \param memory_type Triton preferred type of memory.
-/// \param memory_type_id Triton preferred ID of the memory.
+/// \param memory_type Acts as both input and output. On input gives
+/// the memory type preferred by the caller. Returns memory type preferred
+/// by Triton, taken account of the caller preferred type.
+/// \param memory_type_id Acts as both input and output. On input gives
+/// the memory type ID preferred by the caller. Returns memory type ID preferred
+/// by Triton, taken account of the caller preferred type ID.
 /// \return a TRITONSERVER_Error object if a failure occurs.
 /// A TRITONSERVER_ERROR_UNAVAILABLE error indicates that the properties are not
 /// available, other error codes indicate an error.

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -439,6 +439,29 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_RequestOutputName(
     TRITONBACKEND_Request* request, const uint32_t index,
     const char** output_name);
 
+/// Returns the preferred memory type and memory type ID of the output buffer
+/// for the request. As much as possible, Triton will attempt to return
+/// the same memory_type and memory_type_id values that will be returned by
+/// the subsequent call to TRITONBACKEND_OutputBuffer, however, the backend must
+/// be capable of handling cases where the values differ.
+///
+/// \param request The request.
+/// \param name The name of the output tensor. This is optional
+/// and it should be set to nullptr to indicate that the tensor name has
+/// not determined.
+/// \param byte_size The expected size of the buffer. This is optional
+/// and it should be set to nullptr to indicate that the byte size has
+/// not determined.
+/// \param memory_type Triton preferred type of memory.
+/// \param memory_type_id Triton preferred ID of the memory.
+/// \return a TRITONSERVER_Error object if a failure occurs.
+/// A TRITONSERVER_ERROR_UNAVAILABLE error indicates that the properties are not
+/// available, other error codes indicate an error.
+TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
+TRITONBACKEND_RequestOutputBufferProperties(
+    TRITONBACKEND_Request* request, const char* name, size_t* byte_size,
+    TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
+
 /// Release the request. The request should be released when it is no
 /// longer needed by the backend. If this call returns with an error
 /// (i.e. non-nullptr) then the request was not released and ownership
@@ -593,31 +616,6 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseOutput(
     TRITONBACKEND_Response* response, TRITONBACKEND_Output** output,
     const char* name, const TRITONSERVER_DataType datatype,
     const int64_t* shape, const uint32_t dims_count);
-
-/// Query the response allocator for the preferred memory type and memory
-/// type ID, which will be the attributes of the allocated
-/// buffers if explicitly requested in the sequential call of
-/// TRITONBACKEND_OutputBuffer. 'byte_size' is an optional parameter to
-/// provide more information to the allocator. Note that if 'byte_size' is not
-/// provided, the returned values may not match the attributes of the allocated
-/// buffer even if explicitly requested, as the allocator may allocate
-/// buffers differently based on the requested byte size.
-///
-/// \param response The response.
-/// \param name The name of the output tensor. This is optional
-/// and it should be set to nullptr to indicate that the tensor name has
-/// not determined.
-/// \param byte_size The expected size of the buffer. This is optional
-/// and it should be set to nullptr to indicate that the byte size has
-/// not determined.
-/// \param memory_type The allocator preferred type of memory.
-/// \param memory_type_id The allocator preferred ID of the memory.
-/// \return a TRITONSERVER_Error object if a failure occurs.
-/// A TRITONSERVER_ERROR_UNAVAILABLE error indicates that the allocator
-/// doesn't provide query functionality.
-TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseAllocatorQuery(
-    TRITONBACKEND_Response* response, const char* name,  size_t* byte_size,
-    TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
 
 /// Send a response. Calling this function transfers ownership of the
 /// response object to Triton. The caller must not access or delete

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -352,7 +352,9 @@ typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorAllocFn_t)(
 ///
 /// \param allocator The allocator that is provided in the call to
 /// TRITONSERVER_InferenceRequestSetResponseCallback.
-/// \param buffer_userp The user-specified value associated
+/// \param userp The user data pointer that is provided as
+/// 'response_allocator_userp' in the call to
+/// TRITONSERVER_InferenceRequestSetResponseCallback.
 /// \param tensor_name The name of the output tensor. This is optional
 /// and it should be set to nullptr to indicate that the tensor name has
 /// not determined.
@@ -361,13 +363,13 @@ typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorAllocFn_t)(
 /// not determined.
 /// \param memory_type Acts as both input and output. On input gives
 /// the memory type preferred by the caller. Returns memory type preferred
-/// by the allocator taken account to the caller preferred type.
+/// by the allocator, taken account of the caller preferred type.
 /// \param memory_type_id Acts as both input and output. On input gives
 /// the memory type ID preferred by the caller. Returns memory type ID preferred
-/// by the allocator taken account to the caller preferred type ID.
+/// by the allocator, taken account of the caller preferred type ID.
 /// \return a TRITONSERVER_Error object if a failure occurs.
 typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorQueryFn_t)(
-    TRITONSERVER_ResponseAllocator* allocator, void* buffer_userp,
+    TRITONSERVER_ResponseAllocator* allocator, void* userp,
     const char* tensor_name, size_t* byte_size,
     TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
 
@@ -474,7 +476,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ResponseAllocatorNew(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ResponseAllocatorSetQueryFunction(
-    TRITONSERVER_ResponseAllocator** allocator,
+    TRITONSERVER_ResponseAllocator* allocator,
     TRITONSERVER_ResponseAllocatorQueryFn_t query_fn);
 
 /// Delete a response allocator.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -380,16 +380,18 @@ typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorStartFn_t)(
 
 /// Type for function that is called to query the allocator's preferred memory
 /// type and memory type ID, which will be the attributes of the allocated
-/// buffers if explicitly requested. 'byte_size' is an optional parameter to
-/// provide more information to the allocator. Note that if 'byte_size' is not
-/// provided, the returned values may not match the attributes of the allocated
-/// buffer even if explicitly requested, as the allocator may allocate
-/// buffers differently based on the requested byte size.
+/// buffers if explicitly requested. 'tensor_name' and 'byte_size' are optional
+/// parameters for the allocator. Note that if 'tensor_name' or 'byte_size' is
+/// not provided, the returned values may not match the attributes of the
+/// allocated buffer even if explicitly requested, as the allocator may allocate
+/// buffers differently based on the requested paramters.
 ///
 /// \param allocator The allocator that is provided in the call to
 /// TRITONSERVER_InferenceRequestSetResponseCallback.
 /// \param buffer_userp The user-specified value associated
-/// with the buffer in TRITONSERVER_ResponseAllocatorAllocFn_t.
+/// \param tensor_name The name of the output tensor. This is optional
+/// and it should be set to nullptr to indicate that the tensor name has
+/// not determined.
 /// \param byte_size The expected size of the buffer. This is optional
 /// and it should be set to nullptr to indicate that the byte size has
 /// not determined.
@@ -398,8 +400,8 @@ typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorStartFn_t)(
 /// \return a TRITONSERVER_Error object if a failure occurs.
 typedef TRITONSERVER_Error* (*TRITONSERVER_ResponseAllocatorQueryFn_t)(
     TRITONSERVER_ResponseAllocator* allocator, void* buffer_userp,
-    size_t* byte_size, TRITONSERVER_MemoryType* memory_type,
-    int64_t* memory_type_id);
+     const char* tensor_name, size_t* byte_size,
+     TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id);
 
 /// Create a new response allocator object.
 ///

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -87,7 +87,7 @@ struct TRITONSERVER_ServerOptions;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 5
+#define TRITONSERVER_API_VERSION_MINOR 6
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -94,6 +94,10 @@ TRITONSERVER_ResponseAllocatorNew()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ResponseAllocatorSetQueryFunction()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ResponseAllocatorDelete()
 {
 }
@@ -535,6 +539,10 @@ TRITONBACKEND_RequestOutputCount()
 }
 TRITONAPI_DECLSPEC void
 TRITONBACKEND_RequestOutputName()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_RequestOutputBufferProperties()
 {
 }
 TRITONAPI_DECLSPEC void


### PR DESCRIPTION
@deadeyegoodwin This is how the new APIs look and feel. The caveat is that the memory type returned by the query API isn't necessarily consistent with the buffer returned by the allocate API. Although for simple allocator (HTTP / GRPC frontend / MLPerf harness), it may not be the issue, but it may be less useful for dynamic allocator (i.e. uses memory pool and has some fallback mechanism).