### PR TITLE
Create API to Register/Unregister Model Repository

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1887,11 +1887,12 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerStop(
 ///
 /// \param server The inference server object.
 /// \param repository_path The full path to the model repository.
-/// \param name_mapping List of name_mapping parameters. Each path mapping has
+/// \param name_mapping List of name_mapping parameters. Each mapping has
 /// the model directory name as its key, overriden model name as its value.
-/// These map each directory to overwritten model names. This is for cases where
-/// the directory name does not match the model. \param model_count Number of
-/// mappings provided \return a TRITONSERVER_Error indicating success or
+/// If the model directory name is empty, there must only be one model directory
+/// in the repository. In that case, the name will be set to that model directory.
+/// \param model_count Number of mappings provided.
+/// \return a TRITONSERVER_Error indicating success or
 /// failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerRegisterModelRepository(

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1883,6 +1883,30 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerStop(
     TRITONSERVER_Server* server);
 
+/// Register a new model repository
+///
+/// \param server The inference server object.
+/// \param repository_path The full path to the model repository.
+/// \param name_mapping List of name_mapping parameters. Each path mapping has
+/// the model directory name as its key, overriden model name as its value.
+/// These map each directory to overwritten model names. This is for cases where
+/// the directory name does not match the model. \param model_count Number of
+/// mappings provided \return a TRITONSERVER_Error indicating success or
+/// failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerRegisterModelRepository(
+    TRITONSERVER_Server* server, const char* repository_path,
+    const TRITONSERVER_Parameter** name_mapping, const uint32_t mapping_count);
+
+/// Unregister a model repository
+///
+/// \param server The inference server object.
+/// \param repository_path The full path to the model repository.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerUnregisterModelRepository(
+    TRITONSERVER_Server* server, const char* repository_path);
+
 /// Check the model repository for changes and update server state
 /// based on those changes.
 ///

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1889,10 +1889,8 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerStop(
 /// \param repository_path The full path to the model repository.
 /// \param name_mapping List of name_mapping parameters. Each mapping has
 /// the model directory name as its key, overriden model name as its value.
-/// If the model directory name is empty, there must only be one model directory
-/// in the repository. In that case, the name will be set to that model
-/// directory. \param model_count Number of mappings provided. \return a
-/// TRITONSERVER_Error indicating success or failure.
+/// \param model_count Number of mappings provided.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1883,7 +1883,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerStop(
     TRITONSERVER_Server* server);
 
-/// Register a new model repository
+/// Register a new model repository. Not available in polling mode.
 ///
 /// \param server The inference server object.
 /// \param repository_path The full path to the model repository.
@@ -1896,7 +1896,7 @@ TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,
     const TRITONSERVER_Parameter** name_mapping, const uint32_t mapping_count);
 
-/// Unregister a model repository
+/// Unregister a model repository. Not available in polling mode.
 ///
 /// \param server The inference server object.
 /// \param repository_path The full path to the model repository.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1890,10 +1890,9 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerStop(
 /// \param name_mapping List of name_mapping parameters. Each mapping has
 /// the model directory name as its key, overriden model name as its value.
 /// If the model directory name is empty, there must only be one model directory
-/// in the repository. In that case, the name will be set to that model directory.
-/// \param model_count Number of mappings provided.
-/// \return a TRITONSERVER_Error indicating success or
-/// failure.
+/// in the repository. In that case, the name will be set to that model
+/// directory. \param model_count Number of mappings provided. \return a
+/// TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -57,7 +57,7 @@ namespace triton { namespace core {
 
 Status
 TritonModel::Create(
-    InferenceServer* server, const std::string& model_repository_path,
+    InferenceServer* server, const std::string& original_model_path,
     const BackendCmdlineConfigMap& backend_cmdline_config_map,
     const HostPolicyCmdlineConfigMap& host_policy_map,
     const std::string& model_name, const int64_t version,
@@ -78,8 +78,7 @@ TritonModel::Create(
   // 'model_name'. This model holds a handle to the localized content
   // so that it persists as long as the model is loaded.
   std::shared_ptr<LocalizedDirectory> localized_model_dir;
-  RETURN_IF_ERROR(LocalizeDirectory(
-      JoinPath({model_repository_path, model_name}), &localized_model_dir));
+  RETURN_IF_ERROR(LocalizeDirectory(original_model_path, &localized_model_dir));
 
   // Get some internal configuration values needed for initialization.
   std::string backend_dir;

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -57,7 +57,7 @@ namespace triton { namespace core {
 
 Status
 TritonModel::Create(
-    InferenceServer* server, const std::string& original_model_path,
+    InferenceServer* server, const std::string& model_path,
     const BackendCmdlineConfigMap& backend_cmdline_config_map,
     const HostPolicyCmdlineConfigMap& host_policy_map,
     const std::string& model_name, const int64_t version,
@@ -78,7 +78,7 @@ TritonModel::Create(
   // 'model_name'. This model holds a handle to the localized content
   // so that it persists as long as the model is loaded.
   std::shared_ptr<LocalizedDirectory> localized_model_dir;
-  RETURN_IF_ERROR(LocalizeDirectory(original_model_path, &localized_model_dir));
+  RETURN_IF_ERROR(LocalizeDirectory(model_path, &localized_model_dir));
 
   // Get some internal configuration values needed for initialization.
   std::string backend_dir;
@@ -104,12 +104,13 @@ TritonModel::Create(
 
   // Get the path to the backend shared library. Search path is
   // version directory, model directory, global backend directory.
-  const auto model_path = localized_model_dir->Path();
-  const auto version_path = JoinPath({model_path, std::to_string(version)});
+  const auto localized_model_path = localized_model_dir->Path();
+  const auto version_path =
+      JoinPath({localized_model_path, std::to_string(version)});
   const std::string global_path =
       JoinPath({backend_dir, specialized_backend_name});
-  const std::vector<std::string> search_paths = {version_path, model_path,
-                                                 global_path};
+  const std::vector<std::string> search_paths = {
+      version_path, localized_model_path, global_path};
 
   std::string backend_libdir;
   std::string backend_libpath;

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -47,7 +47,7 @@ class TritonModelInstance;
 class TritonModel : public Model {
  public:
   static Status Create(
-      InferenceServer* server, const std::string& model_repository_path,
+      InferenceServer* server, const std::string& original_model_path,
       const BackendCmdlineConfigMap& backend_cmdline_config_map,
       const HostPolicyCmdlineConfigMap& host_policy_map,
       const std::string& model_name, const int64_t version,

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -47,7 +47,7 @@ class TritonModelInstance;
 class TritonModel : public Model {
  public:
   static Status Create(
-      InferenceServer* server, const std::string& original_model_path,
+      InferenceServer* server, const std::string& model_path,
       const BackendCmdlineConfigMap& backend_cmdline_config_map,
       const HostPolicyCmdlineConfigMap& host_policy_map,
       const std::string& model_name, const int64_t version,

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1705,7 +1705,7 @@ ModelRepositoryManager::RepositoryIndex(
   std::set<std::string> seen_models;
   std::set<std::string> duplicate_models;
   for (const auto& repository_path : repository_paths_) {
-    // Save this repository_path's model mapping, if it has one.
+    // Save this repository's model mapping, if it has one.
     auto mapping_it = model_mappings_.find(repository_path);
     bool mapping_exists = (mapping_it != model_mappings_.end());
     std::set<std::string> subdirs;
@@ -1790,7 +1790,7 @@ ModelRepositoryManager::Poll(
   if (models.empty()) {
     std::set<std::string> duplicated_models;
     for (const auto& repository_path : repository_paths_) {
-      // Save this repository_path's model mapping, if it has one.
+      // Save this repository's model mapping, if it has one.
       auto mapping_it = model_mappings_.find(repository_path);
       bool has_mapping = false;
       if (mapping_it != model_mappings_.end()) {
@@ -2215,8 +2215,6 @@ ModelRepositoryManager::AddModelMapping(
     LOG_ERROR << "Model mapping already found for repository: ";
     return false;
   }
-
-  // TODO: Move vs copy? Pass by reference (const)?
   model_mappings_[repository_path] = model_mapping;
   return true;
 }
@@ -2231,13 +2229,11 @@ ModelRepositoryManager::RemoveModelMapping(const std::string& repository_path)
   return true;
 }
 
-
-// TODO: Fix this, naming and directory... this returns the directory name
 std::string
 ModelRepositoryManager::ModelSubdir(
     const std::string& model_name, const std::string& repository_path)
 {
-  // Save this repository_path's model mapping, if it has one.
+  // Save this repository's model mapping, if it has one.
   auto model = model_name;
   auto mapping_it = model_mappings_.find(repository_path);
 

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -2162,6 +2162,43 @@ ModelRepositoryManager::UpdateDependencyGraph(
   return Status::Success;
 }
 
+bool
+ModelRepositoryManager::AddModelMapping(
+    const std::string& model_name, const std::string& directory_name)
+{
+  auto model_it = model_mappings_.find(model_name);
+  if (model_it != model_mappings_.end()) {
+    LOG_ERROR << "Model mapping already found for: " << model_name
+              << ", current directory name: " << model_it->second;
+    return false;
+  }
+
+  auto directory_it = directory_mappings_.find(model_name);
+  if (directory_it != directory_mappings_.end()) {
+    // The maps should have the same elements, so the code should never get
+    // here. This is a sanity check.
+    LOG_ERROR << "Directory mapping already found for: " << directory_name
+              << ", current model name: " << directory_it->second;
+    return false;
+  }
+  model_mappings_[model_name] = directory_name;
+  directory_mappings_[directory_name] = model_name;
+  return true;
+}
+
+bool
+ModelRepositoryManager::RemoveModelMapping(const std::string& model_name)
+{
+  auto model_it = model_mappings_.find(model_name);
+  if (model_it == model_mappings_.end()) {
+    LOG_ERROR << "Model mapping not found for: " << model_name;
+    return false;
+  }
+  return (
+      (directory_mappings_.erase(model_it->second) == 1) &&
+      (model_mappings_.erase(model_name) == 1));
+}
+
 Status
 ModelRepositoryManager::CircularcyCheck(
     DependencyNode* current_node, const DependencyNode* start_node)

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1138,7 +1138,6 @@ ModelRepositoryManager::ModelLifeCycle::CreateModel(
     const std::string& model_name, const int64_t version, ModelInfo* model_info)
 {
   LOG_VERBOSE(2) << "CreateModel() '" << model_name << "' version " << version;
-  const auto model_path = JoinPath({model_info->repository_path_, model_name});
   // make copy of the current model config in case model config in model info
   // is updated (another poll) during the creation of the model
   inference::ModelConfig model_config;

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1154,8 +1154,8 @@ ModelRepositoryManager::ModelLifeCycle::CreateModel(
   if (!model_config.backend().empty()) {
     std::unique_ptr<TritonModel> model;
     status = TritonModel::Create(
-        server_, model_info->repository_path_, cmdline_config_map_,
-        host_policy_map_, model_name, version, model_config, &model);
+        server_, model_info->model_path_, cmdline_config_map_, host_policy_map_,
+        model_name, version, model_config, &model);
     is.reset(model.release());
   } else {
 #ifdef TRITON_ENABLE_ENSEMBLE
@@ -1853,7 +1853,7 @@ ModelRepositoryManager::Poll(
                 break;
               }
             }
-            if(mapped){
+            if (mapped) {
               continue;
             }
 

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1893,7 +1893,6 @@ ModelRepositoryManager::Poll(
     const auto& child = pair.first;
     const auto& repository = pair.second;
 
-
     auto model_poll_state = STATE_UNMODIFIED;
     std::string full_path;
     auto model_it = model_mappings_.find(child);
@@ -2250,7 +2249,6 @@ ModelRepositoryManager::AddModelMapping(
     const std::string& model_name, const std::string& repository_path,
     const std::string& subdir_name)
 {
-  // If does not already exist, add new model mapping to mappings.
   auto model_it = model_mappings_.find(model_name);
   if (model_it != model_mappings_.end()) {
     return Status(

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -2187,7 +2187,7 @@ ModelRepositoryManager::AddModelMapping(
 }
 
 bool
-ModelRepositoryManager::RemoveModelMapping(const std::string& model_name)
+ModelRepositoryManager::RemoveModelMappingByName(const std::string& model_name)
 {
   auto model_it = model_mappings_.find(model_name);
   if (model_it == model_mappings_.end()) {
@@ -2197,6 +2197,20 @@ ModelRepositoryManager::RemoveModelMapping(const std::string& model_name)
   return (
       (directory_mappings_.erase(model_it->second) == 1) &&
       (model_mappings_.erase(model_name) == 1));
+}
+
+bool
+ModelRepositoryManager::RemoveModelMappingByDirectory(
+    const std::string& directory_name)
+{
+  auto directory_it = directory_mappings_.find(directory_name);
+  if (directory_it == directory_mappings_.end()) {
+    LOG_ERROR << "Directory mapping not found for: " << directory_name;
+    return false;
+  }
+  return (
+      (model_mappings_.erase(directory_it->second) == 1) &&
+      (directory_mappings_.erase(directory_name) == 1));
 }
 
 Status

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1844,6 +1844,19 @@ ModelRepositoryManager::Poll(
                       << "': " << status.Message();
             *all_models_polled = false;
           } else if (exists_in_this_repo) {
+            // Check to make sure this directory is not mapped.
+            // If mapped, continue to next repository path.
+            bool mapped = false;
+            for (auto const& mapping : model_mappings_) {
+              if (mapping.second.second == full_path) {
+                mapped = true;
+                break;
+              }
+            }
+            if(mapped){
+              continue;
+            }
+
             auto res =
                 model_to_repository.emplace(model.first, repository_path);
             if (res.second) {

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -218,22 +218,18 @@ class ModelRepositoryManager {
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
-  /// Insert a model mapping.
-  /// \param model_name Name of the model.
-  /// \param directory_name Name of the model directory.
+  /// Insert a repository's model mapping.
+  /// \param repository_path Path to model repository.
+  /// \param model_mapping Map of overriden model names to directory names.
   /// \return True on success. False otherwise.
   bool AddModelMapping(
-      const std::string& model_name, const std::string& directory_name);
+      const std::string& repository_path,
+      std::unordered_map<std::string, std::string> model_mapping);
 
   /// Remove a model mapping.
-  /// \param model_name Name of the model.
+  /// \param repository_path Path to model repository.
   /// \return True on success. False otherwise.
-  bool RemoveModelMappingByName(const std::string& model_name);
-
-  /// Remove a model mapping.
-  /// \param directory_name Name of the model directory
-  /// \return True on success. False otherwise.
-  bool RemoveModelMappingByDirectory(const std::string& directory_name);
+  bool RemoveModelMapping(const std::string& repository_path);
 
  private:
   struct ModelInfo;
@@ -337,19 +333,13 @@ class ModelRepositoryManager {
   /// \return True if the node is ready. False otherwise.
   bool CheckNode(DependencyNode* node);
 
-  /// Get the model mappings.
-  /// \return Map with model name as key, directory name as value.
-  const std::unordered_map<std::string, std::string>& ModelMappings() const
+  /// Get the model mappings for all repositories.
+  /// \return Map with repository path as key, model mappings as value.
+  const std::unordered_map<
+      std::string, std::unordered_map<std::string, std::string>>&
+  ModelMappings() const
   {
     return model_mappings_;
-  }
-
-  /// Get the directory mappings.
-  /// \return Map with model directory name as key, overriden model name as
-  /// value
-  const std::unordered_map<std::string, std::string>& DirectoryMappings() const
-  {
-    return directory_mappings_;
   }
 
   Status CircularcyCheck(
@@ -369,8 +359,11 @@ class ModelRepositoryManager {
   std::unordered_map<std::string, std::unique_ptr<DependencyNode>>
       missing_nodes_;
 
-  std::unordered_map<std::string, std::string> model_mappings_;
-  std::unordered_map<std::string, std::string> directory_mappings_;
+  // Map from a repository path to its model mapping, if it has one.
+  // The model mapping maps overridden model names (key) to directory names
+  // (value).
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      model_mappings_;
 
   std::unique_ptr<ModelLifeCycle> model_life_cycle_;
 };

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -218,6 +218,18 @@ class ModelRepositoryManager {
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
+  /// Insert a model mapping.
+  /// \param model_name Name of the model.
+  /// \param directory_name Name of the model directory.
+  /// \return True on success. False otherwise.
+  bool AddModelMapping(
+      const std::string& model_name, const std::string& directory_name);
+
+  /// Remove a model mapping.
+  /// \param model_name Name of the model.
+  /// \return True on success. False otherwise.
+  bool RemoveModelMapping(const std::string& model_name);
+
  private:
   struct ModelInfo;
   class ModelLifeCycle;
@@ -327,40 +339,12 @@ class ModelRepositoryManager {
     return model_mappings_;
   }
 
-  /// Insert a model mapping.
-  /// \param model_name Name of the model.
-  /// \param path Path of the model directory.
-  /// \return True on success. False otherwise.
-  bool AddModelMapping(
-      const std::string& model_name, const std::string& path_name)
-  {
-    if (model_mappings_.find(model_name) != model_mappings_.end()) {
-      return false;  // Already exists.
-    }
-    model_mappings_[model_name] = path_name;
-    path_mappings_[path_name] = model_name;
-  }
-
-  /// Remove a model mapping.
-  /// \param path Path of the model directory.
-  /// \return True on success. False otherwise.
-  bool RemoveModelMapping(const std::string& model_name)
-  {
-    auto it = model_mappings_.find(model_name);
-    if (it == model_mappings_.end()) {
-      return false;
-    }
-    return (
-        (path_mappings_.erase(it->second) == 1) &&
-        (model_mappings_.erase(model) == 1));
-  }
-
-  /// Get the path mappings.
+  /// Get the directory mappings.
   /// \return Map with model directory name as key, overriden model name as
   /// value
-  const std::unordered_map<std::string, std::string>& PathMappings() const
+  const std::unordered_map<std::string, std::string>& DirectoryMappings() const
   {
-    return path_mappings_;
+    return directory_mappings_;
   }
 
   Status CircularcyCheck(
@@ -381,7 +365,7 @@ class ModelRepositoryManager {
       missing_nodes_;
 
   std::unordered_map<std::string, std::string> model_mappings_;
-  std::unordered_map<std::string, std::string> path_mappings_;
+  std::unordered_map<std::string, std::string> directory_mappings_;
 
   std::unique_ptr<ModelLifeCycle> model_life_cycle_;
 };

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -218,6 +218,16 @@ class ModelRepositoryManager {
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
+  // Add model repository path.
+  /// \param repository_path Path to model repository.
+  /// \return error status
+  Status AddModelRepositoryPath(const std::string& path);
+
+  // Remove model repository path.
+  /// \param repository_path Path to model repository.
+  /// \return error status
+  Status RemoveModelRepositoryPath(const std::string& path);
+
   /// Insert a model's mapping.
   /// \param model_name Name of the model.
   /// \param repository_path Path to model repository.
@@ -230,7 +240,7 @@ class ModelRepositoryManager {
   /// Remove a model mapping.
   /// \param repository_path Path of the repository
   /// \return error status
-  Status RemoveModelMappingRepository(const std::string& repository_path);
+  Status RemoveModelMapping(const std::string& repository_path);
 
  private:
   struct ModelInfo;
@@ -346,7 +356,7 @@ class ModelRepositoryManager {
   Status CircularcyCheck(
       DependencyNode* current_node, const DependencyNode* start_node);
 
-  const std::set<std::string> repository_paths_;
+  std::set<std::string> repository_paths_;
   const bool autofill_;
   const bool polling_enabled_;
   const bool model_control_enabled_;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -220,7 +220,7 @@ class ModelRepositoryManager {
 
   /// Insert a repository's model mapping.
   /// \param repository_path Path to model repository.
-  /// \param model_mapping Map of overriden model names to directory names.
+  /// \param model_mapping Map of subdirectory names to overridden model names.
   /// \return True on success. False otherwise.
   bool AddModelMapping(
       const std::string& repository_path,
@@ -231,11 +231,12 @@ class ModelRepositoryManager {
   /// \return True on success. False otherwise.
   bool RemoveModelMapping(const std::string& repository_path);
 
-  /// Get a model's name, checking against its repository's model mappings.
+  /// Return a model's subdirectory name, checking against its repository's
+  /// model mappings.
   /// \param model_name Name of model.
   /// \param repository_path Path to model repository.
   /// \return Path to model.
-  std::string ModelName(
+  std::string ModelSubdir(
       const std::string& model_name, const std::string& repository_path);
 
  private:
@@ -367,8 +368,8 @@ class ModelRepositoryManager {
       missing_nodes_;
 
   // Map from a repository path to its model mapping, if it has one.
-  // The model mapping maps overridden model names (key) to directory names
-  // (value).
+  // The model mapping maps subdirectory names (key) to overridden model
+  // names (value).
   std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
       model_mappings_;
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -218,26 +218,19 @@ class ModelRepositoryManager {
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
-  /// Insert a repository's model mapping.
+  /// Insert a model's mapping.
+  /// \param model_name Name of the model.
   /// \param repository_path Path to model repository.
-  /// \param model_mapping Map of subdirectory names to overridden model names.
+  /// \param subdir_name Subdirectory name of model.
   /// \return error status
   Status AddModelMapping(
-      const std::string& repository_path,
-      std::unordered_map<std::string, std::string> model_mapping);
+      const std::string& model_name, const std::string& repository_path,
+      const std::string& subdir_name);
 
   /// Remove a model mapping.
-  /// \param repository_path Path to model repository.
+  /// \param repository_path Path of the repository
   /// \return error status
-  Status RemoveModelMapping(const std::string& repository_path);
-
-  /// Return a model's subdirectory name, checking against its repository's
-  /// model mappings.
-  /// \param model_name Name of model.
-  /// \param repository_path Path to model repository.
-  /// \return Path to model.
-  std::string ModelSubdir(
-      const std::string& model_name, const std::string& repository_path);
+  Status RemoveModelMappingRepository(const std::string& repository_path);
 
  private:
   struct ModelInfo;
@@ -341,10 +334,10 @@ class ModelRepositoryManager {
   /// \return True if the node is ready. False otherwise.
   bool CheckNode(DependencyNode* node);
 
-  /// Get the model mappings for all repositories.
-  /// \return Map with repository path as key, model mappings as value.
-  const std::unordered_map<
-      std::string, std::unordered_map<std::string, std::string>>&
+  /// Get the model mappings.
+  /// \return Map with model name as key, pair of repository path and full path
+  // as value.
+  const std::unordered_map<std::string, std::pair<std::string, std::string>>&
   ModelMappings() const
   {
     return model_mappings_;
@@ -367,10 +360,9 @@ class ModelRepositoryManager {
   std::unordered_map<std::string, std::unique_ptr<DependencyNode>>
       missing_nodes_;
 
-  // Map from a repository path to its model mapping, if it has one.
-  // The model mapping maps subdirectory names (key) to overridden model
-  // names (value).
-  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+  // Mappings from (overridden) model names to a pair of their repository and
+  // absolute path
+  std::unordered_map<std::string, std::pair<std::string, std::string>>
       model_mappings_;
 
   std::unique_ptr<ModelLifeCycle> model_life_cycle_;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -344,15 +344,6 @@ class ModelRepositoryManager {
   /// \return True if the node is ready. False otherwise.
   bool CheckNode(DependencyNode* node);
 
-  /// Get the model mappings.
-  /// \return Map with model name as key, pair of repository path and full path
-  // as value.
-  const std::unordered_map<std::string, std::pair<std::string, std::string>>&
-  ModelMappings() const
-  {
-    return model_mappings_;
-  }
-
   Status CircularcyCheck(
       DependencyNode* current_node, const DependencyNode* start_node);
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -231,6 +231,12 @@ class ModelRepositoryManager {
   /// \return True on success. False otherwise.
   bool RemoveModelMapping(const std::string& repository_path);
 
+  /// Get a model path.
+  /// \param model_name Name of model.
+  /// \param repository_path Path to model repository.
+  /// \return Path to model.
+  std::string ModelPath(const std::string& model_name, const std::string& repository_path);
+
  private:
   struct ModelInfo;
   class ModelLifeCycle;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -231,11 +231,11 @@ class ModelRepositoryManager {
   /// \return True on success. False otherwise.
   bool RemoveModelMapping(const std::string& repository_path);
 
-  /// Get a model path.
+  /// Get a model's name, checking against its repository's model mappings.
   /// \param model_name Name of model.
   /// \param repository_path Path to model repository.
   /// \return Path to model.
-  std::string ModelPath(
+  std::string ModelName(
       const std::string& model_name, const std::string& repository_path);
 
  private:

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -320,6 +320,60 @@ class ModelRepositoryManager {
   /// \return True if the node is ready. False otherwise.
   bool CheckNode(DependencyNode* node);
 
+  /// Get the model mappings.
+  /// \return Map with model name as key, directory path as value.
+  const std::unordered_map<std::string, std::string>& ModelMappings() const
+  {
+    return model_mappings_;
+  }
+
+  /// Insert a model mapping.
+  /// \param model_name Name of the model.
+  /// \param path Path of the model directory.
+  /// \return True on success. False otherwise.
+  bool AddModelMapping(const std::string& model_name, const std::string& path_name)
+  {
+    if (model_mappings_.find(model_name) != model_mappings_.end()) {
+        return false; // Already exists.
+    }
+    model_mappings_[model_name] = path_name;
+  }
+
+  /// Remove a model mapping.
+  /// \param path Path of the model directory.
+  /// \return True on success. False otherwise.
+  bool RemoveModelMapping(const std::string& model)
+  {
+    return model_mappings_.erase(model) == 1;
+  }
+
+  /// Get the path mappings.
+  /// \return Map with model directory name as key, overriden model name as value
+  const std::unordered_map<std::string, std::string>& PathMappings() const
+  {
+    return path_mappings_;
+  }
+
+  /// Insert a path mapping.
+  /// \param path Path of the model directory.
+  /// \param model_name Name of the model.
+  /// \return True on success. False otherwise.
+  bool AddPathMapping(const std::string& path, const std::string& model_name)
+  {
+    if (path_mappings_.find(model_name) != path_mappings_.end()) {
+        return false; // Already exists.
+    }
+    path_mappings_[path] = model_name;
+  }
+
+  /// Remove a path mapping.
+  /// \param path Path of the model directory.
+  /// \return True on success. False otherwise.
+  bool RemovePathMapping(const std::string& path)
+  {
+    return path_mappings_.erase(path) == 1;
+  }
+  
   Status CircularcyCheck(
       DependencyNode* current_node, const DependencyNode* start_node);
 
@@ -337,6 +391,9 @@ class ModelRepositoryManager {
   std::unordered_map<std::string, std::unique_ptr<DependencyNode>>
       missing_nodes_;
 
+  std::unordered_map<std::string, std::string> model_mappings_;
+  std::unordered_map<std::string, std::string> path_mappings_;
+  
   std::unique_ptr<ModelLifeCycle> model_life_cycle_;
 };
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -218,29 +218,18 @@ class ModelRepositoryManager {
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
-  // Add model repository path.
-  /// \param repository_path Path to model repository.
-  /// \return error status
-  Status AddModelRepositoryPath(const std::string& path);
+  // Register model repository path.
+  /// \param repository Path to model repository.
+  /// \param model_mapping Mapping with (overridden) model name as key, subdir
+  /// name as value. \return error status
+  Status RegisterModelRepository(
+      const std::string& repository,
+      const std::unordered_map<std::string, std::string>& model_mapping);
 
-  // Remove model repository path.
-  /// \param repository_path Path to model repository.
+  // Unregister model repository path.
+  /// \param repository Path to model repository.
   /// \return error status
-  Status RemoveModelRepositoryPath(const std::string& path);
-
-  /// Insert a model's mapping.
-  /// \param model_name Name of the model.
-  /// \param repository_path Path to model repository.
-  /// \param subdir_name Subdirectory name of model.
-  /// \return error status
-  Status AddModelMapping(
-      const std::string& model_name, const std::string& repository_path,
-      const std::string& subdir_name);
-
-  /// Remove a model mapping.
-  /// \param repository_path Path of the repository
-  /// \return error status
-  Status RemoveModelMapping(const std::string& repository_path);
+  Status UnregisterModelRepository(const std::string& repository);
 
  private:
   struct ModelInfo;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -228,7 +228,12 @@ class ModelRepositoryManager {
   /// Remove a model mapping.
   /// \param model_name Name of the model.
   /// \return True on success. False otherwise.
-  bool RemoveModelMapping(const std::string& model_name);
+  bool RemoveModelMappingByName(const std::string& model_name);
+
+  /// Remove a model mapping.
+  /// \param directory_name Name of the model directory
+  /// \return True on success. False otherwise.
+  bool RemoveModelMappingByDirectory(const std::string& directory_name);
 
  private:
   struct ModelInfo;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -235,7 +235,8 @@ class ModelRepositoryManager {
   /// \param model_name Name of model.
   /// \param repository_path Path to model repository.
   /// \return Path to model.
-  std::string ModelPath(const std::string& model_name, const std::string& repository_path);
+  std::string ModelPath(
+      const std::string& model_name, const std::string& repository_path);
 
  private:
   struct ModelInfo;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -221,15 +221,15 @@ class ModelRepositoryManager {
   /// Insert a repository's model mapping.
   /// \param repository_path Path to model repository.
   /// \param model_mapping Map of subdirectory names to overridden model names.
-  /// \return True on success. False otherwise.
-  bool AddModelMapping(
+  /// \return error status
+  Status AddModelMapping(
       const std::string& repository_path,
       std::unordered_map<std::string, std::string> model_mapping);
 
   /// Remove a model mapping.
   /// \param repository_path Path to model repository.
-  /// \return True on success. False otherwise.
-  bool RemoveModelMapping(const std::string& repository_path);
+  /// \return error status
+  Status RemoveModelMapping(const std::string& repository_path);
 
   /// Return a model's subdirectory name, checking against its repository's
   /// model mappings.

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -321,7 +321,7 @@ class ModelRepositoryManager {
   bool CheckNode(DependencyNode* node);
 
   /// Get the model mappings.
-  /// \return Map with model name as key, directory path as value.
+  /// \return Map with model name as key, directory name as value.
   const std::unordered_map<std::string, std::string>& ModelMappings() const
   {
     return model_mappings_;
@@ -331,49 +331,38 @@ class ModelRepositoryManager {
   /// \param model_name Name of the model.
   /// \param path Path of the model directory.
   /// \return True on success. False otherwise.
-  bool AddModelMapping(const std::string& model_name, const std::string& path_name)
+  bool AddModelMapping(
+      const std::string& model_name, const std::string& path_name)
   {
     if (model_mappings_.find(model_name) != model_mappings_.end()) {
-        return false; // Already exists.
+      return false;  // Already exists.
     }
     model_mappings_[model_name] = path_name;
+    path_mappings_[path_name] = model_name;
   }
 
   /// Remove a model mapping.
   /// \param path Path of the model directory.
   /// \return True on success. False otherwise.
-  bool RemoveModelMapping(const std::string& model)
+  bool RemoveModelMapping(const std::string& model_name)
   {
-    return model_mappings_.erase(model) == 1;
+    auto it = model_mappings_.find(model_name);
+    if (it == model_mappings_.end()) {
+      return false;
+    }
+    return (
+        (path_mappings_.erase(it->second) == 1) &&
+        (model_mappings_.erase(model) == 1));
   }
 
   /// Get the path mappings.
-  /// \return Map with model directory name as key, overriden model name as value
+  /// \return Map with model directory name as key, overriden model name as
+  /// value
   const std::unordered_map<std::string, std::string>& PathMappings() const
   {
     return path_mappings_;
   }
 
-  /// Insert a path mapping.
-  /// \param path Path of the model directory.
-  /// \param model_name Name of the model.
-  /// \return True on success. False otherwise.
-  bool AddPathMapping(const std::string& path, const std::string& model_name)
-  {
-    if (path_mappings_.find(model_name) != path_mappings_.end()) {
-        return false; // Already exists.
-    }
-    path_mappings_[path] = model_name;
-  }
-
-  /// Remove a path mapping.
-  /// \param path Path of the model directory.
-  /// \return True on success. False otherwise.
-  bool RemovePathMapping(const std::string& path)
-  {
-    return path_mappings_.erase(path) == 1;
-  }
-  
   Status CircularcyCheck(
       DependencyNode* current_node, const DependencyNode* start_node);
 
@@ -393,7 +382,7 @@ class ModelRepositoryManager {
 
   std::unordered_map<std::string, std::string> model_mappings_;
   std::unordered_map<std::string, std::string> path_mappings_;
-  
+
   std::unique_ptr<ModelLifeCycle> model_life_cycle_;
 };
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -626,7 +626,7 @@ InferenceServer::AddModelRepositoryPath(const std::string& path)
 {
   if (!model_repository_paths_.insert(path).second) {
     return Status(
-        Status::Code::INVALID_ARG,
+        Status::Code::ALREADY_EXISTS,
         "model repository '" + path + "' has been registered");
   }
   return Status::Success;

--- a/src/server.cc
+++ b/src/server.cc
@@ -622,30 +622,18 @@ InferenceServer::PrintBackendAndModelSummary()
 }
 
 Status
-InferenceServer::AddModelRepositoryPath(const std::string& path)
+InferenceServer::RegisterModelRepository(
+    const std::string& repository,
+    const std::unordered_map<std::string, std::string>& model_mapping)
 {
-  return model_repository_manager_->AddModelRepositoryPath(path);
+  return model_repository_manager_->RegisterModelRepository(
+      repository, model_mapping);
 }
 
 Status
-InferenceServer::RemoveModelRepositoryPath(const std::string& path)
+InferenceServer::UnregisterModelRepository(const std::string& repository)
 {
-  return model_repository_manager_->RemoveModelRepositoryPath(path);
-}
-
-Status
-InferenceServer::AddModelMapping(
-    const std::string& model_name, const std::string& repository_path,
-    const std::string& subdir_name)
-{
-  return model_repository_manager_->AddModelMapping(
-      model_name, repository_path, subdir_name);
-}
-
-Status
-InferenceServer::RemoveModelMapping(const std::string& repository_name)
-{
-  return model_repository_manager_->RemoveModelMapping(repository_name);
+  return model_repository_manager_->UnregisterModelRepository(repository);
 }
 
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -638,12 +638,12 @@ InferenceServer::AddModelMapping(
     const std::string& model_name, const std::string& repository_path,
     const std::string& subdir_name)
 {
-  return model_repository_manager_->AddModelMapping(model_name, repository_path, subdir_name);
+  return model_repository_manager_->AddModelMapping(
+      model_name, repository_path, subdir_name);
 }
 
 Status
-InferenceServer::RemoveModelMapping(
-    const std::string& repository_name)
+InferenceServer::RemoveModelMapping(const std::string& repository_name)
 {
   return model_repository_manager_->RemoveModelMapping(repository_name);
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -643,23 +643,17 @@ InferenceServer::RemoveModelRepositoryPath(const std::string& path)
 
 bool
 InferenceServer::AddModelMapping(
-    const std::string& model_name, const std::string& directory_name)
+    const std::string& repository_path,
+    const std::unordered_map<std::string, std::string>& model_mapping)
 {
-  return model_repository_manager_->AddModelMapping(model_name, directory_name);
+  return model_repository_manager_->AddModelMapping(
+      repository_path, model_mapping);
 }
 
 bool
-InferenceServer::RemoveModelMappingByName(const std::string& model_name)
+InferenceServer::RemoveModelMapping(const std::string& repository_path)
 {
-  return model_repository_manager_->RemoveModelMappingByName(model_name);
-}
-
-bool
-InferenceServer::RemoveModelMappingByDirectory(
-    const std::string& directory_name)
-{
-  return model_repository_manager_->RemoveModelMappingByDirectory(
-      directory_name);
+  return model_repository_manager_->RemoveModelMapping(repository_path);
 }
 
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -620,4 +620,38 @@ InferenceServer::PrintBackendAndModelSummary()
 
   return Status::Success;
 }
+
+bool
+InferenceServer::AddModelRepositoryPath(const std::string& path)
+{
+  if (model_repository_paths_.insert(path).second) {
+    LOG_ERROR << "Model repository already registered: " << path;
+    return false;
+  }
+  return true;
+}
+
+bool
+InferenceServer::RemoveModelRepositoryPath(const std::string& path)
+{
+  if (model_repository_paths_.erase(path) != 1) {
+    LOG_ERROR << "Model repository is not registered: " << path;
+    return false;
+  }
+  return true;
+}
+
+bool
+InferenceServer::AddModelMapping(
+    const std::string& model_name, const std::string& directory_name)
+{
+  return model_repository_manager_->AddModelMapping(model_name, directory_name);
+}
+
+bool
+InferenceServer::RemoveModelMapping(const std::string& model_name)
+{
+  return model_repository_manager_->RemoveModelMapping(model_name);
+}
+
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -649,9 +649,17 @@ InferenceServer::AddModelMapping(
 }
 
 bool
-InferenceServer::RemoveModelMapping(const std::string& model_name)
+InferenceServer::RemoveModelMappingByName(const std::string& model_name)
 {
-  return model_repository_manager_->RemoveModelMapping(model_name);
+  return model_repository_manager_->RemoveModelMappingByName(model_name);
+}
+
+bool
+InferenceServer::RemoveModelMappingByDirectory(
+    const std::string& directory_name)
+{
+  return model_repository_manager_->RemoveModelMappingByDirectory(
+      directory_name);
 }
 
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -621,39 +621,44 @@ InferenceServer::PrintBackendAndModelSummary()
   return Status::Success;
 }
 
-bool
+Status
 InferenceServer::AddModelRepositoryPath(const std::string& path)
 {
   if (model_repository_paths_.insert(path).second) {
-    LOG_ERROR << "Model repository already registered: " << path;
-    return false;
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Model repository already registered: " + path);
   }
-  return true;
+  return Status::Success;
 }
 
-bool
+Status
 InferenceServer::RemoveModelRepositoryPath(const std::string& path)
 {
   if (model_repository_paths_.erase(path) != 1) {
-    LOG_ERROR << "Model repository is not registered: " << path;
-    return false;
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Model repository is not registered: " + path);
   }
-  return true;
+  return Status::Success;
 }
 
-bool
+Status
 InferenceServer::AddModelMapping(
     const std::string& repository_path,
     const std::unordered_map<std::string, std::string>& model_mapping)
 {
-  return model_repository_manager_->AddModelMapping(
-      repository_path, model_mapping);
+  RETURN_IF_ERROR(model_repository_manager_->AddModelMapping(
+      repository_path, model_mapping));
+  return Status::Success;
 }
 
-bool
+Status
 InferenceServer::RemoveModelMapping(const std::string& repository_path)
 {
-  return model_repository_manager_->RemoveModelMapping(repository_path);
+  RETURN_IF_ERROR(
+      model_repository_manager_->RemoveModelMapping(repository_path));
+  return Status::Success;
 }
 
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -624,7 +624,7 @@ InferenceServer::PrintBackendAndModelSummary()
 Status
 InferenceServer::AddModelRepositoryPath(const std::string& path)
 {
-  if (model_repository_paths_.insert(path).second) {
+  if (!model_repository_paths_.insert(path).second) {
     return Status(
         Status::Code::INVALID_ARG,
         "model repository '" + path + "' has been registered");

--- a/src/server.cc
+++ b/src/server.cc
@@ -624,23 +624,13 @@ InferenceServer::PrintBackendAndModelSummary()
 Status
 InferenceServer::AddModelRepositoryPath(const std::string& path)
 {
-  if (!model_repository_paths_.insert(path).second) {
-    return Status(
-        Status::Code::ALREADY_EXISTS,
-        "model repository '" + path + "' has been registered");
-  }
-  return Status::Success;
+  return model_repository_manager_->AddModelRepositoryPath(path);
 }
 
 Status
 InferenceServer::RemoveModelRepositoryPath(const std::string& path)
 {
-  if (model_repository_paths_.erase(path) != 1) {
-    return Status(
-        Status::Code::INVALID_ARG,
-        "failed to unregister '" + path + "', repository not found");
-  }
-  return Status::Success;
+  return model_repository_manager_->RemoveModelRepositoryPath(path);
 }
 
 Status
@@ -648,18 +638,14 @@ InferenceServer::AddModelMapping(
     const std::string& model_name, const std::string& repository_path,
     const std::string& subdir_name)
 {
-  RETURN_IF_ERROR(model_repository_manager_->AddModelMapping(
-      model_name, repository_path, subdir_name));
-  return Status::Success;
+  return model_repository_manager_->AddModelMapping(model_name, repository_path, subdir_name);
 }
 
 Status
-InferenceServer::RemoveModelMappingRepository(
+InferenceServer::RemoveModelMapping(
     const std::string& repository_name)
 {
-  RETURN_IF_ERROR(
-      model_repository_manager_->RemoveModelMappingRepository(repository_name));
-  return Status::Success;
+  return model_repository_manager_->RemoveModelMapping(repository_name);
 }
 
 }}  // namespace triton::core

--- a/src/server.cc
+++ b/src/server.cc
@@ -645,19 +645,20 @@ InferenceServer::RemoveModelRepositoryPath(const std::string& path)
 
 Status
 InferenceServer::AddModelMapping(
-    const std::string& repository_path,
-    const std::unordered_map<std::string, std::string>& model_mapping)
+    const std::string& model_name, const std::string& repository_path,
+    const std::string& subdir_name)
 {
   RETURN_IF_ERROR(model_repository_manager_->AddModelMapping(
-      repository_path, model_mapping));
+      model_name, repository_path, subdir_name));
   return Status::Success;
 }
 
 Status
-InferenceServer::RemoveModelMapping(const std::string& repository_path)
+InferenceServer::RemoveModelMappingRepository(
+    const std::string& repository_name)
 {
   RETURN_IF_ERROR(
-      model_repository_manager_->RemoveModelMapping(repository_path));
+      model_repository_manager_->RemoveModelMappingRepository(repository_name));
   return Status::Success;
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -627,7 +627,7 @@ InferenceServer::AddModelRepositoryPath(const std::string& path)
   if (model_repository_paths_.insert(path).second) {
     return Status(
         Status::Code::INVALID_ARG,
-        "Model repository already registered: " + path);
+        "model repository '" + path + "' has been registered");
   }
   return Status::Success;
 }
@@ -638,7 +638,7 @@ InferenceServer::RemoveModelRepositoryPath(const std::string& path)
   if (model_repository_paths_.erase(path) != 1) {
     return Status(
         Status::Code::INVALID_ARG,
-        "Model repository is not registered: " + path);
+        "failed to unregister '" + path + "', repository not found");
   }
   return Status::Success;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -138,13 +138,12 @@ class InferenceServer {
 
   // Add model mapping.
   bool AddModelMapping(
-      const std::string& model_name, const std::string& directory_name);
+      const std::string& repository_path,
+      const std::unordered_map<std::string, std::string>& model_mapping);
 
-  // Remove model mapping via the model name.
-  bool RemoveModelMappingByName(const std::string& model_name);
 
-  // Remove model mapping via the directory name.
-  bool RemoveModelMappingByDirectory(const std::string& directory_name);
+  // Remove model mapping associated with a repository_path.
+  bool RemoveModelMapping(const std::string& repository_path);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -140,8 +140,11 @@ class InferenceServer {
   bool AddModelMapping(
       const std::string& model_name, const std::string& directory_name);
 
-  // Remove model mapping.
-  bool RemoveModelMapping(const std::string& model_name);
+  // Remove model mapping via the model name.
+  bool RemoveModelMappingByName(const std::string& model_name);
+
+  // Remove model mapping via the directory name.
+  bool RemoveModelMappingByDirectory(const std::string& directory_name);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -130,6 +130,19 @@ class InferenceServer {
   // Print backends and models summary
   Status PrintBackendAndModelSummary();
 
+  // Add model repository path.
+  bool AddModelRepositoryPath(const std::string& path);
+
+  // Remove model repository path.
+  bool RemoveModelRepositoryPath(const std::string& path);
+
+  // Add model mapping.
+  bool AddModelMapping(
+      const std::string& model_name, const std::string& directory_name);
+
+  // Remove model mapping.
+  bool RemoveModelMapping(const std::string& model_name);
+
   // Return the server version.
   const std::string& Version() const { return version_; }
 
@@ -149,21 +162,6 @@ class InferenceServer {
   void SetModelRepositoryPaths(const std::set<std::string>& p)
   {
     model_repository_paths_ = p;
-  }
-
-  // Add / remove model repository path
-  // Return true on success, else false
-  bool AddModelRepositoryPath(const std::string& path)
-  {
-    if (model_repository_paths_.insert(path).second) {
-      return false;  // Already exists
-    }
-    return true;
-  }
-
-  void RemoveModelRepositoryPath(const std::string& path)
-  {
-    return model_repository_paths_.erase(path) == 1;
   }
 
   // Get / set model control mode.

--- a/src/server.h
+++ b/src/server.h
@@ -143,7 +143,7 @@ class InferenceServer {
 
 
   // Remove model mapping associated with a repository name.
-  Status RemoveModelMappingRepository(const std::string& repository_name);
+  Status RemoveModelMapping(const std::string& repository_name);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -130,20 +130,13 @@ class InferenceServer {
   // Print backends and models summary
   Status PrintBackendAndModelSummary();
 
-  // Add model repository path.
-  Status AddModelRepositoryPath(const std::string& path);
+  // Register model repository path and associated mappings
+  Status RegisterModelRepository(
+      const std::string& repository,
+      const std::unordered_map<std::string, std::string>& model_mapping);
 
-  // Remove model repository path.
-  Status RemoveModelRepositoryPath(const std::string& path);
-
-  // Add model mapping.
-  Status AddModelMapping(
-      const std::string& model_name, const std::string& repository_path,
-      const std::string& subdir_name);
-
-
-  // Remove model mapping associated with a repository name.
-  Status RemoveModelMapping(const std::string& repository_name);
+  // Unregister model repository path.
+  Status UnregisterModelRepository(const std::string& repository);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -138,12 +138,12 @@ class InferenceServer {
 
   // Add model mapping.
   Status AddModelMapping(
-      const std::string& repository_path,
-      const std::unordered_map<std::string, std::string>& model_mapping);
+      const std::string& model_name, const std::string& repository_path,
+      const std::string& subdir_name);
 
 
-  // Remove model mapping associated with a repository_path.
-  Status RemoveModelMapping(const std::string& repository_path);
+  // Remove model mapping associated with a repository name.
+  Status RemoveModelMappingRepository(const std::string& repository_name);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -155,8 +155,8 @@ class InferenceServer {
   // Return true on success, else false
   bool AddModelRepositoryPath(const std::string& path)
   {
-    if ( model_repository_paths_.insert(path).second ){
-      return false; // Already exists
+    if (model_repository_paths_.insert(path).second) {
+      return false;  // Already exists
     }
     return true;
   }

--- a/src/server.h
+++ b/src/server.h
@@ -131,19 +131,19 @@ class InferenceServer {
   Status PrintBackendAndModelSummary();
 
   // Add model repository path.
-  bool AddModelRepositoryPath(const std::string& path);
+  Status AddModelRepositoryPath(const std::string& path);
 
   // Remove model repository path.
-  bool RemoveModelRepositoryPath(const std::string& path);
+  Status RemoveModelRepositoryPath(const std::string& path);
 
   // Add model mapping.
-  bool AddModelMapping(
+  Status AddModelMapping(
       const std::string& repository_path,
       const std::unordered_map<std::string, std::string>& model_mapping);
 
 
   // Remove model mapping associated with a repository_path.
-  bool RemoveModelMapping(const std::string& repository_path);
+  Status RemoveModelMapping(const std::string& repository_path);
 
   // Return the server version.
   const std::string& Version() const { return version_; }

--- a/src/server.h
+++ b/src/server.h
@@ -151,6 +151,21 @@ class InferenceServer {
     model_repository_paths_ = p;
   }
 
+  // Add / remove model repository path
+  // Return true on success, else false
+  bool AddModelRepositoryPath(const std::string& path)
+  {
+    if ( model_repository_paths_.insert(path).second ){
+      return false; // Already exists
+    }
+    return true;
+  }
+
+  void RemoveModelRepositoryPath(const std::string& path)
+  {
+    return model_repository_paths_.erase(path) == 1;
+  }
+
   // Get / set model control mode.
   ModelControlMode GetModelControlMode() const { return model_control_mode_; }
   void SetModelControlMode(ModelControlMode m) { model_control_mode_ = m; }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -478,3 +478,43 @@ if(${TRITON_ENABLE_METRICS})
     RUNTIME DESTINATION bin
   )
 endif() # TRITON_ENABLE_METRICS
+
+#
+# Unit test for Model Repository Register API
+#
+add_executable(
+  register_api_test
+  register_api_test.cc
+)
+
+set_target_properties(
+  register_api_test
+  PROPERTIES
+    SKIP_BUILD_RPATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH_USE_LINK_PATH FALSE
+    INSTALL_RPATH ""
+)
+
+target_include_directories(
+  register_api_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${GTEST_INCLUDE_DIRS}
+)
+
+target_link_libraries(
+  register_api_test
+  PRIVATE
+    triton-common-error   # from repo-common
+    triton-common-logging # from repo-common
+    triton-core
+    GTest::gtest
+    GTest::gtest_main
+)
+
+install(
+  TARGETS register_api_test
+  RUNTIME DESTINATION bin
+)

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -65,6 +65,8 @@ class RegisterApiTest : public ::testing::Test {
     FAIL_TEST_IF_ERR(
         TRITONSERVER_ServerOptionsNew(&server_options),
         "creating server options");
+    //TODO: Remove. For debugging purposes.
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogInfo(server_options, true), "enabling logs");
     // Triton expects at least one model repository is set at start, set to
     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
     // to load models.
@@ -118,577 +120,577 @@ TEST_F(RegisterApiTest, Register)
       "loading model 'model_0'");
 }
 
-TEST_F(RegisterApiTest, RegisterWithMap)
-{
-  // Registering a repository "models_0" where contains "model_0", but with
-  // different name mapping
-  const char* override_name = "name_0";
-  std::shared_ptr<TRITONSERVER_Parameter> managed_param(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
-  std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
+// TEST_F(RegisterApiTest, RegisterWithMap)
+// {
+//   // Registering a repository "models_0" where contains "model_0", but with
+//   // different name mapping
+//   const char* override_name = "name_0";
+//   std::shared_ptr<TRITONSERVER_Parameter> managed_param(
+//       TRITONSERVER_ParameterNew(
+//           "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
+//       TRITONSERVER_ParameterDelete);
+//   ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
+//   std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
 
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
 
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-  // Request to load "name_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_0"),
-      "loading model 'name_0'");
-}
+//   // Request to load "model_0" which should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
+//   // Request to load "name_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
+//       "loading model 'name_0'");
+// }
 
-TEST_F(RegisterApiTest, RegisterTwice)
-{
-  // Registering a startup repository
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "empty_models", nullptr, 0),
-      TRITONSERVER_ERROR_ALREADY_EXISTS,
-      "model repository 'empty_models' has been registered",
-      "registering model repository 'empty_models'");
-}
+// TEST_F(RegisterApiTest, RegisterTwice)
+// {
+//   // Registering a startup repository
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "empty_models", nullptr, 0),
+//       TRITONSERVER_ERROR_ALREADY_EXISTS,
+//       "model repository 'empty_models' has been registered",
+//       "registering model repository 'empty_models'");
+// }
 
-TEST_F(RegisterApiTest, RegisterTwice2)
-{
-  // Registering the same repository twice
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
+// TEST_F(RegisterApiTest, RegisterTwice2)
+// {
+//   // Registering the same repository twice
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
 
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      TRITONSERVER_ERROR_ALREADY_EXISTS,
-      "model repository 'models_0' has been registered",
-      "registering model repository 'models_0'");
-}
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       TRITONSERVER_ERROR_ALREADY_EXISTS,
+//       "model repository 'models_0' has been registered",
+//       "registering model repository 'models_0'");
+// }
 
-TEST_F(RegisterApiTest, RegisterWithMultiMap)
-{
-  // Registering a repository "models_0" where contains "model_0",
-  // and "model_0" is mapped to two different names
-  std::vector<std::string> override_names{"name_0", "name_1"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  for (const auto& name : override_names) {
-    managed_params.emplace_back(
-        TRITONSERVER_ParameterNew(
-            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
-        TRITONSERVER_ParameterDelete);
-    ASSERT_TRUE(managed_params.back() != nullptr)
-        << "failed to create name mapping pair";
-    name_map.emplace_back(managed_params.back().get());
-  }
+// TEST_F(RegisterApiTest, RegisterWithMultiMap)
+// {
+//   // Registering a repository "models_0" where contains "model_0",
+//   // and "model_0" is mapped to two different names
+//   std::vector<std::string> override_names{"name_0", "name_1"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   for (const auto& name : override_names) {
+//     managed_params.emplace_back(
+//         TRITONSERVER_ParameterNew(
+//             "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+//         TRITONSERVER_ParameterDelete);
+//     ASSERT_TRUE(managed_params.back() != nullptr)
+//         << "failed to create name mapping pair";
+//     name_map.emplace_back(managed_params.back().get());
+//   }
 
-  // Such mapping should be allow as it is mapping to unique names
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
+//   // Such mapping should be allow as it is mapping to unique names
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
 
-  // Request to load "name_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_0"),
-      "loading model 'name_0'");
-  // Request to load "name_1"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_1"),
-      "loading model 'name_1'");
-}
+//   // Request to load "name_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
+//       "loading model 'name_0'");
+//   // Request to load "name_1"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_1"),
+//       "loading model 'name_1'");
+// }
 
-TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
-{
-  // Registering a repository "models_1" where contains "model_0" and "model_1",
-  // map "model_0" to "model_1" which creates confliction, however,
-  // in EXPLICIT mode, mapping lookup will have higher priority than
-  // repository polling so the confliction will be resolved by always loading
-  // the model from mapped directory.
-  std::vector<std::string> override_names{"model_1"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  managed_params.emplace_back(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_params.back() != nullptr)
-      << "failed to create name mapping pair";
-  name_map.emplace_back(managed_params.back().get());
+// TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
+// {
+//   // Registering a repository "models_1" where contains "model_0" and "model_1",
+//   // map "model_0" to "model_1" which creates confliction, however,
+//   // in EXPLICIT mode, mapping lookup will have higher priority than
+//   // repository polling so the confliction will be resolved by always loading
+//   // the model from mapped directory.
+//   std::vector<std::string> override_names{"model_1"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   managed_params.emplace_back(
+//       TRITONSERVER_ParameterNew(
+//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+//       TRITONSERVER_ParameterDelete);
+//   ASSERT_TRUE(managed_params.back() != nullptr)
+//       << "failed to create name mapping pair";
+//   name_map.emplace_back(managed_params.back().get());
 
-  // Such mapping should be allow as it is mapping to unique names
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", name_map.data(), name_map.size()),
-      "registering model repository 'models_1'");
+//   // Such mapping should be allow as it is mapping to unique names
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", name_map.data(), name_map.size()),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_1"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
-  // [FIXME] check if the correct model is loaded (directory "model_0")
-}
+//   // Request to load "model_1"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
+//   // [FIXME] check if the correct model is loaded (directory "model_0")
+// }
 
-TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
-{
-  // Registering a repository "models_1" where contains "model_0" and "model_1",
-  // map both directories to the same name which creates confliction. Different
-  // from 'RegisterWithRepeatedMap', the confliction within the mapping can't be
-  // resolved and error should be returend
-  std::vector<std::string> dir_names{"model_0", "model_1"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  for (const auto& name : dir_names) {
-    managed_params.emplace_back(
-        TRITONSERVER_ParameterNew(
-            name.c_str(), TRITONSERVER_PARAMETER_STRING, "name_0"),
-        TRITONSERVER_ParameterDelete);
-    ASSERT_TRUE(managed_params.back() != nullptr)
-        << "failed to create name mapping pair";
-    name_map.emplace_back(managed_params.back().get());
-  }
+// TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
+// {
+//   // Registering a repository "models_1" where contains "model_0" and "model_1",
+//   // map both directories to the same name which creates confliction. Different
+//   // from 'RegisterWithRepeatedMap', the confliction within the mapping can't be
+//   // resolved and error should be returend
+//   std::vector<std::string> dir_names{"model_0", "model_1"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   for (const auto& name : dir_names) {
+//     managed_params.emplace_back(
+//         TRITONSERVER_ParameterNew(
+//             name.c_str(), TRITONSERVER_PARAMETER_STRING, "name_0"),
+//         TRITONSERVER_ParameterDelete);
+//     ASSERT_TRUE(managed_params.back() != nullptr)
+//         << "failed to create name mapping pair";
+//     name_map.emplace_back(managed_params.back().get());
+//   }
 
-  // Register should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", name_map.data(), name_map.size()),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to register 'models_1', there is conflicting mapping for 'model_1'",
-      "registering model repository 'models_1'");
-}
+//   // Register should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", name_map.data(), name_map.size()),
+//       TRITONSERVER_ERROR_INVALID_ARG,
+//       "failed to register 'models_1', there is conflicting mapping for 'model_1'",
+//       "registering model repository 'models_1'");
+// }
 
-TEST_F(RegisterApiTest, RegisterMulti)
-{
-  // Registering repository "models_0" and "model_1" without mappings,
-  // there are duplicate models but it won't be checked until load
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", name_map.data(), name_map.size()),
-      "registering model repository 'models_1'");
+// TEST_F(RegisterApiTest, RegisterMulti)
+// {
+//   // Registering repository "models_0" and "model_1" without mappings,
+//   // there are duplicate models but it won't be checked until load
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", name_map.data(), name_map.size()),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-  // Request to load "model_1"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
-}
+//   // Request to load "model_0" which should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
+//   // Request to load "model_1"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
+// }
 
-TEST_F(RegisterApiTest, RegisterMultiWithMap)
-{
-  // Registering repository "models_0" and "models_1" without mappings,
-  // there are duplicate models but we provides a "override" map for "models_0",
-  // from "model_0" to "model_0" which sets priority to resolve the conflict.
-  std::vector<std::string> override_names{"model_0"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  managed_params.emplace_back(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_params.back() != nullptr)
-      << "failed to create name mapping pair";
-  name_map.emplace_back(managed_params.back().get());
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", nullptr, 0),
-      "registering model repository 'models_1'");
+// TEST_F(RegisterApiTest, RegisterMultiWithMap)
+// {
+//   // Registering repository "models_0" and "models_1" without mappings,
+//   // there are duplicate models but we provides a "override" map for "models_0",
+//   // from "model_0" to "model_0" which sets priority to resolve the conflict.
+//   std::vector<std::string> override_names{"model_0"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   managed_params.emplace_back(
+//       TRITONSERVER_ParameterNew(
+//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+//       TRITONSERVER_ParameterDelete);
+//   ASSERT_TRUE(managed_params.back() != nullptr)
+//       << "failed to create name mapping pair";
+//   name_map.emplace_back(managed_params.back().get());
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", nullptr, 0),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_0", "model_1"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
-}
+//   // Request to load "model_0", "model_1"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
+// }
 
-TEST_F(RegisterApiTest, RegisterMultiWithMap2)
-{
-  // Registering repository "models_0" and "model_1s",
-  // there are duplicate models but we provides a map for "models_1"
-  // so they all have different name.
-  std::vector<std::string> override_names{"model_2"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  managed_params.emplace_back(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_params.back() != nullptr)
-      << "failed to create name mapping pair";
-  name_map.emplace_back(managed_params.back().get());
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", name_map.data(), name_map.size()),
-      "registering model repository 'models_1'");
+// TEST_F(RegisterApiTest, RegisterMultiWithMap2)
+// {
+//   // Registering repository "models_0" and "model_1s",
+//   // there are duplicate models but we provides a map for "models_1"
+//   // so they all have different name.
+//   std::vector<std::string> override_names{"model_2"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   managed_params.emplace_back(
+//       TRITONSERVER_ParameterNew(
+//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+//       TRITONSERVER_ParameterDelete);
+//   ASSERT_TRUE(managed_params.back() != nullptr)
+//       << "failed to create name mapping pair";
+//   name_map.emplace_back(managed_params.back().get());
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", name_map.data(), name_map.size()),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_0", "model_1", "model_2"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_2"),
-      "loading model 'model_2'");
-}
+//   // Request to load "model_0", "model_1", "model_2"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_2"),
+//       "loading model 'model_2'");
+// }
 
-TEST_F(RegisterApiTest, RegisterMultiWithMap3)
-{
-  // Registering repository "models_0" and "model_1s",
-  // there are duplicate models but we provides a map for both
-  // "models_0" and "models_1" so they all have different name.
-  std::vector<std::string> override_names{"name_0", "name_1"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  for (const auto& name : override_names) {
-    managed_params.emplace_back(
-        TRITONSERVER_ParameterNew(
-            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
-        TRITONSERVER_ParameterDelete);
-    ASSERT_TRUE(managed_params.back() != nullptr)
-        << "failed to create name mapping pair";
-  }
-  std::vector<const TRITONSERVER_Parameter*> models_0_map{
-      managed_params[0].get()};
-  std::vector<const TRITONSERVER_Parameter*> models_1_map{
-      managed_params[1].get()};
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", models_0_map.data(), models_0_map.size()),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", models_1_map.data(), models_1_map.size()),
-      "registering model repository 'models_1'");
+// TEST_F(RegisterApiTest, RegisterMultiWithMap3)
+// {
+//   // Registering repository "models_0" and "model_1s",
+//   // there are duplicate models but we provides a map for both
+//   // "models_0" and "models_1" so they all have different name.
+//   std::vector<std::string> override_names{"name_0", "name_1"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   for (const auto& name : override_names) {
+//     managed_params.emplace_back(
+//         TRITONSERVER_ParameterNew(
+//             "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+//         TRITONSERVER_ParameterDelete);
+//     ASSERT_TRUE(managed_params.back() != nullptr)
+//         << "failed to create name mapping pair";
+//   }
+//   std::vector<const TRITONSERVER_Parameter*> models_0_map{
+//       managed_params[0].get()};
+//   std::vector<const TRITONSERVER_Parameter*> models_1_map{
+//       managed_params[1].get()};
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", models_0_map.data(), models_0_map.size()),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", models_1_map.data(), models_1_map.size()),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_0", "model_1", "model_2"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_0"),
-      "loading model 'name_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_1"),
-      "loading model 'name_1'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
-}
+//   // Request to load "model_0", "model_1", "model_2"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
+//       "loading model 'name_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_1"),
+//       "loading model 'name_1'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
+// }
 
-TEST_F(RegisterApiTest, RegisterNonExistingRepo)
-{
-  // Register should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "unknown_repo", nullptr, 0),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to register 'unknown_repo', repository not found",
-      "registering model repository 'unknown_repo'");
-}
+// TEST_F(RegisterApiTest, RegisterNonExistingRepo)
+// {
+//   // Register should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "unknown_repo", nullptr, 0),
+//       TRITONSERVER_ERROR_INVALID_ARG,
+//       "failed to register 'unknown_repo', repository not found",
+//       "registering model repository 'unknown_repo'");
+// }
 
 
-TEST_F(RegisterApiTest, UnregisterInvalidRepo)
-{
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "unknown_repo"),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to unregister 'unknown_repo', repository not found",
-      "unregistering model repository 'unknown_repo'");
-}
+// TEST_F(RegisterApiTest, UnregisterInvalidRepo)
+// {
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "unknown_repo"),
+//       TRITONSERVER_ERROR_INVALID_ARG,
+//       "failed to unregister 'unknown_repo', repository not found",
+//       "unregistering model repository 'unknown_repo'");
+// }
 
-TEST_F(RegisterApiTest, Unregister)
-{
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-      "unregistering model repository 'empty_models'");
-}
+// TEST_F(RegisterApiTest, Unregister)
+// {
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+//       "unregistering model repository 'empty_models'");
+// }
 
-TEST_F(RegisterApiTest, UnregisterTwice)
-{
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-      "unregistering model repository 'empty_models'");
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to unregister 'empty_models', repository not found",
-      "unregistering model repository 'empty_models'");
-}
+// TEST_F(RegisterApiTest, UnregisterTwice)
+// {
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+//       "unregistering model repository 'empty_models'");
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+//       TRITONSERVER_ERROR_INVALID_ARG,
+//       "failed to unregister 'empty_models', repository not found",
+//       "unregistering model repository 'empty_models'");
+// }
 
-TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
-{
-  // Registering a repository "models_0" where contains "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  // Request to load "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
+// TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
+// {
+//   // Registering a repository "models_0" where contains "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   // Request to load "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
 
-  // Unregister and the model should still be loaded
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-      "unregistering model repository 'models_0'");
+//   // Unregister and the model should still be loaded
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+//       "unregistering model repository 'models_0'");
 
-  bool ready = false;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
-      "Is 'model_0' ready");
-  ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
+//   bool ready = false;
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
+//       "Is 'model_0' ready");
+//   ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
 
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-}
+//   // Request to load "model_0" which should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
+// }
 
-TEST_F(RegisterApiTest, MultiRegister)
-{
-  // Register / unregister a repository "models_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-      "unregistering model repository 'models_0'");
-  // Register / unregister "models_0" again
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-      "unregistering model repository 'models_0'");
-}
+// TEST_F(RegisterApiTest, MultiRegister)
+// {
+//   // Register / unregister a repository "models_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+//       "unregistering model repository 'models_0'");
+//   // Register / unregister "models_0" again
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+//       "unregistering model repository 'models_0'");
+// }
 
-TEST_F(RegisterApiTest, RegisterMulti2)
-{
-  // Registering repository "models_0" and "model_1" without mappings,
-  // there are duplicate models but it won't be checked until load
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_1", name_map.data(), name_map.size()),
-      "registering model repository 'models_1'");
+// TEST_F(RegisterApiTest, RegisterMulti2)
+// {
+//   // Registering repository "models_0" and "model_1" without mappings,
+//   // there are duplicate models but it won't be checked until load
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_1", name_map.data(), name_map.size()),
+//       "registering model repository 'models_1'");
 
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-  // Request to load "model_1"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_1"),
-      "loading model 'model_1'");
+//   // Request to load "model_0" which should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
+//   // Request to load "model_1"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
+//       "loading model 'model_1'");
 
-  // Unregister one of the repos and 'model_0' can be loaded as there is no
-  // confliction
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_1"),
-      "unregistering model repository 'models_1'");
-  // Request to load "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
-}
+//   // Unregister one of the repos and 'model_0' can be loaded as there is no
+//   // confliction
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_1"),
+//       "unregistering model repository 'models_1'");
+//   // Request to load "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
+// }
 
-TEST_F(RegisterApiTest, DifferentMapping)
-{
-  // With register and unregister, user can update a mapping for specific repo.
-  //
-  // Registering repository "models_0" and "model_1" without mappings,
-  // there are duplicate models but it won't be checked until load
-  std::vector<std::string> override_names{"name_0"};
-  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-  std::vector<const TRITONSERVER_Parameter*> name_map;
-  managed_params.emplace_back(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_params.back() != nullptr)
-      << "failed to create name mapping pair";
-  name_map.emplace_back(managed_params.back().get());
+// TEST_F(RegisterApiTest, DifferentMapping)
+// {
+//   // With register and unregister, user can update a mapping for specific repo.
+//   //
+//   // Registering repository "models_0" and "model_1" without mappings,
+//   // there are duplicate models but it won't be checked until load
+//   std::vector<std::string> override_names{"name_0"};
+//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+//   std::vector<const TRITONSERVER_Parameter*> name_map;
+//   managed_params.emplace_back(
+//       TRITONSERVER_ParameterNew(
+//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+//       TRITONSERVER_ParameterDelete);
+//   ASSERT_TRUE(managed_params.back() != nullptr)
+//       << "failed to create name mapping pair";
+//   name_map.emplace_back(managed_params.back().get());
 
-  // First register without mapping
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  // Request to load "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
+//   // First register without mapping
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   // Request to load "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
 
-  // Re-register with mapping
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-      "unregistering model repository 'models_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
-  // Request to load "model_0" will fail, but load "name_0" is okay
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "name_0"),
-      "loading model 'name_0'");
-}
+//   // Re-register with mapping
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+//       "unregistering model repository 'models_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", name_map.data(), name_map.size()),
+//       "registering model repository 'models_0'");
+//   // Request to load "model_0" will fail, but load "name_0" is okay
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
+//       "loading model 'name_0'");
+// }
 
-// Test Fixture that runs server with POLLING mode
-class PollingRegisterApiTest : public ::testing::Test {
- protected:
-  void SetUp() override
-  {
-    // Create running server object.
-    TRITONSERVER_ServerOptions* server_options = nullptr;
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsNew(&server_options),
-        "creating server options");
-    // Triton expects at least one model repository is set at start, set to
-    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
-    // to load models.
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
-            server_options, "empty_models"),
-        "setting model repository path");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetModelControlMode(
-            server_options, TRITONSERVER_MODEL_CONTROL_POLL),
-        "setting model control mode");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsDelete(server_options),
-        "deleting server options");
-    ASSERT_TRUE(server_ != nullptr) << "server not created";
-    bool live = false;
-    for (int i = 10; ((i > 0) && !live); --i) {
-      FAIL_TEST_IF_ERR(
-          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
-    }
-    ASSERT_TRUE(live) << "server not live";
-  }
+// // Test Fixture that runs server with POLLING mode
+// class PollingRegisterApiTest : public ::testing::Test {
+//  protected:
+//   void SetUp() override
+//   {
+//     // Create running server object.
+//     TRITONSERVER_ServerOptions* server_options = nullptr;
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsNew(&server_options),
+//         "creating server options");
+//     // Triton expects at least one model repository is set at start, set to
+//     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+//     // to load models.
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+//             server_options, "empty_models"),
+//         "setting model repository path");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsSetModelControlMode(
+//             server_options, TRITONSERVER_MODEL_CONTROL_POLL),
+//         "setting model control mode");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsDelete(server_options),
+//         "deleting server options");
+//     ASSERT_TRUE(server_ != nullptr) << "server not created";
+//     bool live = false;
+//     for (int i = 10; ((i > 0) && !live); --i) {
+//       FAIL_TEST_IF_ERR(
+//           TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+//     }
+//     ASSERT_TRUE(live) << "server not live";
+//   }
 
-  void TearDown() override
-  {
-    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
-  }
+//   void TearDown() override
+//   {
+//     FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+//   }
 
-  TRITONSERVER_Server* server_ = nullptr;
-};
+//   TRITONSERVER_Server* server_ = nullptr;
+// };
 
-TEST_F(PollingRegisterApiTest, unsupport)
-{
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "empty_models", nullptr, 0),
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "Register API is unsupported in POLL model control mode",
-      "registering model repository 'empty_models'");
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "Unregister API is unsupported in POLL model control mode",
-      "unregistering model repository 'empty_models'");
-}
+// TEST_F(PollingRegisterApiTest, unsupport)
+// {
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "empty_models", nullptr, 0),
+//       TRITONSERVER_ERROR_UNSUPPORTED,
+//       "Register API is unsupported in POLL model control mode",
+//       "registering model repository 'empty_models'");
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+//       TRITONSERVER_ERROR_UNSUPPORTED,
+//       "Unregister API is unsupported in POLL model control mode",
+//       "unregistering model repository 'empty_models'");
+// }
 
-// Test Fixture that runs server with NONE mode
-class NoneRegisterApiTest : public ::testing::Test {
- protected:
-  void SetUp() override
-  {
-    // Create running server object.
-    TRITONSERVER_ServerOptions* server_options = nullptr;
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsNew(&server_options),
-        "creating server options");
-    // Triton expects at least one model repository is set at start, set to
-    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
-    // to load models.
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
-            server_options, "empty_models"),
-        "setting model repository path");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetModelControlMode(
-            server_options, TRITONSERVER_MODEL_CONTROL_NONE),
-        "setting model control mode");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsDelete(server_options),
-        "deleting server options");
-    ASSERT_TRUE(server_ != nullptr) << "server not created";
-    bool live = false;
-    for (int i = 10; ((i > 0) && !live); --i) {
-      FAIL_TEST_IF_ERR(
-          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
-    }
-    ASSERT_TRUE(live) << "server not live";
-  }
+// // Test Fixture that runs server with NONE mode
+// class NoneRegisterApiTest : public ::testing::Test {
+//  protected:
+//   void SetUp() override
+//   {
+//     // Create running server object.
+//     TRITONSERVER_ServerOptions* server_options = nullptr;
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsNew(&server_options),
+//         "creating server options");
+//     // Triton expects at least one model repository is set at start, set to
+//     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+//     // to load models.
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+//             server_options, "empty_models"),
+//         "setting model repository path");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsSetModelControlMode(
+//             server_options, TRITONSERVER_MODEL_CONTROL_NONE),
+//         "setting model control mode");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+//     FAIL_TEST_IF_ERR(
+//         TRITONSERVER_ServerOptionsDelete(server_options),
+//         "deleting server options");
+//     ASSERT_TRUE(server_ != nullptr) << "server not created";
+//     bool live = false;
+//     for (int i = 10; ((i > 0) && !live); --i) {
+//       FAIL_TEST_IF_ERR(
+//           TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+//     }
+//     ASSERT_TRUE(live) << "server not live";
+//   }
 
-  void TearDown() override
-  {
-    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
-  }
+//   void TearDown() override
+//   {
+//     FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+//   }
 
-  TRITONSERVER_Server* server_ = nullptr;
-};
+//   TRITONSERVER_Server* server_ = nullptr;
+// };
 
-TEST_F(NoneRegisterApiTest, unsupport)
-{
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "empty_models", nullptr, 0),
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "Register API is unsupported in NONE model control mode",
-      "registering model repository 'empty_models'");
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "Unregister API is unsupported in NONE model control mode",
-      "unregistering model repository 'empty_models'");
-}
+// TEST_F(NoneRegisterApiTest, unsupport)
+// {
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "empty_models", nullptr, 0),
+//       TRITONSERVER_ERROR_UNSUPPORTED,
+//       "Register API is unsupported in NONE model control mode",
+//       "registering model repository 'empty_models'");
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+//       TRITONSERVER_ERROR_UNSUPPORTED,
+//       "Unregister API is unsupported in NONE model control mode",
+//       "unregistering model repository 'empty_models'");
+// }
 
 }  // namespace
 

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -262,7 +262,7 @@ TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
       TRITONSERVER_ServerRegisterModelRepository(
           server_, "models_1", name_map.data(), name_map.size()),
       TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to register 'models_1', there is conflicting mapping",
+      "failed to register 'models_1', there is conflicting mapping for 'model_1'",
       "registering model repository 'models_1'");
 }
 

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -294,7 +294,7 @@ TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
       TRITONSERVER_ServerRegisterModelRepository(
           server_, "models_1", name_map.data(), name_map.size()),
       TRITONSERVER_ERROR_INVALID_ARG,
-      "failed to register 'models_1', there is conflicting mapping for "
+      "failed to register 'models_1', there is a conflicting mapping for "
       "'name_0'",
       "registering model repository 'models_1'");
 }
@@ -746,12 +746,14 @@ TEST_F(PollingRegisterApiTest, unsupport)
       TRITONSERVER_ServerRegisterModelRepository(
           server_, "empty_models", nullptr, 0),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Register API is unsupported in POLL model control mode",
+      "repository registration is not allowed if model control mode is not "
+      "EXPLICIT",
       "registering model repository 'empty_models'");
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Unregister API is unsupported in POLL model control mode",
+      "repository unregistration is not allowed if model control mode is not "
+      "EXPLICIT",
       "unregistering model repository 'empty_models'");
 }
 
@@ -804,12 +806,14 @@ TEST_F(NoneRegisterApiTest, unsupport)
       TRITONSERVER_ServerRegisterModelRepository(
           server_, "empty_models", nullptr, 0),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Register API is unsupported in NONE model control mode",
+      "repository registration is not allowed if model control mode is not "
+      "EXPLICIT",
       "registering model repository 'empty_models'");
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Unregister API is unsupported in NONE model control mode",
+      "repository unregistration is not allowed if model control mode is not "
+      "EXPLICIT",
       "unregistering model repository 'empty_models'");
 }
 

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -65,13 +65,6 @@ class RegisterApiTest : public ::testing::Test {
     FAIL_TEST_IF_ERR(
         TRITONSERVER_ServerOptionsNew(&server_options),
         "creating server options");
-    // TODO: Remove. For debugging purposes.
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetLogInfo(server_options, false),
-        "enabling info logs");
-    FAIL_TEST_IF_ERR(
-        TRITONSERVER_ServerOptionsSetLogVerbose(server_options, 0),
-        "enabling verbose logs");
     // Triton expects at least one model repository is set at start, set to
     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
     // to load models.
@@ -575,7 +568,7 @@ TEST_F(RegisterApiTest, DifferentMapping)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
+      "failed to load 'model_0', failed to poll from model repository",
       "loading model 'model_0'");
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -65,9 +65,13 @@ class RegisterApiTest : public ::testing::Test {
     FAIL_TEST_IF_ERR(
         TRITONSERVER_ServerOptionsNew(&server_options),
         "creating server options");
-    //TODO: Remove. For debugging purposes.
-    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogInfo(server_options, true), "enabling info logs");
-    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogVerbose(server_options, 5), "enabling verbose logs");
+    // TODO: Remove. For debugging purposes.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetLogInfo(server_options, false),
+        "enabling info logs");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetLogVerbose(server_options, 0),
+        "enabling verbose logs");
     // Triton expects at least one model repository is set at start, set to
     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
     // to load models.
@@ -101,54 +105,54 @@ class RegisterApiTest : public ::testing::Test {
   TRITONSERVER_Server* server_ = nullptr;
 };
 
-// TEST_F(RegisterApiTest, Register)
-// {
-//   // Request to load "model_0" which should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
+TEST_F(RegisterApiTest, Register)
+{
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', no version is available",
+      "loading model 'model_0'");
 
-//   // Registering a repository "models_0" where contains "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   // Request to load "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
-// }
+  // Registering a repository "models_0" where contains "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+}
 
-// TEST_F(RegisterApiTest, RegisterWithMap)
-// {
-//   // Registering a repository "models_0" where contains "model_0", but with
-//   // different name mapping
-//   const char* override_name = "name_0";
-//   std::shared_ptr<TRITONSERVER_Parameter> managed_param(
-//       TRITONSERVER_ParameterNew(
-//           "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
-//       TRITONSERVER_ParameterDelete);
-//   ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
-//   std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
+TEST_F(RegisterApiTest, RegisterWithMap)
+{
+  // Registering a repository "models_0" where contains "model_0", but with
+  // different name mapping
+  const char* override_name = "name_0";
+  std::shared_ptr<TRITONSERVER_Parameter> managed_param(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
+  std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
 
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
 
-//   // Request to load "model_0" which should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
-//   // Request to load "name_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
-//       "loading model 'name_0'");
-// }
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', no version is available",
+      "loading model 'model_0'");
+  // Request to load "name_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+}
 
 TEST_F(RegisterApiTest, RegisterTwice)
 {
@@ -177,243 +181,244 @@ TEST_F(RegisterApiTest, RegisterTwice2)
       "registering model repository 'models_0'");
 }
 
-// TEST_F(RegisterApiTest, RegisterWithMultiMap)
-// {
-//   // Registering a repository "models_0" where contains "model_0",
-//   // and "model_0" is mapped to two different names
-//   std::vector<std::string> override_names{"name_0", "name_1"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   for (const auto& name : override_names) {
-//     managed_params.emplace_back(
-//         TRITONSERVER_ParameterNew(
-//             "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
-//         TRITONSERVER_ParameterDelete);
-//     ASSERT_TRUE(managed_params.back() != nullptr)
-//         << "failed to create name mapping pair";
-//     name_map.emplace_back(managed_params.back().get());
-//   }
+TEST_F(RegisterApiTest, RegisterWithMultiMap)
+{
+  // Registering a repository "models_0" where contains "model_0",
+  // and "model_0" is mapped to two different names
+  std::vector<std::string> override_names{"name_0", "name_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  for (const auto& name : override_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+    name_map.emplace_back(managed_params.back().get());
+  }
 
-//   // Such mapping should be allow as it is mapping to unique names
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
+  // Such mapping should be allow as it is mapping to unique names
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
 
-//   // Request to load "name_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
-//       "loading model 'name_0'");
-//   // Request to load "name_1"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_1"),
-//       "loading model 'name_1'");
-// }
+  // Request to load "name_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+  // Request to load "name_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_1"),
+      "loading model 'name_1'");
+}
 
-// TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
-// {
-//   // Registering a repository "models_1" where contains "model_0" and "model_1",
-//   // map "model_0" to "model_1" which creates confliction, however,
-//   // in EXPLICIT mode, mapping lookup will have higher priority than
-//   // repository polling so the confliction will be resolved by always loading
-//   // the model from mapped directory.
-//   std::vector<std::string> override_names{"model_1"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   managed_params.emplace_back(
-//       TRITONSERVER_ParameterNew(
-//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-//       TRITONSERVER_ParameterDelete);
-//   ASSERT_TRUE(managed_params.back() != nullptr)
-//       << "failed to create name mapping pair";
-//   name_map.emplace_back(managed_params.back().get());
+TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
+{
+  // Registering a repository "models_1" where contains "model_0" and "model_1",
+  // map "model_0" to "model_1" which creates confliction, however,
+  // in EXPLICIT mode, mapping lookup will have higher priority than
+  // repository polling so the confliction will be resolved by always loading
+  // the model from mapped directory.
+  std::vector<std::string> override_names{"model_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
 
-//   // Such mapping should be allow as it is mapping to unique names
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", name_map.data(), name_map.size()),
-//       "registering model repository 'models_1'");
+  // Such mapping should be allow as it is mapping to unique names
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_1"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
-//   // [FIXME] check if the correct model is loaded (directory "model_0")
-// }
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+  // [FIXME] check if the correct model is loaded (directory "model_0")
+}
 
-// TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
-// {
-//   // Registering a repository "models_1" where contains "model_0" and "model_1",
-//   // map both directories to the same name which creates confliction. Different
-//   // from 'RegisterWithRepeatedMap', the confliction within the mapping can't be
-//   // resolved and error should be returend
-//   std::vector<std::string> dir_names{"model_0", "model_1"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   for (const auto& name : dir_names) {
-//     managed_params.emplace_back(
-//         TRITONSERVER_ParameterNew(
-//             name.c_str(), TRITONSERVER_PARAMETER_STRING, "name_0"),
-//         TRITONSERVER_ParameterDelete);
-//     ASSERT_TRUE(managed_params.back() != nullptr)
-//         << "failed to create name mapping pair";
-//     name_map.emplace_back(managed_params.back().get());
-//   }
+TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
+{
+  // Registering a repository "models_1" where contains "model_0" and "model_1",
+  // map both directories to the same name which creates confliction. Different
+  // from 'RegisterWithRepeatedMap', the confliction within the mapping can't be
+  // resolved and error should be returend
+  std::vector<std::string> dir_names{"model_0", "model_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  for (const auto& name : dir_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            name.c_str(), TRITONSERVER_PARAMETER_STRING, "name_0"),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+    name_map.emplace_back(managed_params.back().get());
+  }
 
-//   // Register should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", name_map.data(), name_map.size()),
-//       TRITONSERVER_ERROR_INVALID_ARG,
-//       "failed to register 'models_1', there is conflicting mapping for 'model_1'",
-//       "registering model repository 'models_1'");
-// }
+  // Register should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to register 'models_1', there is conflicting mapping for "
+      "'name_0'",
+      "registering model repository 'models_1'");
+}
 
-// TEST_F(RegisterApiTest, RegisterMulti)
-// {
-//   // Registering repository "models_0" and "model_1" without mappings,
-//   // there are duplicate models but it won't be checked until load
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", name_map.data(), name_map.size()),
-//       "registering model repository 'models_1'");
+TEST_F(RegisterApiTest, RegisterMulti)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_0" which should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
-//   // Request to load "model_1"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
-// }
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', no version is available",
+      "loading model 'model_0'");
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
 
-// TEST_F(RegisterApiTest, RegisterMultiWithMap)
-// {
-//   // Registering repository "models_0" and "models_1" without mappings,
-//   // there are duplicate models but we provides a "override" map for "models_0",
-//   // from "model_0" to "model_0" which sets priority to resolve the conflict.
-//   std::vector<std::string> override_names{"model_0"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   managed_params.emplace_back(
-//       TRITONSERVER_ParameterNew(
-//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-//       TRITONSERVER_ParameterDelete);
-//   ASSERT_TRUE(managed_params.back() != nullptr)
-//       << "failed to create name mapping pair";
-//   name_map.emplace_back(managed_params.back().get());
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", nullptr, 0),
-//       "registering model repository 'models_1'");
+TEST_F(RegisterApiTest, RegisterMultiWithMap)
+{
+  // Registering repository "models_0" and "models_1" without mappings,
+  // there are duplicate models but we provides a "override" map for "models_0",
+  // from "model_0" to "model_0" which sets priority to resolve the conflict.
+  std::vector<std::string> override_names{"model_0"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", nullptr, 0),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_0", "model_1"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
-// }
+  // Request to load "model_0", "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
 
-// TEST_F(RegisterApiTest, RegisterMultiWithMap2)
-// {
-//   // Registering repository "models_0" and "model_1s",
-//   // there are duplicate models but we provides a map for "models_1"
-//   // so they all have different name.
-//   std::vector<std::string> override_names{"model_2"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   managed_params.emplace_back(
-//       TRITONSERVER_ParameterNew(
-//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-//       TRITONSERVER_ParameterDelete);
-//   ASSERT_TRUE(managed_params.back() != nullptr)
-//       << "failed to create name mapping pair";
-//   name_map.emplace_back(managed_params.back().get());
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", name_map.data(), name_map.size()),
-//       "registering model repository 'models_1'");
+TEST_F(RegisterApiTest, RegisterMultiWithMap2)
+{
+  // Registering repository "models_0" and "model_1s",
+  // there are duplicate models but we provides a map for "models_1"
+  // so they all have different name.
+  std::vector<std::string> override_names{"model_2"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_0", "model_1", "model_2"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_2"),
-//       "loading model 'model_2'");
-// }
+  // Request to load "model_0", "model_1", "model_2"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_2"),
+      "loading model 'model_2'");
+}
 
-// TEST_F(RegisterApiTest, RegisterMultiWithMap3)
-// {
-//   // Registering repository "models_0" and "model_1s",
-//   // there are duplicate models but we provides a map for both
-//   // "models_0" and "models_1" so they all have different name.
-//   std::vector<std::string> override_names{"name_0", "name_1"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   for (const auto& name : override_names) {
-//     managed_params.emplace_back(
-//         TRITONSERVER_ParameterNew(
-//             "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
-//         TRITONSERVER_ParameterDelete);
-//     ASSERT_TRUE(managed_params.back() != nullptr)
-//         << "failed to create name mapping pair";
-//   }
-//   std::vector<const TRITONSERVER_Parameter*> models_0_map{
-//       managed_params[0].get()};
-//   std::vector<const TRITONSERVER_Parameter*> models_1_map{
-//       managed_params[1].get()};
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", models_0_map.data(), models_0_map.size()),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", models_1_map.data(), models_1_map.size()),
-//       "registering model repository 'models_1'");
+TEST_F(RegisterApiTest, RegisterMultiWithMap3)
+{
+  // Registering repository "models_0" and "model_1s",
+  // there are duplicate models but we provides a map for both
+  // "models_0" and "models_1" so they all have different name.
+  std::vector<std::string> override_names{"name_0", "name_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  for (const auto& name : override_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+  }
+  std::vector<const TRITONSERVER_Parameter*> models_0_map{
+      managed_params[0].get()};
+  std::vector<const TRITONSERVER_Parameter*> models_1_map{
+      managed_params[1].get()};
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", models_0_map.data(), models_0_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", models_1_map.data(), models_1_map.size()),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_0", "model_1", "model_2"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
-//       "loading model 'name_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_1"),
-//       "loading model 'name_1'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
-// }
+  // Request to load "model_0", "model_1", "model_2"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_1"),
+      "loading model 'name_1'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
 
-// TEST_F(RegisterApiTest, RegisterNonExistingRepo)
-// {
-//   // Register should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "unknown_repo", nullptr, 0),
-//       TRITONSERVER_ERROR_INVALID_ARG,
-//       "failed to register 'unknown_repo', repository not found",
-//       "registering model repository 'unknown_repo'");
-// }
+TEST_F(RegisterApiTest, RegisterNonExistingRepo)
+{
+  // Register should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "unknown_repo", nullptr, 0),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to register 'unknown_repo', repository not found",
+      "registering model repository 'unknown_repo'");
+}
 
 
 TEST_F(RegisterApiTest, UnregisterInvalidRepo)
@@ -444,36 +449,36 @@ TEST_F(RegisterApiTest, UnregisterTwice)
       "unregistering model repository 'empty_models'");
 }
 
-// TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
-// {
-//   // Registering a repository "models_0" where contains "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   // Request to load "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
+TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
+{
+  // Registering a repository "models_0" where contains "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
 
-//   // Unregister and the model should still be loaded
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-//       "unregistering model repository 'models_0'");
+  // Unregister and the model should still be loaded
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
 
-//   bool ready = false;
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
-//       "Is 'model_0' ready");
-//   ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
 
-//   // Request to load "model_0" which should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
-// }
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+}
 
 TEST_F(RegisterApiTest, MultiRegister)
 {
@@ -495,89 +500,89 @@ TEST_F(RegisterApiTest, MultiRegister)
       "unregistering model repository 'models_0'");
 }
 
-// TEST_F(RegisterApiTest, RegisterMulti2)
-// {
-//   // Registering repository "models_0" and "model_1" without mappings,
-//   // there are duplicate models but it won't be checked until load
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_1", name_map.data(), name_map.size()),
-//       "registering model repository 'models_1'");
+TEST_F(RegisterApiTest, RegisterMulti2)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
 
-//   // Request to load "model_0" which should fail
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
-//   // Request to load "model_1"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_1"),
-//       "loading model 'model_1'");
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', no version is available",
+      "loading model 'model_0'");
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
 
-//   // Unregister one of the repos and 'model_0' can be loaded as there is no
-//   // confliction
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_1"),
-//       "unregistering model repository 'models_1'");
-//   // Request to load "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
-// }
+  // Unregister one of the repos and 'model_0' can be loaded as there is no
+  // confliction
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_1"),
+      "unregistering model repository 'models_1'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+}
 
-// TEST_F(RegisterApiTest, DifferentMapping)
-// {
-//   // With register and unregister, user can update a mapping for specific repo.
-//   //
-//   // Registering repository "models_0" and "model_1" without mappings,
-//   // there are duplicate models but it won't be checked until load
-//   std::vector<std::string> override_names{"name_0"};
-//   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
-//   std::vector<const TRITONSERVER_Parameter*> name_map;
-//   managed_params.emplace_back(
-//       TRITONSERVER_ParameterNew(
-//           "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
-//       TRITONSERVER_ParameterDelete);
-//   ASSERT_TRUE(managed_params.back() != nullptr)
-//       << "failed to create name mapping pair";
-//   name_map.emplace_back(managed_params.back().get());
+TEST_F(RegisterApiTest, DifferentMapping)
+{
+  // With register and unregister, user can update a mapping for specific repo.
+  //
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<std::string> override_names{"name_0"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
 
-//   // First register without mapping
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   // Request to load "model_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       "loading model 'model_0'");
+  // First register without mapping
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
 
-//   // Re-register with mapping
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-//       "unregistering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", name_map.data(), name_map.size()),
-//       "registering model repository 'models_0'");
-//   // Request to load "model_0" will fail, but load "name_0" is okay
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
-//       TRITONSERVER_ERROR_INTERNAL,
-//       "failed to load 'model_0', no version is available",
-//       "loading model 'model_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerLoadModel(server_, "name_0"),
-//       "loading model 'name_0'");
-// }
+  // Re-register with mapping
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  // Request to load "model_0" will fail, but load "name_0" is okay
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', no version is available",
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+}
 
-// Test Fixture that runs server with POLLING mode
+// // Test Fixture that runs server with POLLING mode
 class PollingRegisterApiTest : public ::testing::Test {
  protected:
   void SetUp() override

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -214,9 +214,6 @@ TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
   // in EXPLICIT mode, mapping lookup will have higher priority than
   // repository polling so the confliction will be resolved by always loading
   // the model from mapped directory.
-  // [FIXME] should this be expected behavior? Should this be the same for
-  // POLLING mode? Or it should be treated as having dupliciate models since
-  // model manager always iterate the repositories in POLLING.
   std::vector<std::string> override_names{"model_1"};
   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
   std::vector<const TRITONSERVER_Parameter*> name_map;
@@ -297,7 +294,7 @@ TEST_F(RegisterApiTest, RegisterMulti)
 
 TEST_F(RegisterApiTest, RegisterMultiWithMap)
 {
-  // Registering repository "models_0" and "model_1" without mappings,
+  // Registering repository "models_0" and "models_1" without mappings,
   // there are duplicate models but we provides a "override" map for "models_0",
   // from "model_0" to "model_0" which sets priority to resolve the conflict.
   std::vector<std::string> override_names{"model_0"};
@@ -330,7 +327,7 @@ TEST_F(RegisterApiTest, RegisterMultiWithMap)
 
 TEST_F(RegisterApiTest, RegisterMultiWithMap2)
 {
-  // Registering repository "models_0" and "model_1" without mappings,
+  // Registering repository "models_0" and "model_1s",
   // there are duplicate models but we provides a map for "models_1"
   // so they all have different name.
   std::vector<std::string> override_names{"model_2"};
@@ -362,6 +359,335 @@ TEST_F(RegisterApiTest, RegisterMultiWithMap2)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_2"),
       "loading model 'model_2'");
+}
+
+TEST_F(RegisterApiTest, RegisterMultiWithMap3)
+{
+  // Registering repository "models_0" and "model_1s",
+  // there are duplicate models but we provides a map for both
+  // "models_0" and "models_1" so they all have different name.
+  std::vector<std::string> override_names{"name_0", "name_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  for (const auto& name : override_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+  }
+  std::vector<const TRITONSERVER_Parameter*> models_0_map{
+      managed_params[0].get()};
+  std::vector<const TRITONSERVER_Parameter*> models_1_map{
+      managed_params[1].get()};
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", models_0_map.data(), models_0_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", models_1_map.data(), models_1_map.size()),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_0", "model_1", "model_2"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_1"),
+      "loading model 'name_1'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
+
+TEST_F(RegisterApiTest, RegisterNonExistingRepo)
+{
+  // Register should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "unknown_repo", nullptr, 0),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to register 'unknown_repo', repository not found",
+      "registering model repository 'unknown_repo'");
+}
+
+
+TEST_F(RegisterApiTest, UnregisterInvalidRepo)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "unknown_repo"),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to unregister 'unknown_repo', repository not found",
+      "unregistering model repository 'unknown_repo'");
+}
+
+TEST_F(RegisterApiTest, Unregister)
+{
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      "unregistering model repository 'empty_models'");
+}
+
+TEST_F(RegisterApiTest, UnregisterTwice)
+{
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      "unregistering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to unregister 'empty_models', repository not found",
+      "unregistering model repository 'empty_models'");
+}
+
+TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
+{
+  // Registering a repository "models_0" where contains "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+
+  // Unregister and the model should still be loaded
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
+
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+}
+
+TEST_F(RegisterApiTest, MultiRegister)
+{
+  // Register / unregister a repository "models_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+  // Register / unregister "models_0" again
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+}
+
+TEST_F(RegisterApiTest, RegisterMulti2)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+
+  // Unregister one of the repos and 'model_0' can be loaded as there is no
+  // confliction
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_1"),
+      "unregistering model repository 'models_1'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+}
+
+TEST_F(RegisterApiTest, DifferentMapping)
+{
+  // With register and unregister, user can update a mapping for specific repo.
+  //
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<std::string> override_names{"name_0"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+
+  // First register without mapping
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+
+  // Re-register with mapping
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  // Request to load "model_0" will fail, but load "name_0" is okay
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+}
+
+// Test Fixture that runs server with POLLING mode
+class PollingRegisterApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    // Create running server object.
+    TRITONSERVER_ServerOptions* server_options = nullptr;
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsNew(&server_options),
+        "creating server options");
+    // Triton expects at least one model repository is set at start, set to
+    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+    // to load models.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+            server_options, "empty_models"),
+        "setting model repository path");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelControlMode(
+            server_options, TRITONSERVER_MODEL_CONTROL_POLL),
+        "setting model control mode");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsDelete(server_options),
+        "deleting server options");
+    ASSERT_TRUE(server_ != nullptr) << "server not created";
+    bool live = false;
+    for (int i = 10; ((i > 0) && !live); --i) {
+      FAIL_TEST_IF_ERR(
+          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+    }
+    ASSERT_TRUE(live) << "server not live";
+  }
+
+  void TearDown() override
+  {
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+  }
+
+  TRITONSERVER_Server* server_ = nullptr;
+};
+
+TEST_F(PollingRegisterApiTest, unsupport)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Register API is unsupported in POLLING model control mode",
+      "registering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Unregister API is unsupported in POLLING model control mode",
+      "unregistering model repository 'empty_models'");
+}
+
+// Test Fixture that runs server with NONE mode
+class NoneRegisterApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    // Create running server object.
+    TRITONSERVER_ServerOptions* server_options = nullptr;
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsNew(&server_options),
+        "creating server options");
+    // Triton expects at least one model repository is set at start, set to
+    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+    // to load models.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+            server_options, "empty_models"),
+        "setting model repository path");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelControlMode(
+            server_options, TRITONSERVER_MODEL_CONTROL_NONE),
+        "setting model control mode");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsDelete(server_options),
+        "deleting server options");
+    ASSERT_TRUE(server_ != nullptr) << "server not created";
+    bool live = false;
+    for (int i = 10; ((i > 0) && !live); --i) {
+      FAIL_TEST_IF_ERR(
+          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+    }
+    ASSERT_TRUE(live) << "server not live";
+  }
+
+  void TearDown() override
+  {
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+  }
+
+  TRITONSERVER_Server* server_ = nullptr;
+};
+
+TEST_F(NoneRegisterApiTest, unsupport)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Register API is unsupported in NONE model control mode",
+      "registering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Unregister API is unsupported in NONE model control mode",
+      "unregistering model repository 'empty_models'");
 }
 
 }  // namespace

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -118,6 +118,12 @@ TEST_F(RegisterApiTest, Register)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       "loading model 'model_0'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+      "Is 'model_0' v1 ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
 }
 
 TEST_F(RegisterApiTest, RegisterWithMap)
@@ -147,36 +153,12 @@ TEST_F(RegisterApiTest, RegisterWithMap)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),
       "loading model 'name_0'");
-}
-
-TEST_F(RegisterApiTest, RegisterWithMap2)
-{
-  // Registering a repository "models_2" where contains "model_2", but with
-  // different name mapping. Different from "RegisterWithMap", the directory
-  // name does not match the original model name.
-  const char* override_name = "mapped_name";
-  std::shared_ptr<TRITONSERVER_Parameter> managed_param(
-      TRITONSERVER_ParameterNew(
-          "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
-      TRITONSERVER_ParameterDelete);
-  ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
-  std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
-
+  bool ready = false;
   FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", name_map.data(), name_map.size()),
-      "registering model repository 'models_0'");
-
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
-  // Request to load "mapped_name"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "mapped_name"),
-      "loading model 'mapped_name'");
+      TRITONSERVER_ServerModelIsReady(server_, "name_0", 1, &ready),
+      "Is 'name_0' v1 ready");
+  ASSERT_TRUE(ready) << "Expect 'name_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
 }
 
 TEST_F(RegisterApiTest, RegisterTwice)
@@ -233,10 +215,23 @@ TEST_F(RegisterApiTest, RegisterWithMultiMap)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),
       "loading model 'name_0'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "name_0", 1, &ready),
+      "Is 'name_0' v1 ready");
+  ASSERT_TRUE(ready) << "Expect 'name_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
   // Request to load "name_1"
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_1"),
       "loading model 'name_1'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "name_1", 1, &ready),
+      "Is 'name_1' v1 ready");
+  ASSERT_TRUE(ready) << "Expect 'name_1' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
 }
 
 TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
@@ -267,7 +262,12 @@ TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_1"),
       "loading model 'model_1'");
-  // [FIXME] check if the correct model is loaded (directory "model_0")
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 2, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v2 to be ready, model directory is "
+                        "'models_1/model_0'";
 }
 
 TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
@@ -323,6 +323,12 @@ TEST_F(RegisterApiTest, RegisterMulti)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_1"),
       "loading model 'model_1'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 3, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v3 to be ready, model directory is "
+                        "'models_1/model_1'";
 }
 
 TEST_F(RegisterApiTest, RegisterMultiWithMap)
@@ -353,9 +359,22 @@ TEST_F(RegisterApiTest, RegisterMultiWithMap)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       "loading model 'model_0'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_1"),
       "loading model 'model_1'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 3, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v3 to be ready, model directory is "
+                        "'models_1/model_1'";
 }
 
 TEST_F(RegisterApiTest, RegisterMultiWithMap2)
@@ -386,12 +405,32 @@ TEST_F(RegisterApiTest, RegisterMultiWithMap2)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       "loading model 'model_0'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_1"),
       "loading model 'model_1'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 3, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v3 to be ready, model directory is "
+                        "'models_1/model_1'";
+
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_2"),
       "loading model 'model_2'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_2", 2, &ready),
+      "Is 'model_2' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_2' v2 to be ready, model directory is "
+                        "'models_1/model_0'";
 }
 
 TEST_F(RegisterApiTest, RegisterMultiWithMap3)
@@ -426,12 +465,32 @@ TEST_F(RegisterApiTest, RegisterMultiWithMap3)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),
       "loading model 'name_0'");
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "name_0", 1, &ready),
+      "Is 'name_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'name_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_1"),
       "loading model 'name_1'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "name_1", 2, &ready),
+      "Is 'name_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'name_1' v2 to be ready, model directory is "
+                        "'models_1/model_0'";
+
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_1"),
       "loading model 'model_1'");
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 3, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v3 to be ready, model directory is "
+                        "'models_1/model_1'";
 }
 
 TEST_F(RegisterApiTest, RegisterNonExistingRepo)
@@ -493,9 +552,10 @@ TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
 
   bool ready = false;
   FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerModelIsReady(server_, "model_0", -1, &ready),
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
       "Is 'model_0' ready");
-  ASSERT_TRUE(ready) << "Expect 'model_0' to be ready";
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
 
   // Request to load "model_0" which should fail
   FAIL_TEST_IF_NOT_ERR(
@@ -559,14 +619,25 @@ TEST_F(RegisterApiTest, RegisterMulti2)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       "loading model 'model_0'");
+
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_1", 3, &ready),
+      "Is 'model_1' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_1' v3 to be ready, model directory is "
+                        "'models_1/model_1'";
 }
 
 TEST_F(RegisterApiTest, DifferentMapping)
 {
   // With register and unregister, user can update a mapping for specific repo.
-  //
-  // Registering repository "models_0" and "model_1" without mappings,
-  // there are duplicate models but it won't be checked until load
   std::vector<std::string> override_names{"name_0"};
   std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
   std::vector<const TRITONSERVER_Parameter*> name_map;
@@ -605,6 +676,25 @@ TEST_F(RegisterApiTest, DifferentMapping)
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),
       "loading model 'name_0'");
+
+  bool ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "name_0", 1, &ready),
+      "Is 'name_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'name_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
+
+  // [FIXME] need to revisit this, currently the model manager will actually
+  // unload 'model_0' as the side affect of calling load 'model_0' after updated
+  // the mapping, the reasoning is 'model_0' no longing "seen" in any
+  // repositories. Probably not the expected behavior as we want to keep the
+  // previously loaded 'model_0'
+  // ready = false;
+  // FAIL_TEST_IF_ERR(
+  //     TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+  //     "Is 'model_0' ready");
+  // ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is
+  // 'models_0/model_0'";
 }
 
 // // Test Fixture that runs server with POLLING mode

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -1,0 +1,374 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <iostream>
+#include <thread>
+#include "gtest/gtest.h"
+#include "triton/core/tritonserver.h"
+
+namespace {
+
+#define FAIL_TEST_IF_ERR(X, MSG)                                              \
+  do {                                                                        \
+    std::shared_ptr<TRITONSERVER_Error> err__((X), TRITONSERVER_ErrorDelete); \
+    ASSERT_TRUE((err__ == nullptr))                                           \
+        << "error: " << (MSG) << ": "                                         \
+        << TRITONSERVER_ErrorCodeString(err__.get()) << " - "                 \
+        << TRITONSERVER_ErrorMessage(err__.get());                            \
+  } while (false)
+
+#define FAIL_TEST_IF_NOT_ERR(X, CODE, ERR_MSG, MSG)                           \
+  do {                                                                        \
+    std::shared_ptr<TRITONSERVER_Error> err__((X), TRITONSERVER_ErrorDelete); \
+    ASSERT_TRUE((err__ != nullptr)) << "expected error on: " << (MSG);        \
+    if (err__ != nullptr) {                                                   \
+      EXPECT_EQ(TRITONSERVER_ErrorCode(err__.get()), (CODE)) << (MSG);        \
+      EXPECT_STREQ(TRITONSERVER_ErrorMessage(err__.get()), (ERR_MSG))         \
+          << (MSG);                                                           \
+    }                                                                         \
+  } while (false)
+
+// Test Fixture, this test suit expects the current direcotry to
+// have the following file structure:
+//  - empty_models (empty directory)
+//  - models_0 (contain model directory "model_0")
+//  - models_1 (contain model directories "model_0", "model_1")
+class RegisterApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    // Create running server object.
+    TRITONSERVER_ServerOptions* server_options = nullptr;
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsNew(&server_options),
+        "creating server options");
+    // Triton expects at least one model repository is set at start, set to
+    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+    // to load models.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+            server_options, "empty_models"),
+        "setting model repository path");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelControlMode(
+            server_options, TRITONSERVER_MODEL_CONTROL_EXPLICIT),
+        "setting model control mode");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsDelete(server_options),
+        "deleting server options");
+    ASSERT_TRUE(server_ != nullptr) << "server not created";
+    bool live = false;
+    for (int i = 10; ((i > 0) && !live); --i) {
+      FAIL_TEST_IF_ERR(
+          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+    }
+    ASSERT_TRUE(live) << "server not live";
+  }
+
+  void TearDown() override
+  {
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+  }
+
+  TRITONSERVER_Server* server_ = nullptr;
+};
+
+TEST_F(RegisterApiTest, Register)
+{
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+
+  // Registering a repository "models_0" where contains "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  // Request to load "model_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+}
+
+TEST_F(RegisterApiTest, RegisterWithMap)
+{
+  // Registering a repository "models_0" where contains "model_0", but with
+  // different name mapping
+  const char* override_name = "name_0";
+  std::shared_ptr<TRITONSERVER_Parameter> managed_param(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_name),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_param != nullptr) << "failed to create name mapping pair";
+  std::vector<const TRITONSERVER_Parameter*> name_map{managed_param.get()};
+
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+  // Request to load "name_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+}
+
+TEST_F(RegisterApiTest, RegisterTwice)
+{
+  // Registering a startup repository
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_ALREADY_EXISTS,
+      "model repository 'empty_models' has been registered",
+      "registering model repository 'empty_models'");
+}
+
+TEST_F(RegisterApiTest, RegisterTwice2)
+{
+  // Registering the same repository twice
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      TRITONSERVER_ERROR_ALREADY_EXISTS,
+      "model repository 'models_0' has been registered",
+      "registering model repository 'models_0'");
+}
+
+TEST_F(RegisterApiTest, RegisterWithMultiMap)
+{
+  // Registering a repository "models_0" where contains "model_0",
+  // and "model_0" is mapped to two different names
+  std::vector<std::string> override_names{"name_0", "name_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  for (const auto& name : override_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            "model_0", TRITONSERVER_PARAMETER_STRING, name.c_str()),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+    name_map.emplace_back(managed_params.back().get());
+  }
+
+  // Such mapping should be allow as it is mapping to unique names
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+
+  // Request to load "name_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_0"),
+      "loading model 'name_0'");
+  // Request to load "name_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "name_1"),
+      "loading model 'name_1'");
+}
+
+TEST_F(RegisterApiTest, RegisterWithRepeatedMap)
+{
+  // Registering a repository "models_1" where contains "model_0" and "model_1",
+  // map "model_0" to "model_1" which creates confliction, however,
+  // in EXPLICIT mode, mapping lookup will have higher priority than
+  // repository polling so the confliction will be resolved by always loading
+  // the model from mapped directory.
+  // [FIXME] should this be expected behavior? Should this be the same for
+  // POLLING mode? Or it should be treated as having dupliciate models since
+  // model manager always iterate the repositories in POLLING.
+  std::vector<std::string> override_names{"model_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+
+  // Such mapping should be allow as it is mapping to unique names
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+  // [FIXME] check if the correct model is loaded (directory "model_0")
+}
+
+TEST_F(RegisterApiTest, RegisterWithRepeatedMap2)
+{
+  // Registering a repository "models_1" where contains "model_0" and "model_1",
+  // map both directories to the same name which creates confliction. Different
+  // from 'RegisterWithRepeatedMap', the confliction within the mapping can't be
+  // resolved and error should be returend
+  std::vector<std::string> dir_names{"model_0", "model_1"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  for (const auto& name : dir_names) {
+    managed_params.emplace_back(
+        TRITONSERVER_ParameterNew(
+            name.c_str(), TRITONSERVER_PARAMETER_STRING, "name_0"),
+        TRITONSERVER_ParameterDelete);
+    ASSERT_TRUE(managed_params.back() != nullptr)
+        << "failed to create name mapping pair";
+    name_map.emplace_back(managed_params.back().get());
+  }
+
+  // Register should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to register 'models_1', there is conflicting mapping",
+      "registering model repository 'models_1'");
+}
+
+TEST_F(RegisterApiTest, RegisterMulti)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but it won't be checked until load
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_0" which should fail
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      TRITONSERVER_ERROR_INTERNAL,
+      "failed to load 'model_0', failed to poll from model repository",
+      "loading model 'model_0'");
+  // Request to load "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
+
+TEST_F(RegisterApiTest, RegisterMultiWithMap)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but we provides a "override" map for "models_0",
+  // from "model_0" to "model_0" which sets priority to resolve the conflict.
+  std::vector<std::string> override_names{"model_0"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", name_map.data(), name_map.size()),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", nullptr, 0),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_0", "model_1"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+}
+
+TEST_F(RegisterApiTest, RegisterMultiWithMap2)
+{
+  // Registering repository "models_0" and "model_1" without mappings,
+  // there are duplicate models but we provides a map for "models_1"
+  // so they all have different name.
+  std::vector<std::string> override_names{"model_2"};
+  std::vector<std::shared_ptr<TRITONSERVER_Parameter>> managed_params;
+  std::vector<const TRITONSERVER_Parameter*> name_map;
+  managed_params.emplace_back(
+      TRITONSERVER_ParameterNew(
+          "model_0", TRITONSERVER_PARAMETER_STRING, override_names[0].c_str()),
+      TRITONSERVER_ParameterDelete);
+  ASSERT_TRUE(managed_params.back() != nullptr)
+      << "failed to create name mapping pair";
+  name_map.emplace_back(managed_params.back().get());
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_1", name_map.data(), name_map.size()),
+      "registering model repository 'models_1'");
+
+  // Request to load "model_0", "model_1", "model_2"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_0"),
+      "loading model 'model_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_1"),
+      "loading model 'model_1'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerLoadModel(server_, "model_2"),
+      "loading model 'model_2'");
+}
+
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -66,7 +66,8 @@ class RegisterApiTest : public ::testing::Test {
         TRITONSERVER_ServerOptionsNew(&server_options),
         "creating server options");
     //TODO: Remove. For debugging purposes.
-    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogInfo(server_options, true), "enabling logs");
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogInfo(server_options, true), "enabling info logs");
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerOptionsSetLogVerbose(server_options, 5), "enabling verbose logs");
     // Triton expects at least one model repository is set at start, set to
     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
     // to load models.
@@ -100,25 +101,25 @@ class RegisterApiTest : public ::testing::Test {
   TRITONSERVER_Server* server_ = nullptr;
 };
 
-TEST_F(RegisterApiTest, Register)
-{
-  // Request to load "model_0" which should fail
-  FAIL_TEST_IF_NOT_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
-      "loading model 'model_0'");
+// TEST_F(RegisterApiTest, Register)
+// {
+//   // Request to load "model_0" which should fail
+//   FAIL_TEST_IF_NOT_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       TRITONSERVER_ERROR_INTERNAL,
+//       "failed to load 'model_0', no version is available",
+//       "loading model 'model_0'");
 
-  // Registering a repository "models_0" where contains "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerRegisterModelRepository(
-          server_, "models_0", nullptr, 0),
-      "registering model repository 'models_0'");
-  // Request to load "model_0"
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerLoadModel(server_, "model_0"),
-      "loading model 'model_0'");
-}
+//   // Registering a repository "models_0" where contains "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerRegisterModelRepository(
+//           server_, "models_0", nullptr, 0),
+//       "registering model repository 'models_0'");
+//   // Request to load "model_0"
+//   FAIL_TEST_IF_ERR(
+//       TRITONSERVER_ServerLoadModel(server_, "model_0"),
+//       "loading model 'model_0'");
+// }
 
 // TEST_F(RegisterApiTest, RegisterWithMap)
 // {
@@ -149,32 +150,32 @@ TEST_F(RegisterApiTest, Register)
 //       "loading model 'name_0'");
 // }
 
-// TEST_F(RegisterApiTest, RegisterTwice)
-// {
-//   // Registering a startup repository
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "empty_models", nullptr, 0),
-//       TRITONSERVER_ERROR_ALREADY_EXISTS,
-//       "model repository 'empty_models' has been registered",
-//       "registering model repository 'empty_models'");
-// }
+TEST_F(RegisterApiTest, RegisterTwice)
+{
+  // Registering a startup repository
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_ALREADY_EXISTS,
+      "model repository 'empty_models' has already been registered",
+      "registering model repository 'empty_models'");
+}
 
-// TEST_F(RegisterApiTest, RegisterTwice2)
-// {
-//   // Registering the same repository twice
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
+TEST_F(RegisterApiTest, RegisterTwice2)
+{
+  // Registering the same repository twice
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
 
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       TRITONSERVER_ERROR_ALREADY_EXISTS,
-//       "model repository 'models_0' has been registered",
-//       "registering model repository 'models_0'");
-// }
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      TRITONSERVER_ERROR_ALREADY_EXISTS,
+      "model repository 'models_0' has already been registered",
+      "registering model repository 'models_0'");
+}
 
 // TEST_F(RegisterApiTest, RegisterWithMultiMap)
 // {
@@ -415,33 +416,33 @@ TEST_F(RegisterApiTest, Register)
 // }
 
 
-// TEST_F(RegisterApiTest, UnregisterInvalidRepo)
-// {
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "unknown_repo"),
-//       TRITONSERVER_ERROR_INVALID_ARG,
-//       "failed to unregister 'unknown_repo', repository not found",
-//       "unregistering model repository 'unknown_repo'");
-// }
+TEST_F(RegisterApiTest, UnregisterInvalidRepo)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "unknown_repo"),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to unregister 'unknown_repo', repository not found",
+      "unregistering model repository 'unknown_repo'");
+}
 
-// TEST_F(RegisterApiTest, Unregister)
-// {
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-//       "unregistering model repository 'empty_models'");
-// }
+TEST_F(RegisterApiTest, Unregister)
+{
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      "unregistering model repository 'empty_models'");
+}
 
-// TEST_F(RegisterApiTest, UnregisterTwice)
-// {
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-//       "unregistering model repository 'empty_models'");
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-//       TRITONSERVER_ERROR_INVALID_ARG,
-//       "failed to unregister 'empty_models', repository not found",
-//       "unregistering model repository 'empty_models'");
-// }
+TEST_F(RegisterApiTest, UnregisterTwice)
+{
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      "unregistering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      "failed to unregister 'empty_models', repository not found",
+      "unregistering model repository 'empty_models'");
+}
 
 // TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
 // {
@@ -474,25 +475,25 @@ TEST_F(RegisterApiTest, Register)
 //       "loading model 'model_0'");
 // }
 
-// TEST_F(RegisterApiTest, MultiRegister)
-// {
-//   // Register / unregister a repository "models_0"
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-//       "unregistering model repository 'models_0'");
-//   // Register / unregister "models_0" again
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "models_0", nullptr, 0),
-//       "registering model repository 'models_0'");
-//   FAIL_TEST_IF_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
-//       "unregistering model repository 'models_0'");
-// }
+TEST_F(RegisterApiTest, MultiRegister)
+{
+  // Register / unregister a repository "models_0"
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+  // Register / unregister "models_0" again
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "models_0", nullptr, 0),
+      "registering model repository 'models_0'");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "models_0"),
+      "unregistering model repository 'models_0'");
+}
 
 // TEST_F(RegisterApiTest, RegisterMulti2)
 // {
@@ -576,121 +577,121 @@ TEST_F(RegisterApiTest, Register)
 //       "loading model 'name_0'");
 // }
 
-// // Test Fixture that runs server with POLLING mode
-// class PollingRegisterApiTest : public ::testing::Test {
-//  protected:
-//   void SetUp() override
-//   {
-//     // Create running server object.
-//     TRITONSERVER_ServerOptions* server_options = nullptr;
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsNew(&server_options),
-//         "creating server options");
-//     // Triton expects at least one model repository is set at start, set to
-//     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
-//     // to load models.
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsSetModelRepositoryPath(
-//             server_options, "empty_models"),
-//         "setting model repository path");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsSetModelControlMode(
-//             server_options, TRITONSERVER_MODEL_CONTROL_POLL),
-//         "setting model control mode");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerNew(&server_, server_options), "creating server");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsDelete(server_options),
-//         "deleting server options");
-//     ASSERT_TRUE(server_ != nullptr) << "server not created";
-//     bool live = false;
-//     for (int i = 10; ((i > 0) && !live); --i) {
-//       FAIL_TEST_IF_ERR(
-//           TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
-//     }
-//     ASSERT_TRUE(live) << "server not live";
-//   }
+// Test Fixture that runs server with POLLING mode
+class PollingRegisterApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    // Create running server object.
+    TRITONSERVER_ServerOptions* server_options = nullptr;
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsNew(&server_options),
+        "creating server options");
+    // Triton expects at least one model repository is set at start, set to
+    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+    // to load models.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+            server_options, "empty_models"),
+        "setting model repository path");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelControlMode(
+            server_options, TRITONSERVER_MODEL_CONTROL_POLL),
+        "setting model control mode");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsDelete(server_options),
+        "deleting server options");
+    ASSERT_TRUE(server_ != nullptr) << "server not created";
+    bool live = false;
+    for (int i = 10; ((i > 0) && !live); --i) {
+      FAIL_TEST_IF_ERR(
+          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+    }
+    ASSERT_TRUE(live) << "server not live";
+  }
 
-//   void TearDown() override
-//   {
-//     FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
-//   }
+  void TearDown() override
+  {
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+  }
 
-//   TRITONSERVER_Server* server_ = nullptr;
-// };
+  TRITONSERVER_Server* server_ = nullptr;
+};
 
-// TEST_F(PollingRegisterApiTest, unsupport)
-// {
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "empty_models", nullptr, 0),
-//       TRITONSERVER_ERROR_UNSUPPORTED,
-//       "Register API is unsupported in POLL model control mode",
-//       "registering model repository 'empty_models'");
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-//       TRITONSERVER_ERROR_UNSUPPORTED,
-//       "Unregister API is unsupported in POLL model control mode",
-//       "unregistering model repository 'empty_models'");
-// }
+TEST_F(PollingRegisterApiTest, unsupport)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Register API is unsupported in POLL model control mode",
+      "registering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Unregister API is unsupported in POLL model control mode",
+      "unregistering model repository 'empty_models'");
+}
 
-// // Test Fixture that runs server with NONE mode
-// class NoneRegisterApiTest : public ::testing::Test {
-//  protected:
-//   void SetUp() override
-//   {
-//     // Create running server object.
-//     TRITONSERVER_ServerOptions* server_options = nullptr;
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsNew(&server_options),
-//         "creating server options");
-//     // Triton expects at least one model repository is set at start, set to
-//     // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
-//     // to load models.
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsSetModelRepositoryPath(
-//             server_options, "empty_models"),
-//         "setting model repository path");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsSetModelControlMode(
-//             server_options, TRITONSERVER_MODEL_CONTROL_NONE),
-//         "setting model control mode");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerNew(&server_, server_options), "creating server");
-//     FAIL_TEST_IF_ERR(
-//         TRITONSERVER_ServerOptionsDelete(server_options),
-//         "deleting server options");
-//     ASSERT_TRUE(server_ != nullptr) << "server not created";
-//     bool live = false;
-//     for (int i = 10; ((i > 0) && !live); --i) {
-//       FAIL_TEST_IF_ERR(
-//           TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
-//     }
-//     ASSERT_TRUE(live) << "server not live";
-//   }
+// Test Fixture that runs server with NONE mode
+class NoneRegisterApiTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    // Create running server object.
+    TRITONSERVER_ServerOptions* server_options = nullptr;
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsNew(&server_options),
+        "creating server options");
+    // Triton expects at least one model repository is set at start, set to
+    // an empty repository set ModelControlMode to EXPLICIT to avoid attempting
+    // to load models.
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelRepositoryPath(
+            server_options, "empty_models"),
+        "setting model repository path");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsSetModelControlMode(
+            server_options, TRITONSERVER_MODEL_CONTROL_NONE),
+        "setting model control mode");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerNew(&server_, server_options), "creating server");
+    FAIL_TEST_IF_ERR(
+        TRITONSERVER_ServerOptionsDelete(server_options),
+        "deleting server options");
+    ASSERT_TRUE(server_ != nullptr) << "server not created";
+    bool live = false;
+    for (int i = 10; ((i > 0) && !live); --i) {
+      FAIL_TEST_IF_ERR(
+          TRITONSERVER_ServerIsLive(server_, &live), "Is server live");
+    }
+    ASSERT_TRUE(live) << "server not live";
+  }
 
-//   void TearDown() override
-//   {
-//     FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
-//   }
+  void TearDown() override
+  {
+    FAIL_TEST_IF_ERR(TRITONSERVER_ServerDelete(server_), "deleting server");
+  }
 
-//   TRITONSERVER_Server* server_ = nullptr;
-// };
+  TRITONSERVER_Server* server_ = nullptr;
+};
 
-// TEST_F(NoneRegisterApiTest, unsupport)
-// {
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerRegisterModelRepository(
-//           server_, "empty_models", nullptr, 0),
-//       TRITONSERVER_ERROR_UNSUPPORTED,
-//       "Register API is unsupported in NONE model control mode",
-//       "registering model repository 'empty_models'");
-//   FAIL_TEST_IF_NOT_ERR(
-//       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
-//       TRITONSERVER_ERROR_UNSUPPORTED,
-//       "Unregister API is unsupported in NONE model control mode",
-//       "unregistering model repository 'empty_models'");
-// }
+TEST_F(NoneRegisterApiTest, unsupport)
+{
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerRegisterModelRepository(
+          server_, "empty_models", nullptr, 0),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Register API is unsupported in NONE model control mode",
+      "registering model repository 'empty_models'");
+  FAIL_TEST_IF_NOT_ERR(
+      TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "Unregister API is unsupported in NONE model control mode",
+      "unregistering model repository 'empty_models'");
+}
 
 }  // namespace
 

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -104,7 +104,7 @@ TEST_F(RegisterApiTest, Register)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
 
   // Registering a repository "models_0" where contains "model_0"
@@ -139,7 +139,7 @@ TEST_F(RegisterApiTest, RegisterWithMap)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
   // Request to load "name_0"
   FAIL_TEST_IF_ERR(
@@ -284,7 +284,7 @@ TEST_F(RegisterApiTest, RegisterMulti)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
   // Request to load "model_1"
   FAIL_TEST_IF_ERR(
@@ -468,7 +468,7 @@ TEST_F(RegisterApiTest, UnregisterWithLoadedModel)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
 }
 
@@ -510,7 +510,7 @@ TEST_F(RegisterApiTest, RegisterMulti2)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
   // Request to load "model_1"
   FAIL_TEST_IF_ERR(
@@ -567,7 +567,7 @@ TEST_F(RegisterApiTest, DifferentMapping)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', failed to poll from model repository",
+      "failed to load 'model_0', no version is available",
       "loading model 'model_0'");
   FAIL_TEST_IF_ERR(
       TRITONSERVER_ServerLoadModel(server_, "name_0"),

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -623,12 +623,12 @@ TEST_F(PollingRegisterApiTest, unsupport)
       TRITONSERVER_ServerRegisterModelRepository(
           server_, "empty_models", nullptr, 0),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Register API is unsupported in POLLING model control mode",
+      "Register API is unsupported in POLL model control mode",
       "registering model repository 'empty_models'");
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerUnregisterModelRepository(server_, "empty_models"),
       TRITONSERVER_ERROR_UNSUPPORTED,
-      "Unregister API is unsupported in POLLING model control mode",
+      "Unregister API is unsupported in POLL model control mode",
       "unregistering model repository 'empty_models'");
 }
 

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2190,17 +2190,9 @@ TRITONSERVER_ServerRegisterModelRepository(
     auto model_name =
         std::string(reinterpret_cast<const char*>(mapping->ValuePointer()));
 
-    if (model_mapping.find(subdir) != model_mapping.end()) {
-      return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INVALID_ARG,
-          std::string("Duplicate mappings found for subdirectory " + subdir)
-              .c_str());
-    }
-    model_mapping[subdir] = model_name;
+    RETURN_IF_STATUS_ERROR(
+        lserver->AddModelMapping(model_name, repository_path, subdir));
   }
-
-  RETURN_IF_STATUS_ERROR(
-      lserver->AddModelMapping(repository_path, model_mapping));
 
   return nullptr;  // Success
 }
@@ -2211,7 +2203,10 @@ TRITONSERVER_ServerUnregisterModelRepository(
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   RETURN_IF_STATUS_ERROR(lserver->RemoveModelRepositoryPath(repository_path));
-  RETURN_IF_STATUS_ERROR(lserver->RemoveModelMapping(repository_path));
+  // TODO: Remove all model mappings associated with a specific path... do when
+  // unregistering path in model_repo_manager?
+  RETURN_IF_STATUS_ERROR(
+      lserver->RemoveModelMappingRepository(repository_path));
   return nullptr;  // Success
 }
 

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2162,11 +2162,23 @@ TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,
     const TRITONSERVER_Parameter** name_mapping, const uint32_t mapping_count)
 {
-  LOG_INFO << "MODE:" << model_control_mode_;
-  if (model_control_mode_ == ModelControlMode::MODE_POLL) {
+  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+  if (lserver->GetModelControlMode() != tc::ModelControlMode::MODE_EXPLICIT) {
+    std::string mode;
+    switch (lserver->GetModelControlMode()) {
+      case tc::ModelControlMode::MODE_NONE:
+        mode = "NONE";
+        break;
+      case tc::ModelControlMode::MODE_POLL:
+        mode = "POLL";
+        break;
+      default:
+        mode = "UNKNOWN";
+        break;
+    }
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_UNSUPPORTED,
-        "Register API is unsupported in POLLING model control mode");
+        (std::string("Register API is unsupported in ") + mode + " model control mode").c_str());
   }
   if ((name_mapping == nullptr) && (mapping_count != 0)) {
     return TRITONSERVER_ErrorNew(
@@ -2174,7 +2186,6 @@ TRITONSERVER_ServerRegisterModelRepository(
         "model mappings are not provided while mapping count is non-zero");
   }
 
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   RETURN_IF_STATUS_ERROR(lserver->AddModelRepositoryPath(repository_path));
   std::unordered_map<std::string, std::string> model_mapping;
 
@@ -2196,12 +2207,12 @@ TRITONSERVER_ServerRegisterModelRepository(
     auto model_name =
         std::string(reinterpret_cast<const char*>(mapping->ValuePointer()));
 
-    tc::Status status = lserver->AddModelMapping(model_name, repository_path, subdir));
+    tc::Status status = lserver->AddModelMapping(model_name, repository_path, subdir);
     if (!status.IsOk()) {
       TRITONSERVER_ServerUnregisterModelRepository(server, repository_path);
       return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
-        "failed to register '" + repository_path + "', there is conflicting mapping for '" + model_name + "'");
+        (std::string("failed to register '") + repository_path + "', there is conflicting mapping for '" + std::string(model_name) + "'").c_str());
     }
   }
 
@@ -2212,12 +2223,24 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerUnregisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path)
 {
-  if (model_control_mode_ == ModelControlMode::MODE_POLL) {
+  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+  if (lserver->GetModelControlMode() == tc::ModelControlMode::MODE_POLL) {
+    std::string mode;
+    switch (lserver->GetModelControlMode()) {
+      case tc::ModelControlMode::MODE_NONE:
+        mode = "NONE";
+        break;
+      case tc::ModelControlMode::MODE_POLL:
+        mode = "POLL";
+        break;
+      default:
+        mode = "UNKNOWN";
+        break;
+    }
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_UNSUPPORTED,
-        "Unregister API is unsupported in POLLING model control mode");
+        (std::string("Unregister API is unsupported in ") + mode + " model control mode").c_str());
   }
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   RETURN_IF_STATUS_ERROR(lserver->RemoveModelRepositoryPath(repository_path));
   RETURN_IF_STATUS_ERROR(
       lserver->RemoveModelMappingRepository(repository_path));

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2224,7 +2224,7 @@ TRITONSERVER_ServerUnregisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path)
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-  if (lserver->GetModelControlMode() == tc::ModelControlMode::MODE_POLL) {
+  if (lserver->GetModelControlMode() != tc::ModelControlMode::MODE_EXPLICIT) {
     std::string mode;
     switch (lserver->GetModelControlMode()) {
       case tc::ModelControlMode::MODE_NONE:
@@ -2243,7 +2243,7 @@ TRITONSERVER_ServerUnregisterModelRepository(
   }
   RETURN_IF_STATUS_ERROR(lserver->RemoveModelRepositoryPath(repository_path));
   RETURN_IF_STATUS_ERROR(
-      lserver->RemoveModelMappingRepository(repository_path));
+      lserver->RemoveModelMapping(repository_path));
   return nullptr;  // Success
 }
 

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2168,8 +2168,6 @@ TRITONSERVER_ServerRegisterModelRepository(
         "model mappings are not provided while mapping count is non-zero");
   }
 
-  // TODO: Change the model/path mapping to be <repository_path>,
-  // std::map<model,path>
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   if (!lserver->AddModelRepositoryPath(repository_path)) {
     return TRITONSERVER_ErrorNew(

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2158,738 +2158,778 @@ TRITONSERVER_ServerStop(TRITONSERVER_Server* server)
 }
 
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerRegisterModelRepository(TRITONSERVER_Server* server,
-    const char* repository_path, const TRITONSERVER_Parameter** model_mapping,
-    const uint32_t mapping_count){
-
-      // TODO: Figure out naming... model_mapping is directory to model name?
-      // But then it's the reverse in model repo manager.
-      if ((model_mapping == nullptr) && (mapping_count != 0)) {
-        return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INVALID_ARG,
-          "model mappings are not provided while mapping count is non-zero");
-      }
-
-      tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-      lserver->AddModelRepositoryPath(repository_path);
-
-      for (size_t i = 0; i < mapping_count; ++i) {
-        auto mapping = reinterpret_cast<tc::InferenceParameter*>(model_mapping[i]);
-        auto model = mapping.Name();
-        if(mapping->Type() != TRITONSERVER_PARAMETER_STRING){
-          return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Requested model mapping directory must be a string, found another type for " + model)
-              .c_str());
-        }
-        // Add model->model_path and model_path->model in model repository manager (via Triton server)
-        // Check if already exists
-        // Maybe we should create these paths by default for all models? To avoid new model mapping overriding current model
-        auto model_path = std::string(reinterpret_cast<const char*>(param->ValuePointer()));
-
-        //TODO Add model map and path map to server (maybe server can do this for both maps)
-
-      return nullptr;  // Success
-}
-
-TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerUnregisterModelRepository(
-    TRITONSERVER_Server* server, const char* repository_path){
-      //TODO: Code
-      return nullptr;  // Success    
-    }
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerPollModelRepository(TRITONSERVER_Server* server)
+TRITONSERVER_ServerRegisterModelRepository(
+    TRITONSERVER_Server* server, const char* repository_path,
+    const TRITONSERVER_Parameter** name_mapping, const uint32_t mapping_count)
 {
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-  RETURN_IF_STATUS_ERROR(lserver->PollModelRepository());
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerIsLive(TRITONSERVER_Server* server, bool* live)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  RETURN_IF_STATUS_ERROR(lserver->IsLive(live));
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerIsReady(TRITONSERVER_Server* server, bool* ready)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  RETURN_IF_STATUS_ERROR(lserver->IsReady(ready));
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelIsReady(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, bool* ready)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  RETURN_IF_STATUS_ERROR(
-      lserver->ModelIsReady(model_name, model_version, ready));
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelBatchProperties(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, uint32_t* flags, void** voidp)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  if (voidp != nullptr) {
-    *voidp = nullptr;
+  if ((name_mapping == nullptr) && (mapping_count != 0)) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "model mappings are not provided while mapping count is non-zero");
   }
 
-  std::shared_ptr<tc::Model> model;
-  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
-
-  if (model->Config().max_batch_size() > 0) {
-    *flags = TRITONSERVER_BATCH_FIRST_DIM;
-  } else {
-    *flags = TRITONSERVER_BATCH_UNKNOWN;
-  }
-
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelTransactionProperties(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, uint32_t* txn_flags, void** voidp)
-{
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  if (voidp != nullptr) {
-    *voidp = nullptr;
+  if (!lserver->AddModelRepositoryPath(repository_path)) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        std::string(
+            "model repository " + repository_path + " already registered")
+            .c_str());
   }
 
-  *txn_flags = 0;
+  for (size_t i = 0; i < mapping_count; ++i) {
+    auto mapping = reinterpret_cast<tc::InferenceParameter*>(name_mapping[i]);
+    auto model = mapping.Name();
 
-  std::shared_ptr<tc::Model> model;
-  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
-
-  if (model->Config().model_transaction_policy().decoupled()) {
-    *txn_flags = TRITONSERVER_TXN_DECOUPLED;
-  } else {
-    *txn_flags = TRITONSERVER_TXN_ONE_TO_ONE;
-  }
-
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerMetadata(
-    TRITONSERVER_Server* server, TRITONSERVER_Message** server_metadata)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  triton::common::TritonJson::Value metadata(
-      triton::common::TritonJson::ValueType::OBJECT);
-
-  // Just store string reference in JSON object since it will be
-  // serialized to another buffer before lserver->Id() or
-  // lserver->Version() lifetime ends.
-  RETURN_IF_STATUS_ERROR(metadata.AddStringRef("name", lserver->Id().c_str()));
-  RETURN_IF_STATUS_ERROR(
-      metadata.AddStringRef("version", lserver->Version().c_str()));
-
-  triton::common::TritonJson::Value extensions(
-      metadata, triton::common::TritonJson::ValueType::ARRAY);
-  const std::vector<const char*>& exts = lserver->Extensions();
-  for (const auto ext : exts) {
-    RETURN_IF_STATUS_ERROR(extensions.AppendStringRef(ext));
-  }
-
-  RETURN_IF_STATUS_ERROR(metadata.Add("extensions", std::move(extensions)));
-
-  *server_metadata = reinterpret_cast<TRITONSERVER_Message*>(
-      new tc::TritonServerMessage(metadata));
-  return nullptr;  // Success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelMetadata(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, TRITONSERVER_Message** model_metadata)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  std::shared_ptr<tc::Model> model;
-  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
-
-  std::vector<int64_t> ready_versions;
-  RETURN_IF_STATUS_ERROR(
-      lserver->ModelReadyVersions(model_name, &ready_versions));
-
-  triton::common::TritonJson::Value metadata(
-      triton::common::TritonJson::ValueType::OBJECT);
-
-  // Can use string ref in this function even though model can be
-  // unloaded and config becomes invalid, because TritonServeMessage
-  // serializes the json when it is constructed below.
-  RETURN_IF_STATUS_ERROR(metadata.AddStringRef("name", model_name));
-
-  triton::common::TritonJson::Value versions(
-      metadata, triton::common::TritonJson::ValueType::ARRAY);
-  if (model_version != -1) {
-    RETURN_IF_STATUS_ERROR(
-        versions.AppendString(std::move(std::to_string(model_version))));
-  } else {
-    for (const auto v : ready_versions) {
-      RETURN_IF_STATUS_ERROR(
-          versions.AppendString(std::move(std::to_string(v))));
-    }
-  }
-
-  RETURN_IF_STATUS_ERROR(metadata.Add("versions", std::move(versions)));
-
-  const auto& model_config = model->Config();
-  if (!model_config.platform().empty()) {
-    RETURN_IF_STATUS_ERROR(
-        metadata.AddStringRef("platform", model_config.platform().c_str()));
-  } else {
-    RETURN_IF_STATUS_ERROR(
-        metadata.AddStringRef("platform", model_config.backend().c_str()));
-  }
-
-  triton::common::TritonJson::Value inputs(
-      metadata, triton::common::TritonJson::ValueType::ARRAY);
-  for (const auto& io : model_config.input()) {
-    triton::common::TritonJson::Value io_metadata(
-        metadata, triton::common::TritonJson::ValueType::OBJECT);
-    RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef("name", io.name().c_str()));
-    RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef(
-        "datatype", tc::DataTypeToProtocolString(io.data_type())));
-
-    // Input shape. If the model supports batching then must include
-    // '-1' for the batch dimension.
-    triton::common::TritonJson::Value io_metadata_shape(
-        metadata, triton::common::TritonJson::ValueType::ARRAY);
-    if (model_config.max_batch_size() >= 1) {
-      RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(-1));
-    }
-    for (const auto d : io.dims()) {
-      RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(d));
-    }
-    RETURN_IF_STATUS_ERROR(
-        io_metadata.Add("shape", std::move(io_metadata_shape)));
-
-    RETURN_IF_STATUS_ERROR(inputs.Append(std::move(io_metadata)));
-  }
-  RETURN_IF_STATUS_ERROR(metadata.Add("inputs", std::move(inputs)));
-
-  triton::common::TritonJson::Value outputs(
-      metadata, triton::common::TritonJson::ValueType::ARRAY);
-  for (const auto& io : model_config.output()) {
-    triton::common::TritonJson::Value io_metadata(
-        metadata, triton::common::TritonJson::ValueType::OBJECT);
-    RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef("name", io.name().c_str()));
-    RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef(
-        "datatype", tc::DataTypeToProtocolString(io.data_type())));
-
-    // Output shape. If the model supports batching then must include
-    // '-1' for the batch dimension.
-    triton::common::TritonJson::Value io_metadata_shape(
-        metadata, triton::common::TritonJson::ValueType::ARRAY);
-    if (model_config.max_batch_size() >= 1) {
-      RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(-1));
-    }
-    for (const auto d : io.dims()) {
-      RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(d));
-    }
-    RETURN_IF_STATUS_ERROR(
-        io_metadata.Add("shape", std::move(io_metadata_shape)));
-
-    RETURN_IF_STATUS_ERROR(outputs.Append(std::move(io_metadata)));
-  }
-  RETURN_IF_STATUS_ERROR(metadata.Add("outputs", std::move(outputs)));
-
-  *model_metadata = reinterpret_cast<TRITONSERVER_Message*>(
-      new tc::TritonServerMessage(metadata));
-  return nullptr;  // success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelStatistics(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, TRITONSERVER_Message** model_stats)
-{
-#ifndef TRITON_ENABLE_STATS
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "statistics not supported");
-#else
-
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-
-  auto model_name_string = std::string(model_name);
-  std::map<std::string, std::vector<int64_t>> ready_model_versions;
-  if (model_name_string.empty()) {
-    RETURN_IF_STATUS_ERROR(lserver->ModelReadyVersions(&ready_model_versions));
-  } else {
-    std::vector<int64_t> ready_versions;
-    RETURN_IF_STATUS_ERROR(
-        lserver->ModelReadyVersions(model_name_string, &ready_versions));
-    if (ready_versions.empty()) {
+    if (mapping->Type() != TRITONSERVER_PARAMETER_STRING) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           std::string(
-              "requested model '" + model_name_string + "' is not available")
+              "Requested model mapping directory must be a string, found "
+              "another type for " +
+              model)
               .c_str());
     }
+    // TODO: Maybe we should create these paths by default for all models? To
+    // avoid new model mapping overriding current model.
+    auto model_path =
+        std::string(reinterpret_cast<const char*>(param->ValuePointer()));
 
-    if (model_version == -1) {
-      ready_model_versions.emplace(
-          model_name_string, std::move(ready_versions));
-    } else {
-      bool found = false;
-      for (const auto v : ready_versions) {
-        if (v == model_version) {
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        ready_model_versions.emplace(
-            model_name_string, std::vector<int64_t>{model_version});
-      } else {
+    // When the model directory name is unknown, the model override name will be
+    // applied to the model directory under the path. There must only be one.
+    if (model_path.empty()) {
+      std::set<std::string> subdirs;
+      RETURN_IF_ERROR(GetDirectorySubdirs(repository_path, &subdirs));
+      if (subdirs.size() != 1) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             std::string(
-                "requested model version is not available for model '" +
-                model_name_string + "'")
+                "empty model directory name mapping can only be registered "
+                "with one model provided, found " +
+                subdirs.size())
                 .c_str());
       }
+      model_path = *(subdirs.begin());
     }
+
+    // TODO Add model map and path map to server (maybe server can do this for
+    // both maps)
+
+    return nullptr;  // Success
   }
 
-  // Can use string ref in this function because TritonServeMessage
-  // serializes the json when it is constructed below.
-  triton::common::TritonJson::Value metadata(
-      triton::common::TritonJson::ValueType::OBJECT);
-
-  triton::common::TritonJson::Value model_stats_json(
-      metadata, triton::common::TritonJson::ValueType::ARRAY);
-  for (const auto& mv_pair : ready_model_versions) {
-    for (const auto& version : mv_pair.second) {
-      std::shared_ptr<tc::Model> model;
-      RETURN_IF_STATUS_ERROR(lserver->GetModel(mv_pair.first, version, &model));
-      const auto& infer_stats = model->StatsAggregator().ImmutableInferStats();
-      const auto& infer_batch_stats =
-          model->StatsAggregator().ImmutableInferBatchStats();
-
-      triton::common::TritonJson::Value inference_stats(
-          metadata, triton::common::TritonJson::ValueType::OBJECT);
-      // Compute figures only calculated when not going through cache, so
-      // subtract cache_hit count from success count. Cache hit count will
-      // simply be 0 when cache is disabled.
-      uint64_t compute_count =
-          infer_stats.success_count_ - infer_stats.cache_hit_count_;
-      SetDurationStat(
-          metadata, inference_stats, "success", infer_stats.success_count_,
-          infer_stats.request_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "fail", infer_stats.failure_count_,
-          infer_stats.failure_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "queue", infer_stats.success_count_,
-          infer_stats.queue_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "compute_input", compute_count,
-          infer_stats.compute_input_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "compute_infer", compute_count,
-          infer_stats.compute_infer_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "compute_output", compute_count,
-          infer_stats.compute_output_duration_ns_);
-      SetDurationStat(
-          metadata, inference_stats, "cache_hit", infer_stats.cache_hit_count_,
-          infer_stats.cache_hit_lookup_duration_ns_);
-      // NOTE: cache_miss_count_ should equal compute_count if non-zero
-      SetDurationStat(
-          metadata, inference_stats, "cache_miss",
-          infer_stats.cache_miss_count_,
-          infer_stats.cache_miss_lookup_duration_ns_ +
-              infer_stats.cache_miss_insertion_duration_ns_);
-
-      triton::common::TritonJson::Value batch_stats(
-          metadata, triton::common::TritonJson::ValueType::ARRAY);
-      for (const auto& batch : infer_batch_stats) {
-        triton::common::TritonJson::Value batch_stat(
-            metadata, triton::common::TritonJson::ValueType::OBJECT);
-        RETURN_IF_STATUS_ERROR(batch_stat.AddUInt("batch_size", batch.first));
-        SetDurationStat(
-            metadata, batch_stat, "compute_input", batch.second.count_,
-            batch.second.compute_input_duration_ns_);
-        SetDurationStat(
-            metadata, batch_stat, "compute_infer", batch.second.count_,
-            batch.second.compute_infer_duration_ns_);
-        SetDurationStat(
-            metadata, batch_stat, "compute_output", batch.second.count_,
-            batch.second.compute_output_duration_ns_);
-        RETURN_IF_STATUS_ERROR(batch_stats.Append(std::move(batch_stat)));
-      }
-
-      triton::common::TritonJson::Value model_stat(
-          metadata, triton::common::TritonJson::ValueType::OBJECT);
-      RETURN_IF_STATUS_ERROR(
-          model_stat.AddStringRef("name", mv_pair.first.c_str()));
-      RETURN_IF_STATUS_ERROR(
-          model_stat.AddString("version", std::move(std::to_string(version))));
-
-      RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
-          "last_inference", model->StatsAggregator().LastInferenceMs()));
-      RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
-          "inference_count", model->StatsAggregator().InferenceCount()));
-      RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
-          "execution_count", model->StatsAggregator().ExecutionCount()));
-
-      RETURN_IF_STATUS_ERROR(
-          model_stat.Add("inference_stats", std::move(inference_stats)));
-      RETURN_IF_STATUS_ERROR(
-          model_stat.Add("batch_stats", std::move(batch_stats)));
-      RETURN_IF_STATUS_ERROR(model_stats_json.Append(std::move(model_stat)));
-    }
+  TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+  TRITONSERVER_ServerUnregisterModelRepository(
+      TRITONSERVER_Server * server, const char* repository_path)
+  {
+    // TODO: Code
+    return nullptr;  // Success
   }
 
-  RETURN_IF_STATUS_ERROR(
-      metadata.Add("model_stats", std::move(model_stats_json)));
-  *model_stats = reinterpret_cast<TRITONSERVER_Message*>(
-      new tc::TritonServerMessage(metadata));
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerPollModelRepository(
+      TRITONSERVER_Server * server)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+    RETURN_IF_STATUS_ERROR(lserver->PollModelRepository());
+    return nullptr;  // Success
+  }
 
-  return nullptr;  // success
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerIsLive(
+      TRITONSERVER_Server * server, bool* live)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-#endif  // TRITON_ENABLE_STATS
-}
+    RETURN_IF_STATUS_ERROR(lserver->IsLive(live));
+    return nullptr;  // Success
+  }
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelConfig(
-    TRITONSERVER_Server* server, const char* model_name,
-    const int64_t model_version, const uint32_t config_version,
-    TRITONSERVER_Message** model_config)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerIsReady(
+      TRITONSERVER_Server * server, bool* ready)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-  std::shared_ptr<tc::Model> model;
-  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
+    RETURN_IF_STATUS_ERROR(lserver->IsReady(ready));
+    return nullptr;  // Success
+  }
 
-  std::string model_config_json;
-  RETURN_IF_STATUS_ERROR(tc::ModelConfigToJson(
-      model->Config(), config_version, &model_config_json));
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerModelIsReady(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, bool* ready)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-  *model_config = reinterpret_cast<TRITONSERVER_Message*>(
-      new tc::TritonServerMessage(std::move(model_config_json)));
+    RETURN_IF_STATUS_ERROR(
+        lserver->ModelIsReady(model_name, model_version, ready));
+    return nullptr;  // Success
+  }
 
-  return nullptr;  // success
-}
+  TRITONAPI_DECLSPEC TRITONSERVER_Error*
+  TRITONSERVER_ServerModelBatchProperties(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, uint32_t* flags, void** voidp)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerModelIndex(
-    TRITONSERVER_Server* server, uint32_t flags,
-    TRITONSERVER_Message** repository_index)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+    if (voidp != nullptr) {
+      *voidp = nullptr;
+    }
 
-  const bool ready_only = ((flags & TRITONSERVER_INDEX_FLAG_READY) != 0);
+    std::shared_ptr<tc::Model> model;
+    RETURN_IF_STATUS_ERROR(
+        lserver->GetModel(model_name, model_version, &model));
 
-  std::vector<tc::ModelRepositoryManager::ModelIndex> index;
-  RETURN_IF_STATUS_ERROR(lserver->RepositoryIndex(ready_only, &index));
+    if (model->Config().max_batch_size() > 0) {
+      *flags = TRITONSERVER_BATCH_FIRST_DIM;
+    } else {
+      *flags = TRITONSERVER_BATCH_UNKNOWN;
+    }
 
-  // Can use string ref in this function because TritonServerMessage
-  // serializes the json when it is constructed below.
-  triton::common::TritonJson::Value repository_index_json(
-      triton::common::TritonJson::ValueType::ARRAY);
+    return nullptr;  // Success
+  }
 
-  for (const auto& in : index) {
-    triton::common::TritonJson::Value model_index(
-        repository_index_json, triton::common::TritonJson::ValueType::OBJECT);
-    RETURN_IF_STATUS_ERROR(model_index.AddStringRef("name", in.name_.c_str()));
-    if (!in.name_only_) {
-      if (in.version_ >= 0) {
-        RETURN_IF_STATUS_ERROR(model_index.AddString(
-            "version", std::move(std::to_string(in.version_))));
-      }
-      RETURN_IF_STATUS_ERROR(model_index.AddStringRef(
-          "state", tc::ModelReadyStateString(in.state_).c_str()));
-      if (!in.reason_.empty()) {
+  TRITONAPI_DECLSPEC TRITONSERVER_Error*
+  TRITONSERVER_ServerModelTransactionProperties(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, uint32_t* txn_flags, void** voidp)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+
+    if (voidp != nullptr) {
+      *voidp = nullptr;
+    }
+
+    *txn_flags = 0;
+
+    std::shared_ptr<tc::Model> model;
+    RETURN_IF_STATUS_ERROR(
+        lserver->GetModel(model_name, model_version, &model));
+
+    if (model->Config().model_transaction_policy().decoupled()) {
+      *txn_flags = TRITONSERVER_TXN_DECOUPLED;
+    } else {
+      *txn_flags = TRITONSERVER_TXN_ONE_TO_ONE;
+    }
+
+    return nullptr;  // Success
+  }
+
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerMetadata(
+      TRITONSERVER_Server * server, TRITONSERVER_Message * *server_metadata)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+
+    triton::common::TritonJson::Value metadata(
+        triton::common::TritonJson::ValueType::OBJECT);
+
+    // Just store string reference in JSON object since it will be
+    // serialized to another buffer before lserver->Id() or
+    // lserver->Version() lifetime ends.
+    RETURN_IF_STATUS_ERROR(
+        metadata.AddStringRef("name", lserver->Id().c_str()));
+    RETURN_IF_STATUS_ERROR(
+        metadata.AddStringRef("version", lserver->Version().c_str()));
+
+    triton::common::TritonJson::Value extensions(
+        metadata, triton::common::TritonJson::ValueType::ARRAY);
+    const std::vector<const char*>& exts = lserver->Extensions();
+    for (const auto ext : exts) {
+      RETURN_IF_STATUS_ERROR(extensions.AppendStringRef(ext));
+    }
+
+    RETURN_IF_STATUS_ERROR(metadata.Add("extensions", std::move(extensions)));
+
+    *server_metadata = reinterpret_cast<TRITONSERVER_Message*>(
+        new tc::TritonServerMessage(metadata));
+    return nullptr;  // Success
+  }
+
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerModelMetadata(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, TRITONSERVER_Message** model_metadata)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+
+    std::shared_ptr<tc::Model> model;
+    RETURN_IF_STATUS_ERROR(
+        lserver->GetModel(model_name, model_version, &model));
+
+    std::vector<int64_t> ready_versions;
+    RETURN_IF_STATUS_ERROR(
+        lserver->ModelReadyVersions(model_name, &ready_versions));
+
+    triton::common::TritonJson::Value metadata(
+        triton::common::TritonJson::ValueType::OBJECT);
+
+    // Can use string ref in this function even though model can be
+    // unloaded and config becomes invalid, because TritonServeMessage
+    // serializes the json when it is constructed below.
+    RETURN_IF_STATUS_ERROR(metadata.AddStringRef("name", model_name));
+
+    triton::common::TritonJson::Value versions(
+        metadata, triton::common::TritonJson::ValueType::ARRAY);
+    if (model_version != -1) {
+      RETURN_IF_STATUS_ERROR(
+          versions.AppendString(std::move(std::to_string(model_version))));
+    } else {
+      for (const auto v : ready_versions) {
         RETURN_IF_STATUS_ERROR(
-            model_index.AddStringRef("reason", in.reason_.c_str()));
+            versions.AppendString(std::move(std::to_string(v))));
+      }
+    }
+
+    RETURN_IF_STATUS_ERROR(metadata.Add("versions", std::move(versions)));
+
+    const auto& model_config = model->Config();
+    if (!model_config.platform().empty()) {
+      RETURN_IF_STATUS_ERROR(
+          metadata.AddStringRef("platform", model_config.platform().c_str()));
+    } else {
+      RETURN_IF_STATUS_ERROR(
+          metadata.AddStringRef("platform", model_config.backend().c_str()));
+    }
+
+    triton::common::TritonJson::Value inputs(
+        metadata, triton::common::TritonJson::ValueType::ARRAY);
+    for (const auto& io : model_config.input()) {
+      triton::common::TritonJson::Value io_metadata(
+          metadata, triton::common::TritonJson::ValueType::OBJECT);
+      RETURN_IF_STATUS_ERROR(
+          io_metadata.AddStringRef("name", io.name().c_str()));
+      RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef(
+          "datatype", tc::DataTypeToProtocolString(io.data_type())));
+
+      // Input shape. If the model supports batching then must include
+      // '-1' for the batch dimension.
+      triton::common::TritonJson::Value io_metadata_shape(
+          metadata, triton::common::TritonJson::ValueType::ARRAY);
+      if (model_config.max_batch_size() >= 1) {
+        RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(-1));
+      }
+      for (const auto d : io.dims()) {
+        RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(d));
+      }
+      RETURN_IF_STATUS_ERROR(
+          io_metadata.Add("shape", std::move(io_metadata_shape)));
+
+      RETURN_IF_STATUS_ERROR(inputs.Append(std::move(io_metadata)));
+    }
+    RETURN_IF_STATUS_ERROR(metadata.Add("inputs", std::move(inputs)));
+
+    triton::common::TritonJson::Value outputs(
+        metadata, triton::common::TritonJson::ValueType::ARRAY);
+    for (const auto& io : model_config.output()) {
+      triton::common::TritonJson::Value io_metadata(
+          metadata, triton::common::TritonJson::ValueType::OBJECT);
+      RETURN_IF_STATUS_ERROR(
+          io_metadata.AddStringRef("name", io.name().c_str()));
+      RETURN_IF_STATUS_ERROR(io_metadata.AddStringRef(
+          "datatype", tc::DataTypeToProtocolString(io.data_type())));
+
+      // Output shape. If the model supports batching then must include
+      // '-1' for the batch dimension.
+      triton::common::TritonJson::Value io_metadata_shape(
+          metadata, triton::common::TritonJson::ValueType::ARRAY);
+      if (model_config.max_batch_size() >= 1) {
+        RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(-1));
+      }
+      for (const auto d : io.dims()) {
+        RETURN_IF_STATUS_ERROR(io_metadata_shape.AppendInt(d));
+      }
+      RETURN_IF_STATUS_ERROR(
+          io_metadata.Add("shape", std::move(io_metadata_shape)));
+
+      RETURN_IF_STATUS_ERROR(outputs.Append(std::move(io_metadata)));
+    }
+    RETURN_IF_STATUS_ERROR(metadata.Add("outputs", std::move(outputs)));
+
+    *model_metadata = reinterpret_cast<TRITONSERVER_Message*>(
+        new tc::TritonServerMessage(metadata));
+    return nullptr;  // success
+  }
+
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerModelStatistics(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, TRITONSERVER_Message** model_stats)
+  {
+#ifndef TRITON_ENABLE_STATS
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "statistics not supported");
+#else
+
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+
+    auto model_name_string = std::string(model_name);
+    std::map<std::string, std::vector<int64_t>> ready_model_versions;
+    if (model_name_string.empty()) {
+      RETURN_IF_STATUS_ERROR(
+          lserver->ModelReadyVersions(&ready_model_versions));
+    } else {
+      std::vector<int64_t> ready_versions;
+      RETURN_IF_STATUS_ERROR(
+          lserver->ModelReadyVersions(model_name_string, &ready_versions));
+      if (ready_versions.empty()) {
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INVALID_ARG,
+            std::string(
+                "requested model '" + model_name_string + "' is not available")
+                .c_str());
+      }
+
+      if (model_version == -1) {
+        ready_model_versions.emplace(
+            model_name_string, std::move(ready_versions));
+      } else {
+        bool found = false;
+        for (const auto v : ready_versions) {
+          if (v == model_version) {
+            found = true;
+            break;
+          }
+        }
+        if (found) {
+          ready_model_versions.emplace(
+              model_name_string, std::vector<int64_t>{model_version});
+        } else {
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_INVALID_ARG,
+              std::string(
+                  "requested model version is not available for model '" +
+                  model_name_string + "'")
+                  .c_str());
+        }
+      }
+    }
+
+    // Can use string ref in this function because TritonServeMessage
+    // serializes the json when it is constructed below.
+    triton::common::TritonJson::Value metadata(
+        triton::common::TritonJson::ValueType::OBJECT);
+
+    triton::common::TritonJson::Value model_stats_json(
+        metadata, triton::common::TritonJson::ValueType::ARRAY);
+    for (const auto& mv_pair : ready_model_versions) {
+      for (const auto& version : mv_pair.second) {
+        std::shared_ptr<tc::Model> model;
+        RETURN_IF_STATUS_ERROR(
+            lserver->GetModel(mv_pair.first, version, &model));
+        const auto& infer_stats =
+            model->StatsAggregator().ImmutableInferStats();
+        const auto& infer_batch_stats =
+            model->StatsAggregator().ImmutableInferBatchStats();
+
+        triton::common::TritonJson::Value inference_stats(
+            metadata, triton::common::TritonJson::ValueType::OBJECT);
+        // Compute figures only calculated when not going through cache, so
+        // subtract cache_hit count from success count. Cache hit count will
+        // simply be 0 when cache is disabled.
+        uint64_t compute_count =
+            infer_stats.success_count_ - infer_stats.cache_hit_count_;
+        SetDurationStat(
+            metadata, inference_stats, "success", infer_stats.success_count_,
+            infer_stats.request_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "fail", infer_stats.failure_count_,
+            infer_stats.failure_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "queue", infer_stats.success_count_,
+            infer_stats.queue_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "compute_input", compute_count,
+            infer_stats.compute_input_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "compute_infer", compute_count,
+            infer_stats.compute_infer_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "compute_output", compute_count,
+            infer_stats.compute_output_duration_ns_);
+        SetDurationStat(
+            metadata, inference_stats, "cache_hit",
+            infer_stats.cache_hit_count_,
+            infer_stats.cache_hit_lookup_duration_ns_);
+        // NOTE: cache_miss_count_ should equal compute_count if non-zero
+        SetDurationStat(
+            metadata, inference_stats, "cache_miss",
+            infer_stats.cache_miss_count_,
+            infer_stats.cache_miss_lookup_duration_ns_ +
+                infer_stats.cache_miss_insertion_duration_ns_);
+
+        triton::common::TritonJson::Value batch_stats(
+            metadata, triton::common::TritonJson::ValueType::ARRAY);
+        for (const auto& batch : infer_batch_stats) {
+          triton::common::TritonJson::Value batch_stat(
+              metadata, triton::common::TritonJson::ValueType::OBJECT);
+          RETURN_IF_STATUS_ERROR(batch_stat.AddUInt("batch_size", batch.first));
+          SetDurationStat(
+              metadata, batch_stat, "compute_input", batch.second.count_,
+              batch.second.compute_input_duration_ns_);
+          SetDurationStat(
+              metadata, batch_stat, "compute_infer", batch.second.count_,
+              batch.second.compute_infer_duration_ns_);
+          SetDurationStat(
+              metadata, batch_stat, "compute_output", batch.second.count_,
+              batch.second.compute_output_duration_ns_);
+          RETURN_IF_STATUS_ERROR(batch_stats.Append(std::move(batch_stat)));
+        }
+
+        triton::common::TritonJson::Value model_stat(
+            metadata, triton::common::TritonJson::ValueType::OBJECT);
+        RETURN_IF_STATUS_ERROR(
+            model_stat.AddStringRef("name", mv_pair.first.c_str()));
+        RETURN_IF_STATUS_ERROR(model_stat.AddString(
+            "version", std::move(std::to_string(version))));
+
+        RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
+            "last_inference", model->StatsAggregator().LastInferenceMs()));
+        RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
+            "inference_count", model->StatsAggregator().InferenceCount()));
+        RETURN_IF_STATUS_ERROR(model_stat.AddUInt(
+            "execution_count", model->StatsAggregator().ExecutionCount()));
+
+        RETURN_IF_STATUS_ERROR(
+            model_stat.Add("inference_stats", std::move(inference_stats)));
+        RETURN_IF_STATUS_ERROR(
+            model_stat.Add("batch_stats", std::move(batch_stats)));
+        RETURN_IF_STATUS_ERROR(model_stats_json.Append(std::move(model_stat)));
       }
     }
 
     RETURN_IF_STATUS_ERROR(
-        repository_index_json.Append(std::move(model_index)));
+        metadata.Add("model_stats", std::move(model_stats_json)));
+    *model_stats = reinterpret_cast<TRITONSERVER_Message*>(
+        new tc::TritonServerMessage(metadata));
+
+    return nullptr;  // success
+
+#endif  // TRITON_ENABLE_STATS
   }
 
-  *repository_index = reinterpret_cast<TRITONSERVER_Message*>(
-      new tc::TritonServerMessage(repository_index_json));
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerModelConfig(
+      TRITONSERVER_Server * server, const char* model_name,
+      const int64_t model_version, const uint32_t config_version,
+      TRITONSERVER_Message** model_config)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-  return nullptr;  // success
-}
+    std::shared_ptr<tc::Model> model;
+    RETURN_IF_STATUS_ERROR(
+        lserver->GetModel(model_name, model_version, &model));
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerLoadModel(
-    TRITONSERVER_Server* server, const char* model_name)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+    std::string model_config_json;
+    RETURN_IF_STATUS_ERROR(tc::ModelConfigToJson(
+        model->Config(), config_version, &model_config_json));
 
-  RETURN_IF_STATUS_ERROR(lserver->LoadModel({{std::string(model_name), {}}}));
+    *model_config = reinterpret_cast<TRITONSERVER_Message*>(
+        new tc::TritonServerMessage(std::move(model_config_json)));
 
-  return nullptr;  // success
-}
-
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerLoadModelWithParameters(
-    TRITONSERVER_Server* server, const char* model_name,
-    const TRITONSERVER_Parameter** parameters, const uint64_t parameter_count)
-{
-  if ((parameters == nullptr) && (parameter_count != 0)) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG,
-        "load parameters are not provided while parameter count is non-zero");
+    return nullptr;  // success
   }
 
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerModelIndex(
+      TRITONSERVER_Server * server, uint32_t flags,
+      TRITONSERVER_Message * *repository_index)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-  std::unordered_map<std::string, std::vector<const tc::InferenceParameter*>>
-      models;
-  std::vector<const tc::InferenceParameter*> mp;
-  for (size_t i = 0; i < parameter_count; ++i) {
-    mp.emplace_back(
-        reinterpret_cast<const tc::InferenceParameter*>(parameters[i]));
+    const bool ready_only = ((flags & TRITONSERVER_INDEX_FLAG_READY) != 0);
+
+    std::vector<tc::ModelRepositoryManager::ModelIndex> index;
+    RETURN_IF_STATUS_ERROR(lserver->RepositoryIndex(ready_only, &index));
+
+    // Can use string ref in this function because TritonServerMessage
+    // serializes the json when it is constructed below.
+    triton::common::TritonJson::Value repository_index_json(
+        triton::common::TritonJson::ValueType::ARRAY);
+
+    for (const auto& in : index) {
+      triton::common::TritonJson::Value model_index(
+          repository_index_json, triton::common::TritonJson::ValueType::OBJECT);
+      RETURN_IF_STATUS_ERROR(
+          model_index.AddStringRef("name", in.name_.c_str()));
+      if (!in.name_only_) {
+        if (in.version_ >= 0) {
+          RETURN_IF_STATUS_ERROR(model_index.AddString(
+              "version", std::move(std::to_string(in.version_))));
+        }
+        RETURN_IF_STATUS_ERROR(model_index.AddStringRef(
+            "state", tc::ModelReadyStateString(in.state_).c_str()));
+        if (!in.reason_.empty()) {
+          RETURN_IF_STATUS_ERROR(
+              model_index.AddStringRef("reason", in.reason_.c_str()));
+        }
+      }
+
+      RETURN_IF_STATUS_ERROR(
+          repository_index_json.Append(std::move(model_index)));
+    }
+
+    *repository_index = reinterpret_cast<TRITONSERVER_Message*>(
+        new tc::TritonServerMessage(repository_index_json));
+
+    return nullptr;  // success
   }
-  models[model_name] = std::move(mp);
-  RETURN_IF_STATUS_ERROR(lserver->LoadModel(models));
 
-  return nullptr;  // success
-}
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerLoadModel(
+      TRITONSERVER_Server * server, const char* model_name)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerUnloadModel(
-    TRITONSERVER_Server* server, const char* model_name)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+    RETURN_IF_STATUS_ERROR(lserver->LoadModel({{std::string(model_name), {}}}));
 
-  RETURN_IF_STATUS_ERROR(lserver->UnloadModel(
-      std::string(model_name), false /* unload_dependents */));
+    return nullptr;  // success
+  }
 
-  return nullptr;  // success
-}
+  TRITONAPI_DECLSPEC TRITONSERVER_Error*
+  TRITONSERVER_ServerLoadModelWithParameters(
+      TRITONSERVER_Server * server, const char* model_name,
+      const TRITONSERVER_Parameter** parameters, const uint64_t parameter_count)
+  {
+    if ((parameters == nullptr) && (parameter_count != 0)) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          "load parameters are not provided while parameter count is non-zero");
+    }
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerUnloadModelAndDependents(
-    TRITONSERVER_Server* server, const char* model_name)
-{
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+
+    std::unordered_map<std::string, std::vector<const tc::InferenceParameter*>>
+        models;
+    std::vector<const tc::InferenceParameter*> mp;
+    for (size_t i = 0; i < parameter_count; ++i) {
+      mp.emplace_back(
+          reinterpret_cast<const tc::InferenceParameter*>(parameters[i]));
+    }
+    models[model_name] = std::move(mp);
+    RETURN_IF_STATUS_ERROR(lserver->LoadModel(models));
+
+    return nullptr;  // success
+  }
+
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerUnloadModel(
+      TRITONSERVER_Server * server, const char* model_name)
   {
     tc::InferenceServer* lserver =
         reinterpret_cast<tc::InferenceServer*>(server);
 
     RETURN_IF_STATUS_ERROR(lserver->UnloadModel(
-        std::string(model_name), true /* unload_dependents */));
+        std::string(model_name), false /* unload_dependents */));
 
     return nullptr;  // success
   }
-}
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerMetrics(
-    TRITONSERVER_Server* server, TRITONSERVER_Metrics** metrics)
-{
+  TRITONAPI_DECLSPEC TRITONSERVER_Error*
+  TRITONSERVER_ServerUnloadModelAndDependents(
+      TRITONSERVER_Server * server, const char* model_name)
+  {
+    {
+      tc::InferenceServer* lserver =
+          reinterpret_cast<tc::InferenceServer*>(server);
+
+      RETURN_IF_STATUS_ERROR(lserver->UnloadModel(
+          std::string(model_name), true /* unload_dependents */));
+
+      return nullptr;  // success
+    }
+  }
+
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerMetrics(
+      TRITONSERVER_Server * server, TRITONSERVER_Metrics * *metrics)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  TritonServerMetrics* lmetrics = new TritonServerMetrics();
-  *metrics = reinterpret_cast<TRITONSERVER_Metrics*>(lmetrics);
-  return nullptr;  // Success
+    TritonServerMetrics* lmetrics = new TritonServerMetrics();
+    *metrics = reinterpret_cast<TRITONSERVER_Metrics*>(lmetrics);
+    return nullptr;  // Success
 #else
-  *metrics = nullptr;
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    *metrics = nullptr;
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
+  }
 
-TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerInferAsync(
-    TRITONSERVER_Server* server,
-    TRITONSERVER_InferenceRequest* inference_request,
-    TRITONSERVER_InferenceTrace* trace)
-{
-  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
-  tc::InferenceRequest* lrequest =
-      reinterpret_cast<tc::InferenceRequest*>(inference_request);
+  TRITONAPI_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerInferAsync(
+      TRITONSERVER_Server * server,
+      TRITONSERVER_InferenceRequest * inference_request,
+      TRITONSERVER_InferenceTrace * trace)
+  {
+    tc::InferenceServer* lserver =
+        reinterpret_cast<tc::InferenceServer*>(server);
+    tc::InferenceRequest* lrequest =
+        reinterpret_cast<tc::InferenceRequest*>(inference_request);
 
-  RETURN_IF_STATUS_ERROR(lrequest->PrepareForInference());
+    RETURN_IF_STATUS_ERROR(lrequest->PrepareForInference());
 
-  // Set the trace object in the request so that activity associated
-  // with the request can be recorded as the request flows through
-  // Triton.
-  if (trace != nullptr) {
+    // Set the trace object in the request so that activity associated
+    // with the request can be recorded as the request flows through
+    // Triton.
+    if (trace != nullptr) {
 #ifdef TRITON_ENABLE_TRACING
-    tc::InferenceTrace* ltrace = reinterpret_cast<tc::InferenceTrace*>(trace);
-    ltrace->SetModelName(lrequest->ModelName());
-    ltrace->SetModelVersion(lrequest->ActualModelVersion());
+      tc::InferenceTrace* ltrace = reinterpret_cast<tc::InferenceTrace*>(trace);
+      ltrace->SetModelName(lrequest->ModelName());
+      ltrace->SetModelVersion(lrequest->ActualModelVersion());
 
-    lrequest->SetTrace(std::make_shared<tc::InferenceTraceProxy>(ltrace));
+      lrequest->SetTrace(std::make_shared<tc::InferenceTraceProxy>(ltrace));
+#else
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_UNSUPPORTED, "inference tracing not supported");
+#endif  // TRITON_ENABLE_TRACING
+    }
+
+    // We wrap the request in a unique pointer to ensure that it flows
+    // through inferencing with clear ownership.
+    std::unique_ptr<tc::InferenceRequest> ureq(lrequest);
+
+    // Run inference...
+    tc::Status status = lserver->InferAsync(ureq);
+
+    // If there is an error then must explicitly release any trace
+    // object associated with the inference request above.
+#ifdef TRITON_ENABLE_TRACING
+    if (!status.IsOk()) {
+      ureq->ReleaseTrace();
+    }
+#endif  // TRITON_ENABLE_TRACING
+
+    // If there is an error then ureq will still have 'lrequest' and we
+    // must release it from unique_ptr since the caller should retain
+    // ownership when there is error. If there is not an error then ureq
+    // == nullptr and so this release is a nop.
+    ureq.release();
+
+    RETURN_IF_STATUS_ERROR(status);
+    return nullptr;  // Success
+  }
+
+  //
+  // TRITONSERVER_MetricFamily
+  //
+  TRITONSERVER_Error* TRITONSERVER_MetricFamilyNew(
+      TRITONSERVER_MetricFamily * *family, TRITONSERVER_MetricKind kind,
+      const char* name, const char* description)
+  {
+#ifdef TRITON_ENABLE_METRICS
+    try {
+      *family = reinterpret_cast<TRITONSERVER_MetricFamily*>(
+          new tc::MetricFamily(kind, name, description));
+    }
+    catch (std::invalid_argument const& ex) {
+      // Catch invalid kinds passed to constructor
+      return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, ex.what());
+    }
+    return nullptr;  // Success
 #else
     return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_UNSUPPORTED, "inference tracing not supported");
-#endif  // TRITON_ENABLE_TRACING
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+#endif  // TRITON_ENABLE_METRICS
   }
 
-  // We wrap the request in a unique pointer to ensure that it flows
-  // through inferencing with clear ownership.
-  std::unique_ptr<tc::InferenceRequest> ureq(lrequest);
-
-  // Run inference...
-  tc::Status status = lserver->InferAsync(ureq);
-
-  // If there is an error then must explicitly release any trace
-  // object associated with the inference request above.
-#ifdef TRITON_ENABLE_TRACING
-  if (!status.IsOk()) {
-    ureq->ReleaseTrace();
-  }
-#endif  // TRITON_ENABLE_TRACING
-
-  // If there is an error then ureq will still have 'lrequest' and we
-  // must release it from unique_ptr since the caller should retain
-  // ownership when there is error. If there is not an error then ureq
-  // == nullptr and so this release is a nop.
-  ureq.release();
-
-  RETURN_IF_STATUS_ERROR(status);
-  return nullptr;  // Success
-}
-
-//
-// TRITONSERVER_MetricFamily
-//
-TRITONSERVER_Error*
-TRITONSERVER_MetricFamilyNew(
-    TRITONSERVER_MetricFamily** family, TRITONSERVER_MetricKind kind,
-    const char* name, const char* description)
-{
+  TRITONSERVER_Error* TRITONSERVER_MetricFamilyDelete(
+      TRITONSERVER_MetricFamily * family)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  try {
-    *family = reinterpret_cast<TRITONSERVER_MetricFamily*>(
-        new tc::MetricFamily(kind, name, description));
-  }
-  catch (std::invalid_argument const& ex) {
-    // Catch invalid kinds passed to constructor
-    return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, ex.what());
-  }
-  return nullptr;  // Success
+    delete reinterpret_cast<tc::MetricFamily*>(family);
+    return nullptr;  // Success
 #else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
-
-TRITONSERVER_Error*
-TRITONSERVER_MetricFamilyDelete(TRITONSERVER_MetricFamily* family)
-{
-#ifdef TRITON_ENABLE_METRICS
-  delete reinterpret_cast<tc::MetricFamily*>(family);
-  return nullptr;  // Success
-#else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
-#endif  // TRITON_ENABLE_METRICS
-}
-
-//
-// TRITONSERVER_Metric
-//
-TRITONSERVER_Error*
-TRITONSERVER_MetricNew(
-    TRITONSERVER_Metric** metric, TRITONSERVER_MetricFamily* family,
-    const TRITONSERVER_Parameter** labels, const uint64_t label_count)
-{
-#ifdef TRITON_ENABLE_METRICS
-  std::vector<const tc::InferenceParameter*> labels_vec;
-  for (size_t i = 0; i < label_count; i++) {
-    labels_vec.emplace_back(
-        reinterpret_cast<const tc::InferenceParameter*>(labels[i]));
   }
 
-  try {
-    *metric = reinterpret_cast<TRITONSERVER_Metric*>(
-        new tc::Metric(family, labels_vec));
+  //
+  // TRITONSERVER_Metric
+  //
+  TRITONSERVER_Error* TRITONSERVER_MetricNew(
+      TRITONSERVER_Metric * *metric, TRITONSERVER_MetricFamily * family,
+      const TRITONSERVER_Parameter** labels, const uint64_t label_count)
+  {
+#ifdef TRITON_ENABLE_METRICS
+    std::vector<const tc::InferenceParameter*> labels_vec;
+    for (size_t i = 0; i < label_count; i++) {
+      labels_vec.emplace_back(
+          reinterpret_cast<const tc::InferenceParameter*>(labels[i]));
+    }
+
+    try {
+      *metric = reinterpret_cast<TRITONSERVER_Metric*>(
+          new tc::Metric(family, labels_vec));
+    }
+    catch (std::invalid_argument const& ex) {
+      // Catch invalid kinds passed to constructor
+      return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, ex.what());
+    }
+
+    return nullptr;  // Success
+#else
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+#endif  // TRITON_ENABLE_METRICS
   }
-  catch (std::invalid_argument const& ex) {
-    // Catch invalid kinds passed to constructor
-    return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, ex.what());
+
+  TRITONSERVER_Error* TRITONSERVER_MetricDelete(TRITONSERVER_Metric * metric)
+  {
+#ifdef TRITON_ENABLE_METRICS
+    delete reinterpret_cast<tc::Metric*>(metric);
+    return nullptr;  // Success
+#else
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+#endif  // TRITON_ENABLE_METRICS
   }
 
-  return nullptr;  // Success
-#else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
-#endif  // TRITON_ENABLE_METRICS
-}
-
-TRITONSERVER_Error*
-TRITONSERVER_MetricDelete(TRITONSERVER_Metric* metric)
-{
+  TRITONSERVER_Error* TRITONSERVER_MetricValue(
+      TRITONSERVER_Metric * metric, double* value)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  delete reinterpret_cast<tc::Metric*>(metric);
-  return nullptr;  // Success
+    return reinterpret_cast<tc::Metric*>(metric)->Value(value);
 #else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
+  }
 
-TRITONSERVER_Error*
-TRITONSERVER_MetricValue(TRITONSERVER_Metric* metric, double* value)
-{
+  TRITONSERVER_Error* TRITONSERVER_MetricIncrement(
+      TRITONSERVER_Metric * metric, double value)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  return reinterpret_cast<tc::Metric*>(metric)->Value(value);
+    return reinterpret_cast<tc::Metric*>(metric)->Increment(value);
 #else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
+  }
 
-TRITONSERVER_Error*
-TRITONSERVER_MetricIncrement(TRITONSERVER_Metric* metric, double value)
-{
+  TRITONSERVER_Error* TRITONSERVER_MetricSet(
+      TRITONSERVER_Metric * metric, double value)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  return reinterpret_cast<tc::Metric*>(metric)->Increment(value);
+    return reinterpret_cast<tc::Metric*>(metric)->Set(value);
 #else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
+  }
 
-TRITONSERVER_Error*
-TRITONSERVER_MetricSet(TRITONSERVER_Metric* metric, double value)
-{
+  TRITONSERVER_Error* TRITONSERVER_GetMetricKind(
+      TRITONSERVER_Metric * metric, TRITONSERVER_MetricKind * kind)
+  {
 #ifdef TRITON_ENABLE_METRICS
-  return reinterpret_cast<tc::Metric*>(metric)->Set(value);
+    *kind = reinterpret_cast<tc::Metric*>(metric)->Kind();
+    return nullptr;  // Success
 #else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS
-}
-
-TRITONSERVER_Error*
-TRITONSERVER_GetMetricKind(
-    TRITONSERVER_Metric* metric, TRITONSERVER_MetricKind* kind)
-{
-#ifdef TRITON_ENABLE_METRICS
-  *kind = reinterpret_cast<tc::Metric*>(metric)->Kind();
-  return nullptr;  // Success
-#else
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
-#endif  // TRITON_ENABLE_METRICS
-}
+  }
 
 }  // extern C

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2162,6 +2162,11 @@ TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,
     const TRITONSERVER_Parameter** name_mapping, const uint32_t mapping_count)
 {
+  if (model_control_mode_ == ModelControlMode::MODE_POLL) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED,
+        "Register API is unsupported in POLLING model control mode");
+  }
   if ((name_mapping == nullptr) && (mapping_count != 0)) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
@@ -2201,6 +2206,11 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerUnregisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path)
 {
+  if (model_control_mode_ == ModelControlMode::MODE_POLL) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNSUPPORTED,
+        "Unregister API is unsupported in POLLING model control mode");
+  }
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   RETURN_IF_STATUS_ERROR(lserver->RemoveModelRepositoryPath(repository_path));
   // TODO: Remove all model mappings associated with a specific path... do when

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2157,6 +2157,48 @@ TRITONSERVER_ServerStop(TRITONSERVER_Server* server)
   return nullptr;  // Success
 }
 
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerRegisterModelRepository(TRITONSERVER_Server* server,
+    const char* repository_path, const TRITONSERVER_Parameter** model_mapping,
+    const uint32_t mapping_count){
+
+      // TODO: Figure out naming... model_mapping is directory to model name?
+      // But then it's the reverse in model repo manager.
+      if ((model_mapping == nullptr) && (mapping_count != 0)) {
+        return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          "model mappings are not provided while mapping count is non-zero");
+      }
+
+      tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+      lserver->AddModelRepositoryPath(repository_path);
+
+      for (size_t i = 0; i < mapping_count; ++i) {
+        auto mapping = reinterpret_cast<tc::InferenceParameter*>(model_mapping[i]);
+        auto model = mapping.Name();
+        if(mapping->Type() != TRITONSERVER_PARAMETER_STRING){
+          return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          std::string(
+              "Requested model mapping directory must be a string, found another type for " + model)
+              .c_str());
+        }
+        // Add model->model_path and model_path->model in model repository manager (via Triton server)
+        // Check if already exists
+        // Maybe we should create these paths by default for all models? To avoid new model mapping overriding current model
+        auto model_path = std::string(reinterpret_cast<const char*>(param->ValuePointer()));
+
+        //TODO Add model map and path map to server (maybe server can do this for both maps)
+
+      return nullptr;  // Success
+}
+
+TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_ServerUnregisterModelRepository(
+    TRITONSERVER_Server* server, const char* repository_path){
+      //TODO: Code
+      return nullptr;  // Success    
+    }
+
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerPollModelRepository(TRITONSERVER_Server* server)
 {
@@ -2561,7 +2603,7 @@ TRITONSERVER_ServerModelIndex(
   std::vector<tc::ModelRepositoryManager::ModelIndex> index;
   RETURN_IF_STATUS_ERROR(lserver->RepositoryIndex(ready_only, &index));
 
-  // Can use string ref in this function because TritonServeMessage
+  // Can use string ref in this function because TritonServerMessage
   // serializes the json when it is constructed below.
   triton::common::TritonJson::Value repository_index_json(
       triton::common::TritonJson::ValueType::ARRAY);


### PR DESCRIPTION
Allow users to register and unregister model repositories via the C API.
Maintain a model mapping between directories and model names to make it possible for users to run models where the model repository and model have different names.