### PR TITLE
Fix uninitialized error

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -383,7 +383,7 @@ InferenceRequest::CopyAsNull(const InferenceRequest& from)
   // Second pass
   size_t max_byte_size = 0;
   size_t max_str_byte_size = 0;
-  const std::string* max_input_name;
+  const std::string* max_input_name = nullptr;
   for (const auto& input : from.OriginalInputs()) {
     // Skip shape tensors in this pass
     if (input.second.IsShapeTensor()) {


### PR DESCRIPTION
Without this patch, when building Triton on a bullseye base we get
the following error:

/build/citritonbuild/tritonserver/build/_deps/repo-core-src/src/infer_request.cc: In static member function ‘static triton::core::InferenceRequest* triton::core::InferenceRequest::CopyAsNull(const triton::core::InferenceRequest&)’:
/build/citritonbuild/tritonserver/build/_deps/repo-core-src/src/infer_request.cc:386:22: error: ‘max_input_name’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  386 |   const std::string* max_input_name;
      |                      ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors