### PR TITLE
Default CPU Instance to 2 

### DIFF
--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -768,7 +768,7 @@ GetNormalizedModelConfig(
 
       // Count
       if (group.count() < 1) {
-        group.set_count(1);
+        RETURN_IF_ERROR(SetDefaultInstanceCount(&group, config->backend()));
       }
 
       // GPUs
@@ -782,6 +782,27 @@ GetNormalizedModelConfig(
   }
 
   return Status::Success;
+}
+
+Status
+SetDefaultInstanceCount(
+    ::inference::ModelInstanceGroup* group, std::string& backend)
+{
+  if (group->kind() == inference::ModelInstanceGroup::KIND_CPU) {
+    // Some backends don't perform well with multiple
+    // model instances such as pytorch so we want to
+    // default to a different value. Add other similar backends
+    // to this check.
+    if (backend.compare(kPyTorchBackend) == 0) {
+      group->set_count(1);
+    } else {
+      group->set_count(2)
+    }
+  } else {
+    group->set_count(1);
+  }
+
+  return nullptr;  // Success
 }
 
 Status

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -791,12 +791,11 @@ SetDefaultInstanceCount(
   const int default_cpu_instance_count = 2;
   if (group->kind() == inference::ModelInstanceGroup::KIND_CPU) {
     // Backends opt into the default_cpu_instance_count since
-    // some backends don't perform well/have high overhead
+    // some backends (pytorch, OpenVINO) don't perform well/have high overhead
     // when using multiple instances.
-    bool use_default_cpu_instance_count =
-        (backend.compare(kTensorRTBackend) == 0) ||
-        (backend.compare(kTensorFlowBackend) == 0) ||
-        (backend.compare(kOnnxRuntimeBackend) == 0);
+    bool use_default_cpu_instance_count = (backend == kTensorRTBackend) ||
+                                          (backend == kTensorFlowBackend) ||
+                                          (backend == kOnnxRuntimeBackend);
     if (use_default_cpu_instance_count) {
       group->set_count(default_cpu_instance_count);
     } else {

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -794,9 +794,8 @@ SetDefaultInstanceCount(
   // some backends (pytorch, OpenVINO) don't perform well/have high overhead
   // when using multiple instances.
   const int default_cpu_instance_count = 2;
-  bool use_default_cpu_instance_count = (backend == kTensorRTBackend) ||
-                                        (backend == kTensorFlowBackend) ||
-                                        (backend == kOnnxRuntimeBackend);
+  bool use_default_cpu_instance_count =
+      (backend == kTensorFlowBackend) || (backend == kOnnxRuntimeBackend);
   if (group->kind() == inference::ModelInstanceGroup::KIND_CPU &&
       use_default_cpu_instance_count) {
     group->set_count(default_cpu_instance_count);

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -786,8 +786,9 @@ GetNormalizedModelConfig(
 
 Status
 SetDefaultInstanceCount(
-    ::inference::ModelInstanceGroup* group, std::string& backend)
+    ::inference::ModelInstanceGroup* group, const std::string& backend)
 {
+  const int default_cpu_instance_count = 2;
   if (group->kind() == inference::ModelInstanceGroup::KIND_CPU) {
     // Some backends don't perform well with multiple
     // model instances such as pytorch so we want to
@@ -796,13 +797,13 @@ SetDefaultInstanceCount(
     if (backend.compare(kPyTorchBackend) == 0) {
       group->set_count(1);
     } else {
-      group->set_count(2)
+      group->set_count(default_cpu_instance_count);
     }
   } else {
     group->set_count(1);
   }
 
-  return nullptr;  // Success
+  return Status::Success;
 }
 
 Status

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -790,14 +790,17 @@ SetDefaultInstanceCount(
 {
   const int default_cpu_instance_count = 2;
   if (group->kind() == inference::ModelInstanceGroup::KIND_CPU) {
-    // Some backends don't perform well with multiple
-    // model instances such as pytorch so we want to
-    // default to a different value. Add other similar backends
-    // to this check.
-    if (backend.compare(kPyTorchBackend) == 0) {
-      group->set_count(1);
-    } else {
+    // Backends opt into the default_cpu_instance_count since
+    // some backends don't perform well/have high overhead
+    // when using multiple instances.
+    bool use_default_cpu_instance_count =
+        (backend.compare(kTensorRTBackend) == 0) ||
+        (backend.compare(kTensorFlowBackend) == 0) ||
+        (backend.compare(kOnnxRuntimeBackend) == 0);
+    if (use_default_cpu_instance_count) {
       group->set_count(default_cpu_instance_count);
+    } else {
+      group->set_count(1);
     }
   } else {
     group->set_count(1);

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -86,6 +86,14 @@ Status GetNormalizedModelConfig(
     const std::string& model_name, const std::string& path,
     const double min_compute_capability, inference::ModelConfig* config);
 
+/// Auto-complete the instance count based on instance kind and backend name.
+/// For KIND_CPU the default instance count is 2 except for the pytorch backend.
+/// \param group The instance group to set the count for.
+/// \param backned The backend name to check against.
+/// \return The error status.
+Status SetDefaultInstanceCount(
+    ::inference::ModelInstanceGroup* group, const std::string& backend);
+
 /// Auto-complete backend related fields (platform, backend and default model
 /// filename) if not set, note that only Triton recognized backends will be
 /// checked.

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -87,12 +87,11 @@ Status GetNormalizedModelConfig(
     const double min_compute_capability, inference::ModelConfig* config);
 
 /// Auto-complete the instance count based on instance kind and backend name.
-/// For KIND_CPU the default instance count is 2 except for the pytorch backend.
 /// \param group The instance group to set the count for.
-/// \param backned The backend name to check against.
+/// \param backend The backend name to check against.
 /// \return The error status.
 Status SetDefaultInstanceCount(
-    ::inference::ModelInstanceGroup* group, const std::string& backend);
+    inference::ModelInstanceGroup* group, const std::string& backend);
 
 /// Auto-complete backend related fields (platform, backend and default model
 /// filename) if not set, note that only Triton recognized backends will be


### PR DESCRIPTION
Defaults instance groups of KIND_CPU to a count of 2 rather than 1 be default. Pytorch is excluded from this list as it doesn't benefit from this higher instance count. Other backends which need to be excluded can be added to the list.