### PR TITLE
Add equal input check while merging payloads

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -323,7 +323,6 @@ DynamicBatchScheduler::BatcherThread(const int nice)
         if (payload_saturated_ || IsStaleState(payload_state)) {
           NewPayload();
           next_preferred_batch_size_ = 0;
-          required_equal_inputs_.clear();
         }
       }
 
@@ -458,9 +457,10 @@ DynamicBatchScheduler::GetDynamicBatch()
     if ((payload_batch_size + queue_.PendingBatchCount()) == 0) {
       // Get the shape of the new batch that is being started...
       if (check_input) {
-        if (!InitRequiredEqualInputs(
-                 queue_.RequestAtCursor(), enforce_equal_shape_tensors_,
-                 has_optional_input_, &required_equal_inputs_)
+        if (!curr_payload_->MutableRequiredEqualInputs()
+                 ->Initialize(
+                     queue_.RequestAtCursor(), enforce_equal_shape_tensors_,
+                     has_optional_input_)
                  .IsOk()) {
           send_now = true;
           break;
@@ -486,9 +486,9 @@ DynamicBatchScheduler::GetDynamicBatch()
 
       // There is a pending batch and it has a different shape then
       // this request, so send the pending batch as it is.
-      if (check_input && !CompareWithRequiredEqualInputs(
-                             queue_.RequestAtCursor(), has_optional_input_,
-                             required_equal_inputs_)) {
+      if (check_input &&
+          !curr_payload_->MutableRequiredEqualInputs()->HasEqualInputs(
+              queue_.RequestAtCursor())) {
         curr_payload_->MarkSaturated();
         send_now = true;
         break;

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -139,7 +139,6 @@ class DynamicBatchScheduler : public Scheduler {
   std::set<int32_t> preferred_batch_sizes_;
   uint64_t pending_batch_delay_ns_;
   size_t pending_batch_size_;
-  RequiredEqualInputs required_equal_inputs_;
 
   size_t queued_batch_size_;
   size_t next_preferred_batch_size_;

--- a/src/instance_queue.cc
+++ b/src/instance_queue.cc
@@ -82,7 +82,8 @@ InstanceQueue::Dequeue(
           payload_queue_.front()->SetState(Payload::State::EXECUTING);
           size_t front_batch_size = payload_queue_.front()->BatchSize();
           if ((batch_size + front_batch_size) <= max_batch_size_) {
-            auto status = (*payload)->MergePayload(payload_queue_.front());
+            const auto& status =
+                (*payload)->MergePayload(payload_queue_.front());
             if (status.IsOk()) {
               merged_payloads->push_back(payload_queue_.front());
               payload_queue_.pop_front();

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -37,34 +37,38 @@ Payload::Payload()
   exec_mu_.reset(new std::mutex());
 }
 
-Status
+const Status&
 Payload::MergePayload(std::shared_ptr<Payload>& payload)
 {
   if ((payload->GetOpType() != Operation::INFER_RUN) ||
       (op_type_ != Operation::INFER_RUN)) {
-    return Status(
+    static Status op_type_error(
         Status::Code::INTERNAL,
         "Attempted to merge payloads of type that are not INFER_RUN");
+    return op_type_error;
   }
   if (payload->GetInstance() != instance_) {
-    return Status(
+    static Status instance_error(
         Status::Code::INTERNAL,
         "Attempted to merge payloads of mismatching instance");
+    return instance_error;
   }
   if ((payload->GetState() != State::EXECUTING) ||
       (state_ != State::EXECUTING)) {
-    return Status(
+    static Status state_error(
         Status::Code::INTERNAL,
         "Attempted to merge payloads that are not in executing state");
+    return state_error;
   }
 
   // Skip comparison if not initialized (required), here assume either all
   // payloads are initialized or otherwise.
   if (required_equal_inputs_.Initialized() &&
       !required_equal_inputs_.HasEqualInputs(*payload->Requests().begin())) {
-    return Status(
+    static Status shape_error(
         Status::Code::INVALID_ARG,
         "Attempted to merge payloads that has non-equal inputs");
+    return shape_error;
   }
 
   requests_.insert(

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -90,6 +90,7 @@ Payload::Reset(const Operation op_type, TritonModelInstance* instance)
   instance_ = instance;
   state_ = State::UNINITIALIZED;
   status_.reset(new std::promise<Status>());
+  required_equal_inputs_ = RequiredEqualInputs();
   batcher_start_ns_ = 0;
   saturated_ = false;
 }
@@ -103,6 +104,7 @@ Payload::Release()
   release_callbacks_.clear();
   instance_ = nullptr;
   state_ = State::RELEASED;
+  required_equal_inputs_ = RequiredEqualInputs();
   batcher_start_ns_ = 0;
   saturated_ = false;
 }

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -25,7 +25,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "payload.h"
-#include "triton/common/logging.h"
 
 namespace triton { namespace core {
 
@@ -59,7 +58,10 @@ Payload::MergePayload(std::shared_ptr<Payload>& payload)
         "Attempted to merge payloads that are not in executing state");
   }
 
-  if (!required_equal_inputs_.HasEqualInputs(*payload->Requests().begin())) {
+  // Skip comparison if not initialized (required), here assume either all
+  // payloads are initialized or otherwise.
+  if (required_equal_inputs_.Initialized() &&
+      !required_equal_inputs_.HasEqualInputs(*payload->Requests().begin())) {
     return Status(
         Status::Code::INVALID_ARG,
         "Attempted to merge payloads that has non-equal inputs");

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "payload.h"
+#include "triton/common/logging.h"
 
 namespace triton { namespace core {
 
@@ -56,6 +57,12 @@ Payload::MergePayload(std::shared_ptr<Payload>& payload)
     return Status(
         Status::Code::INTERNAL,
         "Attempted to merge payloads that are not in executing state");
+  }
+
+  if (!required_equal_inputs_.HasEqualInputs(*payload->Requests().begin())) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Attempted to merge payloads that has non-equal inputs");
   }
 
   requests_.insert(

--- a/src/payload.h
+++ b/src/payload.h
@@ -34,6 +34,7 @@
 
 #include "backend_model_instance.h"
 #include "infer_request.h"
+#include "scheduler_utils.h"
 #include "status.h"
 
 namespace triton { namespace core {
@@ -72,7 +73,10 @@ class Payload {
   TritonModelInstance* GetInstance() { return instance_; }
   void MarkSaturated();
   bool IsSaturated() { return saturated_; }
-
+  RequiredEqualInputs* MutableRequiredEqualInputs()
+  {
+    return &required_equal_inputs_;
+  }
 
   State GetState() { return state_; }
   void SetState(State state);
@@ -90,6 +94,7 @@ class Payload {
   std::unique_ptr<std::promise<Status>> status_;
   std::unique_ptr<std::mutex> exec_mu_;
   uint64_t batcher_start_ns_;
+  RequiredEqualInputs required_equal_inputs_;
 
   bool saturated_;
 };

--- a/src/payload.h
+++ b/src/payload.h
@@ -53,7 +53,7 @@ class Payload {
 
   Payload();
   void Reset(const Operation op_type, TritonModelInstance* instance = nullptr);
-  Status MergePayload(std::shared_ptr<Payload>& payload);
+  const Status& MergePayload(std::shared_ptr<Payload>& payload);
   Operation GetOpType() { return op_type_; }
   std::mutex* GetExecMutex() { return exec_mu_.get(); }
   size_t RequestCount() { return requests_.size(); }

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -33,49 +33,49 @@
 namespace triton { namespace core {
 
 Status
-InitRequiredEqualInputs(
+RequiredEqualInputs::Initialize(
     const std::unique_ptr<InferenceRequest>& request,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
-    const bool has_optional_input, RequiredEqualInputs* required_equal_inputs)
+    const bool has_optional_input)
 {
-  required_equal_inputs->clear();
+  has_optional_input_ = has_optional_input;
+  required_inputs_.clear();
 
   for (const auto& pr : request->ImmutableInputs()) {
     const InferenceRequest::Input* input = pr.second;
     const auto itr = enforce_equal_shape_tensors.find(input->Name());
     if (itr != enforce_equal_shape_tensors.end()) {
-      required_equal_inputs->emplace(
+      required_inputs_.emplace(
           std::piecewise_construct, std::forward_as_tuple(input->Name()),
           std::forward_as_tuple(input, itr->second));
     }
-    // When the model has optional inputs, overload 'required_equal_inputs'
+    // When the model has optional inputs, overload 'required_inputs_'
     // to track the inputs involved in the batch
     else if (has_optional_input) {
-      required_equal_inputs->emplace(
+      required_inputs_.emplace(
           std::piecewise_construct, std::forward_as_tuple(input->Name()),
           std::forward_as_tuple(nullptr, false));
     }
   }
 
+  init_ = true;
   return Status::Success;
 }
 
 bool
-CompareWithRequiredEqualInputs(
-    const std::unique_ptr<InferenceRequest>& request,
-    const bool has_optional_input,
-    const RequiredEqualInputs& required_equal_inputs)
+RequiredEqualInputs::HasEqualInputs(
+    const std::unique_ptr<InferenceRequest>& request)
 {
   // If current request has different number of inputs, then dynamic batching
   // shouldn't be applied.
-  if (has_optional_input &&
-      (request->ImmutableInputs().size() != required_equal_inputs.size())) {
+  if (has_optional_input_ &&
+      (request->ImmutableInputs().size() != required_inputs_.size())) {
     return false;
   }
   for (const auto& pr : request->ImmutableInputs()) {
     const InferenceRequest::Input* input = pr.second;
-    const auto itr = required_equal_inputs.find(input->Name());
-    if (itr != required_equal_inputs.end()) {
+    const auto itr = required_inputs_.find(input->Name());
+    if (itr != required_inputs_.end()) {
       if (itr->second.first != nullptr) {
         // Make sure shape of input tensors is equal.
         if (!triton::common::CompareDims(
@@ -117,9 +117,9 @@ CompareWithRequiredEqualInputs(
           }
         }
       }
-    } else if (has_optional_input) {
+    } else if (has_optional_input_) {
       // If the model has optional inputs, the current request must contains all
-      // inputs that in the first request (tracked in 'required_equal_inputs').
+      // inputs that in the first request (tracked in 'required_inputs_').
       return false;
     }
   }

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -31,21 +31,27 @@
 
 namespace triton { namespace core {
 
-// A collection of inputs in the request, an nullptr for InferenceRequest::Input
-// indicates that the inputs doesn't require equality check
-using RequiredEqualInputs = std::unordered_map<
-    std::string,
-    std::pair<const InferenceRequest::Input*, bool /* compare contents */>>;
+struct RequiredEqualInputs {
+ public:
+  RequiredEqualInputs() : init_(false), has_optional_input_(false) {}
+  Status Initialize(
+      const std::unique_ptr<InferenceRequest>& request,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const bool has_optional_input);
+  bool HasEqualInputs(const std::unique_ptr<InferenceRequest>& request);
+  bool Initialized() { return init_; };
 
-Status InitRequiredEqualInputs(
-    const std::unique_ptr<InferenceRequest>& request,
-    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
-    const bool has_optional_input, RequiredEqualInputs* required_equal_inputs);
-
-bool CompareWithRequiredEqualInputs(
-    const std::unique_ptr<InferenceRequest>& request,
-    const bool has_optional_input,
-    const RequiredEqualInputs& required_equal_inputs);
+ private:
+  bool init_;
+  bool has_optional_input_;
+  // A collection of inputs in the request, an nullptr for
+  // InferenceRequest::Input indicates that the inputs doesn't require
+  // equality check
+  std::unordered_map<
+      std::string,
+      std::pair<const InferenceRequest::Input*, bool /* compare contents */>>
+      required_inputs_;
+};
 
 //
 // PriorityQueue

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -1296,7 +1296,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
             // If this is the first non-null request capture the shape
             // of the tensors that don't support ragged so we can
             // compare them to later requests.
-            if (curr_payload_->MutableRequiredEqualInputs()->Initialized() &&
+            if (!curr_payload_->MutableRequiredEqualInputs()->Initialized() &&
                 check_input) {
               Status status =
                   curr_payload_->MutableRequiredEqualInputs()->Initialize(
@@ -1376,7 +1376,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
           // ragged batch, then don't allow a request into an existing
           // batch if shape differs.
           else if (
-              !curr_payload_->MutableRequiredEqualInputs()->Initialized() &&
+              curr_payload_->MutableRequiredEqualInputs()->Initialized() &&
               check_input) {
             if (!curr_payload_->MutableRequiredEqualInputs()->HasEqualInputs(
                     queue.front())) {


### PR DESCRIPTION
Before this change, the payload merging may be performed without checking the shape consistency. This change extend the same check in batcher to the merging function for completeness.

@tanmayv25 I think this is needed to fix the root cause. That being said, I will still revisit the GetDynamicBatch() logic for better batching: we should prefer growing existing payload over creating new payload because we have limit on payloads enqueued (2 payload / instance). If 4 requests arrive, forming 2 2-request payloads has different result from 4 1-request payloads even if payload merging is performed.