### PR TITLE
Don't unload existing models on failed load model in explicit model control mode

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -612,7 +612,9 @@ ModelRepositoryManager::LoadUnloadModels(
       for (const auto& model : models) {
         deleted.insert(model.first);
       }
-    } else {
+    }
+    // ActionType::LOAD and in model control mode
+    else {
       std::set<std::string> checked_models;
       auto current_models = models;
       for (const auto& model : models) {
@@ -880,7 +882,9 @@ ModelRepositoryManager::Poll(
       LOG_ERROR << "failed to poll model '" << model
                 << "': not unique across all model repositories";
     }
-  } else {
+  }
+  // If models are specified, this is explicit model control mode.
+  else {
     for (const auto& model : models) {
       // Skip repository polling if override model files
       if (ModelDirectoryOverride(model.second)) {
@@ -946,9 +950,10 @@ ModelRepositoryManager::Poll(
           }
         }
       }
+      // For an explicitly specified model that doesn't exist, we don't mark it
+      // as deleted, we simply mark that we couldn't poll all models.
       if (!exists) {
         *all_models_polled = false;
-        deleted->insert(model.first);
       }
     }
   }

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -274,6 +274,8 @@ class ModelRepositoryManager {
   /// \param deleted The names of the models removed from the repository.
   /// \param modified The names of the models remaining in the
   /// repository that have been changed.
+  /// \param deleted_dependents The names of dependent models to be removed
+  /// from the repository.
   /// \return The error status.
   Status UpdateDependencyGraph(
       const std::set<std::string>& added, const std::set<std::string>& deleted,

--- a/src/test/register_api_test.cc
+++ b/src/test/register_api_test.cc
@@ -684,17 +684,13 @@ TEST_F(RegisterApiTest, DifferentMapping)
   ASSERT_TRUE(ready) << "Expect 'name_0' v1 to be ready, model directory is "
                         "'models_0/model_0'";
 
-  // [FIXME] need to revisit this, currently the model manager will actually
-  // unload 'model_0' as the side affect of calling load 'model_0' after updated
-  // the mapping, the reasoning is 'model_0' no longing "seen" in any
-  // repositories. Probably not the expected behavior as we want to keep the
-  // previously loaded 'model_0'
-  // ready = false;
-  // FAIL_TEST_IF_ERR(
-  //     TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
-  //     "Is 'model_0' ready");
-  // ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is
-  // 'models_0/model_0'";
+  // Verify that model_0 still exists in-memory
+  ready = false;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_ServerModelIsReady(server_, "model_0", 1, &ready),
+      "Is 'model_0' ready");
+  ASSERT_TRUE(ready) << "Expect 'model_0' v1 to be ready, model directory is "
+                        "'models_0/model_0'";
 }
 
 TEST_F(RegisterApiTest, CorrectIndex)


### PR DESCRIPTION
- don't unload existing model after a failed model load in explicit model control mode
- uncomment register API test that required this fix
- add some comments for clarity on model manager code/flow

corresponding CI test updates: https://github.com/triton-inference-server/server/pull/4686