### PR TITLE
Prevent stale reference to model's config_.Name()

### DIFF
--- a/src/model.h
+++ b/src/model.h
@@ -118,11 +118,11 @@ class Model {
   // model. The scheduler can only be set once for a model.
   Status SetScheduler(std::unique_ptr<Scheduler> scheduler);
 
-  // The scheduler to use for this model.
-  std::unique_ptr<Scheduler> scheduler_;
-
   // Configuration of the model.
   inference::ModelConfig config_;
+
+  // The scheduler to use for this model.
+  std::unique_ptr<Scheduler> scheduler_;
 
  private:
   // The minimum supported CUDA compute capability.


### PR DESCRIPTION
This can be non-deterministically reproduced by loading and unloading
a model with dynamic sequence batching enabled, and running
tritonserver binary with --log-verbose=1.

The destructor of DynamicBatchScheduler, when --log-verbose=1, prints
the following:

```
  LOG_VERBOSE(1) << "Stopping dynamic-batcher thread for " << model_->Name()
                 << "...";
```

That is actually printed by the BatcherThread() function; however,
~DynamicBatchScheduler waits to return until it has run.


Unfortunately, model_->Name() is implemented as:
```
const std::string& Name() const { return config_.name(); }
```
config_ has already been destroyed by the time that the scheduler's
destructor is run, so the reference to the name is stale. This stale
reference sometimes causes a segfault (or sometimes not, depending
upon how long it takes to reach a null byte in the invalid memory)
when unloading a model that looks like this:

```
I0427 20:19:40.309255 106 model_repository_manager.cc:700] AsyncLoad()
'vista_conformer-ctc-decoder-cpu-streaming'
I0427 20:19:40.309388 106 model_repository_manager.cc:939]
TriggerNextAction() 'vista_conformer-ctc-decoder-cpu-streaming'
version 1: 1
I0427 20:19:40.309409 106 model_repository_manager.cc:975] Load()
'vista_conformer-ctc-decoder-cpu-streaming' version 1
I0427 20:19:40.550437 106 ctc-decoder-library.cc:22]
TRITONBACKEND_ModelFinalize: delete model state
I0427 20:19:40.550490 106 triton_backend_manager.cc:101] unloading
backend 'riva_asr_decoder'
I0427 20:19:40.594447 106 sequence_batch_scheduler.cc:866] Stopping
sequence-batch reaper thread...
[Thread 0x7fbb0bfff000 (LWP 128) exited]
--Type <RET> for more, q to quit, c to continue without paging--

Thread 7 "tritonserver" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fbb20c15000 (LWP 127)]
0x00007fbbffedc959 in ?? () from /usr/lib/x86_64-linux-gnu/libc.so.6
(cuda-gdb) bt
 #0  0x00007fbbffedc959 in ?? () from
 #/usr/lib/x86_64-linux-gnu/libc.so.6
 #1  0x00007fbc001edb28 in std::basic_streambuf<char,
 #std::char_traits<char> >::xsputn(char const*, long) () from
 #/usr/lib/x86_64-linux-gnu/libstdc++.so.6
 #2  0x00007fbc001df824 in std::basic_ostream<char,
 #std::char_traits<char> >& std::__ostream_insert<char,
 #std::char_traits<char> >(std::basic_ostream<char,
 #std::char_traits<char> >&, char const*, long) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
   #3  0x00007fbc00722f4c in
   nvidia::inferenceserver::DynamicBatchScheduler::BatcherThread(int) ()
   from /opt/tritonserver/lib/libtritonserver.so
   #4  0x00007fbc00182de4 in ?? () from
   /usr/lib/x86_64-linux-gnu/libstdc++.so.6
   #5  0x00007fbc00600609 in start_thread ()
      from /usr/lib/x86_64-linux-gnu/libpthread.so.0
      #6  0x00007fbbffe70293 in clone () from /usr/lib/x86_64-linux-gnu/libc.so.6
```
The workaround is to swap the order of scheduler_ and config_ in
src/core/model.h, since destructors of member variables run bottom-up. 
TritonModel::SetConfiguredScheduler()
depends upon config_ having already been set, but this is the case
already because the constructor for TritonModel has already run by the
time SetConfiguredScheduler() is run.