### PR TITLE
Add thread_pool to unit test cmake libs, fix InitFourWorker test

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1207,7 +1207,7 @@ ModelRepositoryManager::ModelLifeCycle::Load(
       model_info->state_ = ModelReadyState::LOADING;
       model_info->state_reason_.clear();
       // Load model asynchronously via thread pool
-      load_pool_->enqueue([this, model_name, version, model_info]() {
+      load_pool_->Enqueue([this, model_name, version, model_info]() {
         CreateModel(model_name, version, model_info);
       });
       break;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -362,7 +362,7 @@ target_include_directories(
 target_link_libraries(
   async_work_queue_test
   PRIVATE
-    triton-common-sync-queue         # from repo-common
+    triton-common-thread-pool        # from repo-common
     triton-common-async-work-queue   # from repo-common
     triton-common-error              # from repo-common
     GTest::gtest

--- a/src/test/async_work_queue_test.cc
+++ b/src/test/async_work_queue_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ TEST_F(AsyncWorkQueueTest, InitOneWorker)
 
 TEST_F(AsyncWorkQueueTest, InitFourWorker)
 {
-  auto error = tc::AsyncWorkQueue::Initialize(1);
+  auto error = tc::AsyncWorkQueue::Initialize(4);
   EXPECT_TRUE(error.IsOk()) << error.Message();
 }
 


### PR DESCRIPTION
- Link ThreadPool when building async work queue unit test
- Fix InitFourWorker unit test to actually use 4 workers

Backend: https://github.com/triton-inference-server/backend/pull/62
Common: https://github.com/triton-inference-server/common/pull/63
Core: https://github.com/triton-inference-server/core/pull/89