### PR TITLE
Use thread pool to load models

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1751,8 +1751,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetBufferManagerThreadCount(
     TRITONSERVER_ServerOptions* options, unsigned int thread_count);
 
-/// Set the number of threads used to concurrently Load/Unload models in server
-/// options.
+/// Set the number of threads to concurrently load models in a server options.
 ///
 /// \param thread_count The number of threads.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 14
+#define TRITONSERVER_API_VERSION_MINOR 15
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the
@@ -1749,6 +1749,15 @@ TRITONSERVER_ServerOptionsSetExitTimeout(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetBufferManagerThreadCount(
+    TRITONSERVER_ServerOptions* options, unsigned int thread_count);
+
+/// Set the number of threads used to concurrently Load/Unload models in server
+/// options.
+///
+/// \param thread_count The number of threads.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetModelLoadThreadCount(
     TRITONSERVER_ServerOptions* options, unsigned int thread_count);
 
 /// Enable or disable info level logging.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1745,6 +1745,7 @@ TRITONSERVER_ServerOptionsSetExitTimeout(
 
 /// Set the number of threads used in buffer manager in a server options.
 ///
+/// \param options The server options object.
 /// \param thread_count The number of threads.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
@@ -1753,6 +1754,7 @@ TRITONSERVER_ServerOptionsSetBufferManagerThreadCount(
 
 /// Set the number of threads to concurrently load models in a server options.
 ///
+/// \param options The server options object.
 /// \param thread_count The number of threads.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,7 +422,6 @@ target_link_libraries(
   PRIVATE
     proto-library                    # from repo-common
     triton-common-async-work-queue   # from repo-common
-    triton-common-thread-pool        # from repo-common
     triton-common-error              # from repo-common
     triton-common-model-config       # from repo-common
     triton-common-logging            # from repo-common

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,6 +422,7 @@ target_link_libraries(
   PRIVATE
     proto-library                    # from repo-common
     triton-common-async-work-queue   # from repo-common
+    triton-common-thread-pool        # from repo-common
     triton-common-error              # from repo-common
     triton-common-model-config       # from repo-common
     triton-common-logging            # from repo-common

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -28,6 +28,8 @@
 #include "model_repository_manager.h"
 
 #include <algorithm>
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
 #include <deque>
 #include <future>
 #include <stdexcept>
@@ -39,10 +41,6 @@
 #include "model_config_utils.h"
 #include "repo_agent.h"
 #include "triton/common/logging.h"
-
-// Thread Pool
-#include <boost/asio/post.hpp>
-#include <boost/asio/thread_pool.hpp>
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -557,8 +557,6 @@ class ModelRepositoryManager::ModelLifeCycle {
         cmdline_config_map_(backend_cmdline_config_map),
         host_policy_map_(host_policy_map)
   {
-    LOG_VERBOSE(2) << "Creating load_pool_ with thread_count: "
-                   << model_load_thread_count;
     load_pool_.reset(
         new boost::asio::thread_pool(std::max(1u, model_load_thread_count)));
   }

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -561,7 +561,7 @@ class ModelRepositoryManager::ModelLifeCycle {
         host_policy_map_(host_policy_map)
   {
     load_pool_.reset(
-        new triton::comon::ThreadPool(std::max(1u, model_load_thread_count)));
+        new triton::common::ThreadPool(std::max(1u, model_load_thread_count)));
   }
 
   // Function called after model state / next action is updated.

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -467,7 +467,13 @@ class ModelRepositoryManager::ModelLifeCycle {
       const unsigned int model_load_thread_count,
       std::unique_ptr<ModelLifeCycle>* life_cycle);
 
-  ~ModelLifeCycle() { map_.clear(); }
+  ~ModelLifeCycle()
+  {
+    // Explicitly clean up thread pool first to clean up any pending callbacks
+    // that may modify model lifecycle members
+    load_pool_.reset();
+    map_.clear();
+  }
 
   // Start loading model with specified versions asynchronously.
   // If 'defer_unload' is false, all versions that are being served will

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -28,8 +28,6 @@
 #include "model_repository_manager.h"
 
 #include <algorithm>
-#include <boost/asio/post.hpp>
-#include <boost/asio/thread_pool.hpp>
 #include <deque>
 #include <future>
 #include <stdexcept>
@@ -41,6 +39,7 @@
 #include "model_config_utils.h"
 #include "repo_agent.h"
 #include "triton/common/logging.h"
+#include "triton/common/thread_pool.h"
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>
@@ -562,7 +561,7 @@ class ModelRepositoryManager::ModelLifeCycle {
         host_policy_map_(host_policy_map)
   {
     load_pool_.reset(
-        new boost::asio::thread_pool(std::max(1u, model_load_thread_count)));
+        new triton::comon::ThreadPool(std::max(1u, model_load_thread_count)));
   }
 
   // Function called after model state / next action is updated.
@@ -600,7 +599,7 @@ class ModelRepositoryManager::ModelLifeCycle {
   const triton::common::HostPolicyCmdlineConfigMap host_policy_map_;
 
   // Fixed-size thread pool to load models at specified concurrency
-  std::unique_ptr<boost::asio::thread_pool> load_pool_;
+  std::unique_ptr<triton::common::ThreadPool> load_pool_;
 };
 
 Status
@@ -1208,7 +1207,7 @@ ModelRepositoryManager::ModelLifeCycle::Load(
       model_info->state_ = ModelReadyState::LOADING;
       model_info->state_reason_.clear();
       // Load model asynchronously via thread pool
-      boost::asio::post(*load_pool_, [this, model_name, version, model_info]() {
+      load_pool_->enqueue([this, model_name, version, model_info]() {
         CreateModel(model_name, version, model_info);
       });
       break;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -151,7 +151,7 @@ class ModelRepositoryManager {
       const bool polling_enabled, const bool model_control_enabled,
       const double min_compute_capability,
       const triton::common::HostPolicyCmdlineConfigMap& host_policy_map,
-      const uint32_t model_load_thread_count,
+      const unsigned int model_load_thread_count,
       std::unique_ptr<ModelRepositoryManager>* model_repository_manager);
 
   /// Poll the model repository to determine the new set of models and

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -138,6 +138,8 @@ class ModelRepositoryManager {
   /// \param min_compute_capability The minimum support CUDA compute
   /// capability.
   /// \param host_policy_map The host policy setting used when loading models.
+  /// \param model_load_thread_count The number of threads to allocate to the
+  /// thread pool for concurrently loading/unloading models.
   /// \param model_repository_manager Return the model repository manager.
   /// \return The error status.
   static Status Create(
@@ -149,6 +151,7 @@ class ModelRepositoryManager {
       const bool polling_enabled, const bool model_control_enabled,
       const double min_compute_capability,
       const triton::common::HostPolicyCmdlineConfigMap& host_policy_map,
+      const uint32_t model_load_thread_count,
       std::unique_ptr<ModelRepositoryManager>* model_repository_manager);
 
   /// Poll the model repository to determine the new set of models and
@@ -157,8 +160,8 @@ class ModelRepositoryManager {
   Status PollAndUpdate();
 
   /// Load or unload a specified model.
-  /// \parm models The models and the parameters to be loaded or unloaded
-  /// \parm type The type action to be performed. If the action is LOAD and
+  /// \param models The models and the parameters to be loaded or unloaded
+  /// \param type The type action to be performed. If the action is LOAD and
   /// the model has been loaded, the model will be re-loaded.
   /// \return error status. Return "NOT_FOUND" if it tries to load
   /// a non-existing model or if it tries to unload a model that hasn't been
@@ -221,7 +224,8 @@ class ModelRepositoryManager {
   // Register model repository path.
   /// \param repository Path to model repository.
   /// \param model_mapping Mapping with (overridden) model name as key, subdir
-  /// name as value. \return error status
+  /// name as value.
+  /// \return error status
   Status RegisterModelRepository(
       const std::string& repository,
       const std::unordered_map<std::string, std::string>& model_mapping);

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -139,7 +139,7 @@ class ModelRepositoryManager {
   /// capability.
   /// \param host_policy_map The host policy setting used when loading models.
   /// \param model_load_thread_count The number of threads to allocate to the
-  /// thread pool for concurrently loading/unloading models.
+  /// thread pool for concurrently loading models.
   /// \param model_repository_manager Return the model repository manager.
   /// \return The error status.
   static Status Create(

--- a/src/server.cc
+++ b/src/server.cc
@@ -102,8 +102,8 @@ InferenceServer::InferenceServer()
   exit_timeout_secs_ = 30;
   pinned_memory_pool_size_ = 1 << 28;
   buffer_manager_thread_count_ = 0;
-  model_load_thread_count =
-      std::max(2, 2 * std::thread::hardware_concurrency());
+  model_load_thread_count_ =
+      std::max(2u, 2 * std::thread::hardware_concurrency());
 
 #ifdef TRITON_ENABLE_GPU
   min_supported_compute_capability_ = TRITON_MIN_COMPUTE_CAPABILITY;

--- a/src/server.cc
+++ b/src/server.cc
@@ -102,6 +102,9 @@ InferenceServer::InferenceServer()
   exit_timeout_secs_ = 30;
   pinned_memory_pool_size_ = 1 << 28;
   buffer_manager_thread_count_ = 0;
+  model_load_thread_count =
+      std::max(2, 2 * std::thread::hardware_concurrency());
+
 #ifdef TRITON_ENABLE_GPU
   min_supported_compute_capability_ = TRITON_MIN_COMPUTE_CAPABILITY;
 #else
@@ -222,7 +225,7 @@ InferenceServer::Init()
       this, version_, model_repository_paths_, startup_models_,
       strict_model_config_, backend_cmdline_config_map_, polling_enabled,
       model_control_enabled, min_supported_compute_capability_,
-      host_policy_map_, &model_repository_manager_);
+      host_policy_map_, model_load_thread_count_, &model_repository_manager_);
   if (!status.IsOk()) {
     if (model_repository_manager_ == nullptr) {
       ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;

--- a/src/server.h
+++ b/src/server.h
@@ -236,6 +236,8 @@ class InferenceServer {
     buffer_manager_thread_count_ = c;
   }
 
+  void SetModelLoadThreadCount(unsigned int c) { model_load_thread_count_ = c; }
+
   // Set a backend command-line configuration
   void SetBackendCmdlineConfig(
       const triton::common::BackendCmdlineConfigMap& bc)
@@ -293,6 +295,7 @@ class InferenceServer {
   bool strict_readiness_;
   uint32_t exit_timeout_secs_;
   uint32_t buffer_manager_thread_count_;
+  uint32_t model_load_thread_count_;
   uint64_t pinned_memory_pool_size_;
   uint64_t response_cache_byte_size_;
   bool response_cache_enabled_;

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -269,6 +269,9 @@ class TritonServerOptions {
     buffer_manager_thread_count_ = c;
   }
 
+  unsigned int ModelLoadThreadCount() const { return model_load_thread_count_; }
+  void SetModelLoadThreadCount(unsigned int c) { model_load_thread_count_ = c; }
+
   bool Metrics() const { return metrics_; }
   void SetMetrics(bool b) { metrics_ = b; }
 
@@ -1200,6 +1203,16 @@ TRITONSERVER_ServerOptionsSetBufferManagerThreadCount(
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetModelLoadThreadCount(
+    TRITONSERVER_ServerOptions* options, unsigned int thread_count)
+{
+  TritonServerOptions* loptions =
+      reinterpret_cast<TritonServerOptions*>(options);
+  loptions->SetModelLoadThreadCount(thread_count);
+  return nullptr;  // Success
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetLogInfo(
     TRITONSERVER_ServerOptions* options, bool log)
 {
@@ -2018,6 +2031,7 @@ TRITONSERVER_ServerNew(
   lserver->SetHostPolicyCmdlineConfig(loptions->HostPolicyCmdlineConfigMap());
   lserver->SetRepoAgentDir(loptions->RepoAgentDir());
   lserver->SetBufferManagerThreadCount(loptions->BufferManagerThreadCount());
+  lserver->SetModelLoadThreadCount(loptions->ModelLoadThreadCount());
 
   // SetBackendCmdlineConfig must be called after all AddBackendConfig calls
   // have completed.

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -325,6 +325,7 @@ class TritonServerOptions {
   uint64_t pinned_memory_pool_size_;
   uint64_t response_cache_byte_size_;
   unsigned int buffer_manager_thread_count_;
+  unsigned int model_load_thread_count_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_compute_capability_;
   std::string backend_dir_;

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -342,6 +342,8 @@ TritonServerOptions::TritonServerOptions()
       gpu_metrics_(true), metrics_interval_(2000), exit_timeout_(30),
       pinned_memory_pool_size_(1 << 28), response_cache_byte_size_(0),
       buffer_manager_thread_count_(0),
+      model_load_thread_count_(
+          std::max(2u, 2 * std::thread::hardware_concurrency())),
 #ifdef TRITON_ENABLE_GPU
       min_compute_capability_(TRITON_MIN_COMPUTE_CAPABILITY),
 #else

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -382,6 +382,10 @@ TRITONSERVER_ServerOptionsSetBufferManagerThreadCount()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetModelLoadThreadCount()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetLogInfo()
 {
 }


### PR DESCRIPTION
Fixes DLIS-1833 and removes need for 100ms sleep in model load thread due to [glibc bug](https://sourceware.org/bugzilla/show_bug.cgi?id=19329).

Corresponding server PR: https://github.com/triton-inference-server/server/pull/4474