### PR TITLE
Verify startup_models (--load-model args) exist

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -907,7 +907,6 @@ ModelRepositoryManager::Poll(
           LOG_ERROR << "mapped path '" << full_path
                     << "' does not exist for model '" << model.first << "'";
           exists = false;
-          *all_models_polled = false;
         }
       } else {
         for (const auto repository_path : repository_paths_) {
@@ -939,7 +938,6 @@ ModelRepositoryManager::Poll(
               exists = true;
             } else {
               exists = false;
-              *all_models_polled = false;
               model_to_path.erase(res.first);
               LOG_ERROR << "failed to poll model '" << model.first
                         << "': not unique across all model repositories";
@@ -949,8 +947,8 @@ ModelRepositoryManager::Poll(
         }
       }
       if (!exists) {
-        deleted->insert(model.first);
         *all_models_polled = false;
+        deleted->insert(model.first);
       }
     }
   }

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -366,8 +366,8 @@ ModelRepositoryManager::Create(
     for (const auto& model_name : startup_models) {
       // Verify each model loads successfully, one at a time
       models[model_name];
-      RETURN_IF_ERROR(local_manager->LoadUnloadModel(
-        models, ActionType::LOAD, false));
+      RETURN_IF_ERROR(
+          local_manager->LoadUnloadModel(models, ActionType::LOAD, false));
       models.clear();
     }
   }

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -364,10 +364,12 @@ ModelRepositoryManager::Create(
     std::unordered_map<std::string, std::vector<const InferenceParameter*>>
         models;
     for (const auto& model_name : startup_models) {
+      // Verify each model loads successfully, one at a time
       models[model_name];
+      RETURN_IF_ERROR(local_manager->LoadUnloadModel(
+        models, ActionType::LOAD, false));
+      models.clear();
     }
-    RETURN_IF_ERROR(local_manager->LoadUnloadModels(
-        models, ActionType::LOAD, false, &all_models_polled));
   }
 
   *model_repository_manager = std::move(local_manager);

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -370,7 +370,8 @@ ModelRepositoryManager::Create(
     }
     RETURN_IF_ERROR(
         (*model_repository_manager)
-            ->LoadUnloadModels(models, ActionType::LOAD, &all_models_polled));
+            ->LoadUnloadModels(
+                models, ActionType::LOAD, false, &all_models_polled));
   }
 
 

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -106,7 +106,7 @@ TEST_F(RegisterApiTest, Register)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
+      "failed to load 'model_0', failed to poll from model repository",
       "loading model 'model_0'");
 
   // Registering a repository "models_0" where contains "model_0"
@@ -147,7 +147,7 @@ TEST_F(RegisterApiTest, RegisterWithMap)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
+      "failed to load 'model_0', failed to poll from model repository",
       "loading model 'model_0'");
   // Request to load "name_0"
   FAIL_TEST_IF_ERR(
@@ -718,7 +718,7 @@ TEST_F(RegisterApiTest, CorrectIndex)
   FAIL_TEST_IF_NOT_ERR(
       TRITONSERVER_ServerLoadModel(server_, "model_0"),
       TRITONSERVER_ERROR_INTERNAL,
-      "failed to load 'model_0', no version is available",
+      "failed to load 'model_0', failed to poll from model repository",
       "loading model 'model_0'");
   // Request to load "name_0"
   FAIL_TEST_IF_ERR(


### PR DESCRIPTION
Detect non-existent startup models and raise an error on failing to load them

Server QA test update: https://github.com/triton-inference-server/server/pull/4681