### PR TITLE
Fix possible segfault from invalid infer shape input

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -881,8 +881,14 @@ InferenceRequest::Normalize()
                 "'");
       }
 
-      input.MutableShape()->assign(
-          input.OriginalShape().begin() + 1, input.OriginalShape().end());
+      // When skipping the first dimension, make sure there is a second
+      // dimension
+      if (input.OriginalShape().size() > 1) {
+        input.MutableShape()->assign(
+            input.OriginalShape().begin() + 1, input.OriginalShape().end());
+      } else {
+        input.MutableShape()->clear();
+      }
     }
   }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -863,11 +863,12 @@ InferenceRequest::Normalize()
         continue;
       }
 
-      if (input.OriginalShape().size() == 0) {
+      // Make sure shape has batch dimension and at least 1d shape for model
+      if (input.OriginalShape().size() < 2) {
         return Status(
             Status::Code::INVALID_ARG,
             LogRequest() + "input '" + input.Name() +
-                "' has no shape but model requires batch dimension for '" +
+                "' shape is missing batch and/or subsequent dimension '" +
                 ModelName() + "'");
       }
 
@@ -881,14 +882,8 @@ InferenceRequest::Normalize()
                 "'");
       }
 
-      // When skipping the first dimension, make sure there is a second
-      // dimension
-      if (input.OriginalShape().size() > 1) {
-        input.MutableShape()->assign(
-            input.OriginalShape().begin() + 1, input.OriginalShape().end());
-      } else {
-        input.MutableShape()->clear();
-      }
+      input.MutableShape()->assign(
+          input.OriginalShape().begin() + 1, input.OriginalShape().end());
     }
   }
 


### PR DESCRIPTION
When a model config has `max_batch_size > 0` and `dims = [1]`, the server will copy the `shape` object without the outer most dimension from the `shape` during infer requests. The original copy process did not check if there are at least two elements in the `shape` object. Thus, if the user sets `shape = [1]`, the server can run into a segmentation fault by reading the second element from the `shape` object, which does not exist. This PR adds the check.