### PR TITLE
Add check for config.pbtxt for backends not supporting autocomplete

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -358,6 +358,7 @@ TritonModel::UpdateModelConfig(
   RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability_, &config));
 
   RETURN_IF_ERROR(SetModelConfig(config));
+
   return Status::Success;
 }
 

--- a/src/model.h
+++ b/src/model.h
@@ -44,7 +44,8 @@ class Model {
       const double min_compute_capability, const std::string& model_dir,
       const int64_t version, const inference::ModelConfig& config)
       : config_(config), min_compute_capability_(min_compute_capability),
-        version_(version), required_input_count_(0), model_dir_(model_dir)
+        version_(version), required_input_count_(0), model_dir_(model_dir),
+        set_model_config_(false)
   {
   }
   virtual ~Model() {}
@@ -153,6 +154,9 @@ class Model {
 
   // The largest priority value for the model.
   uint32_t max_priority_level_;
+
+  // Whether or not model config has been set.
+  bool set_model_config_;
 };
 
 }}  // namespace triton::core


### PR DESCRIPTION
Example error message:

```
E0729 00:03:13.080458 2295 model_lifecycle.cc:596] failed to load 'noautofill_noconfig' version 1: Not found: unable to find the model configuration file '/opt/tritonserver/qa/L0_model_config/models/noautofill_noconfig/config.pbtxt' for model 'noautofill_noconfig'
```
