### PR TITLE
Normalize the updated model configuration received from backend

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -981,9 +981,9 @@ TRITONBACKEND_ModelAutoCompleteConfig(
 /// context will result in an error being returned. Additionally, Triton server
 /// can add some of the missing fields in the provided config with this call.
 /// The backend must get the complete configuration again by using
-/// TRITONBACKEND_ModelConfig. The function does not take ownership of the
-/// message object and so the caller should call TRITONSERVER_MessageDelete to
-/// release the object once the function returns.
+/// TRITONBACKEND_ModelConfig. TRITONBACKEND_ModelSetConfig does not take
+/// ownership of the message object and so the caller should call
+/// TRITONSERVER_MessageDelete to release the object once the function returns.
 ///
 /// \param model The model.
 /// \param config_version The format version of the model configuration.

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -978,9 +978,12 @@ TRITONBACKEND_ModelAutoCompleteConfig(
 /// scheduling choice can only be changed if none is previously set. Any other
 /// changes to the model configuration will be ignored by Triton. This function
 /// can only be called from TRITONBACKEND_ModelInitialize, calling in any other
-/// context will result in an error being returned. The function does not take
-/// ownership of the message object and so the caller should call
-/// TRITONSERVER_MessageDelete to release the object once the function returns.
+/// context will result in an error being returned. Additionally, Triton server
+/// can add some of the missing fields in the provided config with this call.
+/// The backend must get the complete configuration again by using
+/// TRITONBACKEND_ModelConfig. The function does not take ownership of the
+/// message object and so the caller should call TRITONSERVER_MessageDelete to
+/// release the object once the function returns.
 ///
 /// \param model The model.
 /// \param config_version The format version of the model configuration.

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -353,8 +353,8 @@ TritonModel::UpdateModelConfig(
             .c_str());
   }  // else do nothing
 
-  // The updated model config may have added some
-  // fields that may need normalizing.
+  // Need to normalize the model configuration for
+  // populating missing fields.
   RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability_, &config));
 
   RETURN_IF_ERROR(SetModelConfig(config));

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -353,6 +353,10 @@ TritonModel::UpdateModelConfig(
             .c_str());
   }  // else do nothing
 
+  // The updated model config may have added some
+  // fields that may need normalizing.
+  RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability_, &config));
+
   RETURN_IF_ERROR(SetModelConfig(config));
   return Status::Success;
 }
@@ -438,7 +442,8 @@ TritonModel::TritonModel(
     const inference::ModelConfig& config, const bool auto_complete_config)
     : Model(
           min_compute_capability, localized_model_dir->Path(), version, config),
-      server_(server), auto_complete_config_(auto_complete_config),
+      server_(server), min_compute_capability_(min_compute_capability),
+      auto_complete_config_(auto_complete_config),
       localized_model_dir_(localized_model_dir), backend_(backend),
       state_(nullptr)
 {

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -108,6 +108,9 @@ class TritonModel : public Model {
   // be longer than the lifetime of a model owned by the server.
   InferenceServer* server_;
 
+  // The minimum supported compute capability on device.
+  const double min_compute_capability_;
+
   // Whether the backend should attempt to auto-complete the model config.
   const bool auto_complete_config_;
 

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -645,6 +645,15 @@ GetNormalizedModelConfig(
   LOG_VERBOSE(1) << "Server side auto-completed config: "
                  << config->DebugString();
 
+  RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability, config));
+
+  return Status::Success;
+}
+
+Status
+NormalizeModelConfig(
+    const double min_compute_capability, inference::ModelConfig* config)
+{
   if (config->backend().empty()) {
     // Expect backend is not empty unless it is ensemble platform.
 #ifdef TRITON_ENABLE_ENSEMBLE

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -99,9 +99,9 @@ Status AutoCompleteBackendFields(
     inference::ModelConfig* config);
 
 /// Detects and adds missing fields in the model configuration.
-/// \param config The model configuration
-/// \param min_compute_capability The minimum support CUDA compute
+/// \param min_compute_capability The minimum supported CUDA compute
 /// capability.
+/// \param config The model configuration
 /// \return The error status
 Status NormalizeModelConfig(
     const double min_compute_capability, inference::ModelConfig* config);

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -86,13 +86,6 @@ Status GetNormalizedModelConfig(
     const std::string& model_name, const std::string& path,
     const double min_compute_capability, inference::ModelConfig* config);
 
-/// Auto-complete the instance count based on instance kind and backend name.
-/// \param group The instance group to set the count for.
-/// \param backend The backend name to check against.
-/// \return The error status.
-Status SetDefaultInstanceCount(
-    inference::ModelInstanceGroup* group, const std::string& backend);
-
 /// Auto-complete backend related fields (platform, backend and default model
 /// filename) if not set, note that only Triton recognized backends will be
 /// checked.
@@ -104,6 +97,21 @@ Status SetDefaultInstanceCount(
 Status AutoCompleteBackendFields(
     const std::string& model_name, const std::string& model_path,
     inference::ModelConfig* config);
+
+/// Detects and adds missing fields in the model configuration.
+/// \param config The model configuration
+/// \param min_compute_capability The minimum support CUDA compute
+/// capability.
+/// \return The error status
+Status NormalizeModelConfig(
+    const double min_compute_capability, inference::ModelConfig* config);
+
+/// Auto-complete the instance count based on instance kind and backend name.
+/// \param group The instance group to set the count for.
+/// \param backend The backend name to check against.
+/// \return The error status.
+Status SetDefaultInstanceCount(
+    inference::ModelInstanceGroup* group, const std::string& backend);
 
 /// Validate that a model is specified correctly, except for model inputs
 /// and outputs. ValidateModelIOConfig() should be called to


### PR DESCRIPTION
Running complete normalizing for future-proofing auto-complete. In case other, features gets added to the auto-complete logic on backend side.

I didn't move all the auto-complete logic from core to backend utilities because the changes will not be backwards compatible with our suggestion. We don't require users to essentially use our backend utilities. Some server-side auto-complete is definitely needed. 
https://github.com/triton-inference-server/backend/blob/main/include/triton/backend/backend_model.h#L40-L41


