### PR TITLE
Fix Windows Compilation

### DIFF
--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1384,9 +1384,11 @@ TRITONSERVER_ServerOptionsSetModelLoadDeviceLimit(
       reinterpret_cast<TritonServerOptions*>(options);
   switch (kind) {
     case TRITONSERVER_INSTANCEGROUPKIND_GPU:
-      static std::string key_prefix = "model-load-gpu-limit-device-";
-      return loptions->AddBackendConfig(
-          "", key_prefix + std::to_string(device_id), std::to_string(fraction));
+      {
+        static std::string key_prefix = "model-load-gpu-limit-device-";
+        return loptions->AddBackendConfig(
+            "", key_prefix + std::to_string(device_id), std::to_string(fraction));
+      }
     default:
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,


### PR DESCRIPTION
This fixes the following error:
>C:\tmp\tritonbuild\tritonserver\build\_deps\repo-core-src\src\tritonserver.cc(1390,5): error C2361: initialization of 'key_prefix' is skipped by 'default' label [C:\tmp\tritonbuild\tritonserver\build\_deps\repo-core-build\triton-core\triton-core.vcxproj] [C:\tmp\tritonbuild\tritonserver\build\_deps\repo-core-build\triton-core.vcxproj]

Link to the MSDN doc for C2361: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2361?view=msvc-170