### PR TITLE
Catch exception on boost managed_buffer creation

### DIFF
--- a/src/response_cache.cc
+++ b/src/response_cache.cc
@@ -87,7 +87,14 @@ Status
 RequestResponseCache::Create(
     uint64_t cache_size, std::unique_ptr<RequestResponseCache>* cache)
 {
-  cache->reset(new RequestResponseCache(cache_size));
+  try {
+    cache->reset(new RequestResponseCache(cache_size));
+  }
+  catch (const std::exception& ex) {
+    return Status(
+        Status::Code::INTERNAL,
+        "Failed to initialize Response Cache: " + ex.what());
+  }
 
   return Status::Success;
 }

--- a/src/response_cache.cc
+++ b/src/response_cache.cc
@@ -93,7 +93,7 @@ RequestResponseCache::Create(
   catch (const std::exception& ex) {
     return Status(
         Status::Code::INTERNAL,
-        "Failed to initialize Response Cache: " + ex.what());
+        "Failed to initialize Response Cache: " + std::string(ex.what()));
   }
 
   return Status::Success;

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -559,8 +559,38 @@ TEST_F(RequestResponseCacheTest, TestHashing)
   ASSERT_EQ(request3->CacheKey(), request4->CacheKey());
 }
 
+
+// Test cache size too large to initialize.
+TEST_F(RequestResponseCacheTest, TestCacheSizeTooLarge)
+{
+  // Pick intentionally large cache size, expecting failure
+  constexpr uint64_t cache_size = ULLONG_MAX;
+  std::cout << "Create cache of size: " << cache_size << std::endl;
+  std::unique_ptr<tc::RequestResponseCache> cache;
+  auto status = tc::RequestResponseCache::Create(cache_size, &cache);
+  ASSERT_FALSE(status.IsOk()) << "Creating cache of size " << cache_size
+                              << " succeeded when it should fail.";
+}
+
+// Test cache size too small to initialize.
+// See following boost code for reference:
+// -
+// https://github.com/boostorg/interprocess/blob/41018201d6b7a34f38a0303a1ad591d978989cb8/include/boost/interprocess/managed_external_buffer.hpp#L75-L77
+// -
+// https://github.com/boostorg/interprocess/blob/41018201d6b7a34f38a0303a1ad591d978989cb8/include/boost/interprocess/detail/managed_memory_impl.hpp#L172-L174
+TEST_F(RequestResponseCacheTest, TestCacheSizeTooSmall)
+{
+  // Pick intentionally small cache size, expecting failure
+  constexpr uint64_t cache_size = 1;
+  std::cout << "Create cache of size: " << cache_size << std::endl;
+  std::unique_ptr<tc::RequestResponseCache> cache;
+  auto status = tc::RequestResponseCache::Create(cache_size, &cache);
+  ASSERT_FALSE(status.IsOk()) << "Creating cache of size " << cache_size
+                              << " succeeded when it should fail.";
+}
+
 // Test cache too small for entry
-TEST_F(RequestResponseCacheTest, TestCacheTooSmall)
+TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntry)
 {
   // Create cache
   constexpr uint64_t cache_size = 1024;


### PR DESCRIPTION
- [x] Add unit tests for cache init failures due to size
- [x] Return error status instead of throwing exception for failed cache initialization

Boost managed buffer has a minimum size requirement that will throw if not met. For example, allocating a cache of size 1 byte will throw:

## Response Cache
```
$ tritonserver --model-repository models --pinned-memory-pool-byte-size=1
...
terminate called after throwing an instance of 'boost::interprocess::interprocess_exception'
  what():  Could not initialize buffer in basic_managed_external_buffer constructor
Aborted (core dumped)
```

This PR catches the exceptions in `RequestResponseCache::Create()` and `PinnedMemoryManager::Create()` instead:
```
$ tritonserver --model-repository models --pinned-memory-pool-byte-size=1
...
I0803 17:12:27.730577 223 server.cc:259] No server context available. Exiting immediately.
error: creating server: Internal - Failed to initialize Response Cache: Could not initialize buffer in basic_managed_external_buffer constructor
```

## Pinned Memory Pool

```
$ tritonserver --model-repository models --pinned-memory-pool-byte-size=1
...
I0803 18:23:10.166266 292 server.cc:259] No server context available. Exiting immediately.
error: creating server: Internal - Failed to add Pinned Memory buffer: Could not initialize buffer in basic_managed_external_buffer constructor
```

