### PR TITLE
Update prometheus-cpp and Metric API unit tests

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -2269,8 +2269,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_MetricFamilyNew(
 /// Delete a metric family object.
 /// A TRITONSERVER_MetricFamily* object should be deleted AFTER its
 /// corresponding TRITONSERVER_Metric* objects have been deleted.
-/// If a family is deleted before its metrics, an error will be
-/// returned on TRITONSERVER_MetricDelete.
+/// Attempting to delete a family before its metrics will return an error.
 ///
 /// \param family The metric family object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
@@ -2296,8 +2295,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_MetricNew(
 /// Delete a metric object.
 /// All TRITONSERVER_Metric* objects should be deleted BEFORE their
 /// corresponding TRITONSERVER_MetricFamily* objects have been deleted.
-/// If a family is deleted before its metrics, an error will be
-/// returned on TRITONSERVER_MetricDelete.
+/// If a family is deleted before its metrics, an error will be returned.
 ///
 /// \param metric The metric object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -2267,6 +2267,10 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_MetricFamilyNew(
     const char* name, const char* description);
 
 /// Delete a metric family object.
+/// A TRITONSERVER_MetricFamily* object should be deleted AFTER its
+/// corresponding TRITONSERVER_Metric* objects have been deleted.
+/// If a family is deleted before its metrics, an error will be
+/// returned on TRITONSERVER_MetricDelete.
 ///
 /// \param family The metric family object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
@@ -2275,7 +2279,10 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_MetricFamilyDelete(
 
 /// Create a new metric object. The caller takes ownership of the
 /// TRITONSERVER_Metric object and must call
-/// TRITONSERVER_MetricDelete to release the object.
+/// TRITONSERVER_MetricDelete to release the object. The caller is also
+/// responsible for ownership of the labels passed in. Each label can be deleted
+/// immediately after creating the metric with TRITONSERVER_ParameterDelete
+/// if not re-using the labels.
 ///
 /// \param metric Returns the new metric object.
 /// \param family The metric family to add this new metric to.
@@ -2287,6 +2294,10 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_MetricNew(
     const TRITONSERVER_Parameter** labels, const uint64_t label_count);
 
 /// Delete a metric object.
+/// All TRITONSERVER_Metric* objects should be deleted BEFORE their
+/// corresponding TRITONSERVER_MetricFamily* objects have been deleted.
+/// If a family is deleted before its metrics, an error will be
+/// returned on TRITONSERVER_MetricDelete.
 ///
 /// \param metric The metric object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -154,6 +154,11 @@ MetricFamily::InvalidateReferences()
 
 MetricFamily::~MetricFamily()
 {
+  if (HasMetrics()) {
+    LOG_WARNING << "MetricFamily was deleted before its child Metrics, this "
+                   "should not happen. Make sure to delete all child Metrics "
+                   "before deleting their MetricFamily.";
+  }
   InvalidateReferences();
   // DLIS-4072: Support for removing metric families from registry
 }

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -94,8 +94,11 @@ MetricFamily::Add(std::map<std::string, std::string> label_map, Metric* metric)
 void
 MetricFamily::Remove(void* prom_metric, Metric* metric)
 {
-  // Remove reference to dependent Metric object
-  child_metrics_.erase(metric);
+  {
+    // Remove reference to dependent Metric object
+    std::lock_guard<std::mutex> lk(metric_mtx_);
+    child_metrics_.erase(metric);
+  }
 
   if (prom_metric == nullptr) {
     return;

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -116,6 +116,7 @@ MetricFamily::Remove(void* metric)
       }
     }
   }
+
   switch (kind_) {
     case TRITONSERVER_METRIC_KIND_COUNTER: {
       auto counter_family_ptr =

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -154,7 +154,7 @@ MetricFamily::InvalidateReferences()
 
 MetricFamily::~MetricFamily()
 {
-  if (HasMetrics()) {
+  if (NumMetrics() > 0) {
     LOG_WARNING << "MetricFamily was deleted before its child Metrics, this "
                    "should not happen. Make sure to delete all child Metrics "
                    "before deleting their MetricFamily.";

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -52,7 +52,12 @@ class MetricFamily {
 
   void* Add(std::map<std::string, std::string> label_map, Metric* metric);
   void Remove(void* prom_metric, Metric* metric);
-  bool HasMetrics() { return !child_metrics_.empty(); }
+
+  int NumMetrics()
+  {
+    std::lock_guard<std::mutex> lk(metric_mtx_);
+    return child_metrics_.size();
+  }
 
  private:
   // If a MetricFamily is deleted before its dependent Metric, we want to

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -50,11 +50,14 @@ class MetricFamily {
 
   void* Add(std::map<std::string, std::string> label_map);
   void Remove(void* metric);
+  // Decrements the reference count of the MetricFamily.
+  // Removes the family from the registry when the reference count hits zero.
+  void Unregister();
 
  private:
   void* family_;
   std::mutex mtx_;
-  // prometheus returns the existing metric pointer if the metric with the same
+  // Prometheus returns the existing metric pointer if the metric with the same
   // set of labels are requested, as a result, different Metric objects may
   // refer to the same prometheus metric. So we must track the reference count
   // of the metric and request prometheus to remove it only when all references

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -28,6 +28,7 @@
 #ifdef TRITON_ENABLE_METRICS
 
 #include <mutex>
+#include <set>
 #include <unordered_map>
 
 #include "infer_parameter.h"
@@ -39,6 +40,7 @@ namespace triton { namespace core {
 //
 // Implementation for TRITONSERVER_MetricFamily.
 //
+class Metric;
 class MetricFamily {
  public:
   MetricFamily(
@@ -48,22 +50,28 @@ class MetricFamily {
   void* Family() const { return family_; }
   TRITONSERVER_MetricKind Kind() const { return kind_; }
 
-  void* Add(std::map<std::string, std::string> label_map);
-  void Remove(void* metric);
+  void* Add(std::map<std::string, std::string> label_map, Metric* metric);
+  void Remove(void* prom_metric, Metric* metric);
   // Decrements the reference count of the MetricFamily.
   // Removes the family from the registry when the reference count hits zero.
   void Unregister();
 
  private:
+  // If a MetricFamily is deleted before its dependent Metric, we want to
+  // invalidate the reference so we don't access invalid memory.
+  void InvalidateReferences();
+
   void* family_;
-  std::mutex mtx_;
+  TRITONSERVER_MetricKind kind_;
+  // Synchronize access of related metric objects
+  std::mutex metric_mtx_;
   // Prometheus returns the existing metric pointer if the metric with the same
   // set of labels are requested, as a result, different Metric objects may
   // refer to the same prometheus metric. So we must track the reference count
   // of the metric and request prometheus to remove it only when all references
   // are released.
-  std::unordered_map<void*, size_t> metric_ref_cnt_;
-  TRITONSERVER_MetricKind kind_;
+  std::unordered_map<void*, size_t> prom_metric_ref_cnt_;
+  std::set<Metric*> child_metrics_;
 };
 
 //
@@ -82,6 +90,10 @@ class Metric {
   TRITONSERVER_Error* Value(double* value);
   TRITONSERVER_Error* Increment(double value);
   TRITONSERVER_Error* Set(double value);
+
+  // If a MetricFamily is deleted before its dependent Metric, we want to
+  // invalidate the reference so we don't access invalid memory.
+  void InvalidateFamily();
 
  private:
   void* metric_;

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -52,6 +52,7 @@ class MetricFamily {
 
   void* Add(std::map<std::string, std::string> label_map, Metric* metric);
   void Remove(void* prom_metric, Metric* metric);
+  bool HasMetrics() { return !child_metrics_.empty(); }
 
  private:
   // If a MetricFamily is deleted before its dependent Metric, we want to

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -91,8 +91,8 @@ class Metric {
   TRITONSERVER_Error* Set(double value);
 
   // If a MetricFamily is deleted before its dependent Metric, we want to
-  // invalidate the reference so we don't access invalid memory.
-  void InvalidateFamily();
+  // invalidate the references so we don't access invalid memory.
+  void Invalidate();
 
  private:
   void* metric_;

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -52,9 +52,6 @@ class MetricFamily {
 
   void* Add(std::map<std::string, std::string> label_map, Metric* metric);
   void Remove(void* prom_metric, Metric* metric);
-  // Decrements the reference count of the MetricFamily.
-  // Removes the family from the registry when the reference count hits zero.
-  void Unregister();
 
  private:
   // If a MetricFamily is deleted before its dependent Metric, we want to
@@ -71,6 +68,8 @@ class MetricFamily {
   // of the metric and request prometheus to remove it only when all references
   // are released.
   std::unordered_map<void*, size_t> prom_metric_ref_cnt_;
+  // Maintain references to metrics created from this metric family to
+  // invalidate their references if a family is deleted before its metric
   std::set<Metric*> child_metrics_;
 };
 

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -198,10 +198,12 @@ Metrics::Metrics()
 {
 }
 
+static prometheus::detail::LabelHasher label_hasher_;
+
 size_t
 Metrics::HashLabels(const std::map<std::string, std::string>& labels)
 {
-  return prometheus::detail::hash_labels(labels);
+  return label_hasher_(labels);
 }
 
 Metrics::~Metrics()

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -31,6 +31,8 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include "prometheus/counter.h"
+#include "prometheus/gauge.h"
 #include "prometheus/registry.h"
 #include "prometheus/serializer.h"
 #include "prometheus/text_serializer.h"

--- a/src/response_cache.h
+++ b/src/response_cache.h
@@ -32,6 +32,7 @@
 
 #include "infer_request.h"
 #include "infer_response.h"
+#include "model.h"
 #include "status.h"
 
 #include <boost/functional/hash.hpp>

--- a/src/response_cache.h
+++ b/src/response_cache.h
@@ -32,7 +32,6 @@
 
 #include "infer_request.h"
 #include "infer_response.h"
-#include "model.h"
 #include "status.h"
 
 #include <boost/functional/hash.hpp>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -434,6 +434,12 @@ if(${TRITON_ENABLE_METRICS})
   add_executable(
     metrics_api_test
     metrics_api_test.cc
+    ../metric_family.cc
+    ../metric_family.h
+    ../metrics.cc
+    ../metrics.h
+    ../infer_parameter.cc
+    ../infer_parameter.h
   )
 
   set_target_properties(
@@ -465,6 +471,7 @@ if(${TRITON_ENABLE_METRICS})
     PRIVATE
       triton-common-error   # from repo-common
       triton-common-logging # from repo-common
+      proto-library         # from repo-common
       triton-core
       GTest::gtest
       GTest::gtest_main

--- a/src/test/metrics_api_test.cc
+++ b/src/test/metrics_api_test.cc
@@ -153,25 +153,8 @@ DupeMetricHelper(
   // Assert custom metric/family remains when there's still a reference to it
   AssertNumMetricMatches(server, description, 1);
 
-  // TODO
-  std::cout << "==START=============================================="
-            << std::endl;
-  std::string metrics_str;
-  GetMetrics(server, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  std::cout << "==END=============================================="
-            << std::endl;
-
   // Delete the last metric reference
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric2), "delete metric2");
-
-  // TODO
-  std::cout << "==START=============================================="
-            << std::endl;
-  GetMetrics(server, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  std::cout << "==END=============================================="
-            << std::endl;
 
   // Assert custom metric/family unregistered after last reference deleted
   AssertNumMetricMatches(server, description, 0);
@@ -300,8 +283,6 @@ TEST_F(MetricsApiTest, TestCounterEndToEnd)
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
-  // TODO: Check metric?
-  AssertNumMetricMatches(server_, description, 1);
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyDelete(family), "delete metric family");
 
@@ -379,8 +360,6 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
-  // TODO: Check metric?
-  AssertNumMetricMatches(server_, description, 1);
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyDelete(family), "delete metric family");
 

--- a/src/test/metrics_api_test.cc
+++ b/src/test/metrics_api_test.cc
@@ -76,13 +76,26 @@ CountMatches(const std::string s, const std::string substr)
   return num_matches;
 }
 
+void
+AssertNumMetricMatches(
+    TRITONSERVER_Server* server, const std::string substr,
+    const int expected_matches)
+{
+  std::string metrics_str;
+  GetMetrics(server, &metrics_str);
+  const int num_matches = CountMatches(metrics_str, substr);
+  ASSERT_EQ(num_matches, expected_matches);
+}
+
 // Add two metrics with the same labels from the same metric family
 // and verify they refer to the same metric/value
 void
-DupeMetricHelper(std::vector<const TRITONSERVER_Parameter*> labels)
+DupeMetricHelper(
+    TRITONSERVER_Server* server,
+    std::vector<const TRITONSERVER_Parameter*> labels)
 {
   // Create metric family
-  TRITONSERVER_MetricFamily* family;
+  TRITONSERVER_MetricFamily* family = nullptr;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
   const char* name = "dupe_metric_test";
   const char* description = "dupe metric description";
@@ -91,19 +104,16 @@ DupeMetricHelper(std::vector<const TRITONSERVER_Parameter*> labels)
       "Creating new metric family1");
 
   // Create metric
-  TRITONSERVER_Metric* metric1;
+  TRITONSERVER_Metric* metric1 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric1, family, labels.data(), labels.size()),
       "Creating new metric");
 
   // Create duplicate metric
-  TRITONSERVER_Metric* metric2;
+  TRITONSERVER_Metric* metric2 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric2, family, labels.data(), labels.size()),
       "Creating new metric");
-
-  // Verify dupe metrics are different pointers
-  ASSERT_NE(metric1, metric2);
 
   // Verify dupe metrics reference same underlying metric
   double value1 = -1;
@@ -136,7 +146,43 @@ DupeMetricHelper(std::vector<const TRITONSERVER_Parameter*> labels)
   ASSERT_EQ(value1, value2);
   std::cout << "metric1 value: " << value1 << " == metric2 value: " << value2
             << std::endl;
+
+  // Delete one of the metric references
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric1), "delete metric1");
+
+  // Assert custom metric/family remains when there's still a reference to it
+  AssertNumMetricMatches(server, description, 1);
+
+  // TODO
+  std::cout << "==START=============================================="
+            << std::endl;
+  std::string metrics_str;
+  GetMetrics(server, &metrics_str);
+  std::cout << metrics_str << std::endl;
+  std::cout << "==END=============================================="
+            << std::endl;
+
+  // Delete the last metric reference
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric2), "delete metric2");
+
+  // TODO
+  std::cout << "==START=============================================="
+            << std::endl;
+  GetMetrics(server, &metrics_str);
+  std::cout << metrics_str << std::endl;
+  std::cout << "==END=============================================="
+            << std::endl;
+
+  // Assert custom metric/family unregistered after last reference deleted
+  AssertNumMetricMatches(server, description, 0);
+
+  // Delete the last metric family reference
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family), "delete family");
+
+  // Assert custom metric/family unregistered after last reference deleted
+  AssertNumMetricMatches(server, description, 0);
 }
+
 
 // Test Fixture
 class MetricsApiTest : public ::testing::Test {
@@ -250,16 +296,17 @@ TEST_F(MetricsApiTest, TestCounterEndToEnd)
   ASSERT_EQ(kind_tmp, kind);
 
   // Assert custom metric is reported and found in output
-  std::string metrics_str;
-  GetMetrics(server_, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  const int num_matches = CountMatches(metrics_str, description);
-  ASSERT_EQ(num_matches, 1);
+  AssertNumMetricMatches(server_, description, 1);
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
+  // TODO: Check metric?
+  AssertNumMetricMatches(server_, description, 1);
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyDelete(family), "delete metric family");
+
+  // Assert custom metric/family is unregistered and no longer in output
+  AssertNumMetricMatches(server_, description, 0);
 }
 
 // Test end-to-end flow of Generic Metrics API for Gauge metric
@@ -328,15 +375,17 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
   ASSERT_EQ(kind_tmp, kind);
 
   // Assert custom metric is reported and found in output
-  std::string metrics_str;
-  GetMetrics(server_, &metrics_str);
-  const int num_matches = CountMatches(metrics_str, description);
-  ASSERT_EQ(num_matches, 1);
+  AssertNumMetricMatches(server_, description, 1);
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
+  // TODO: Check metric?
+  AssertNumMetricMatches(server_, description, 1);
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyDelete(family), "delete metric family");
+
+  // Assert custom metric/family is unregistered and no longer in output
+  AssertNumMetricMatches(server_, description, 0);
 }
 
 // Test that a duplicate metric family can't be added
@@ -344,7 +393,7 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
 TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffKind)
 {
   // Create metric family
-  TRITONSERVER_MetricFamily* family1;
+  TRITONSERVER_MetricFamily* family1 = nullptr;
   TRITONSERVER_MetricKind kind1 = TRITONSERVER_METRIC_KIND_COUNTER;
   const char* name = "diff_kind_test";
   const char* description = "diff kind description";
@@ -353,11 +402,12 @@ TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffKind)
       "Creating new metric family1");
 
   // Create duplicate metric family with different kind
-  TRITONSERVER_MetricFamily* family2;
+  TRITONSERVER_MetricFamily* family2 = nullptr;
   TRITONSERVER_MetricKind kind2 = TRITONSERVER_METRIC_KIND_GAUGE;
   // Expect this to fail, can't have duplicate name of different kind
   auto err = TRITONSERVER_MetricFamilyNew(&family2, kind2, name, description);
   ASSERT_NE(err, nullptr);
+  ASSERT_EQ(family2, nullptr);
 }
 
 // Test that a duplicate metric family name will still
@@ -366,7 +416,7 @@ TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffKind)
 TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffDescription)
 {
   // Create metric family
-  TRITONSERVER_MetricFamily* family1;
+  TRITONSERVER_MetricFamily* family1 = nullptr;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
   const char* name = "diff_description_test";
   const char* description1 = "first description";
@@ -375,43 +425,47 @@ TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffDescription)
       "Creating new metric family1");
 
   // Create duplicate metric family
-  TRITONSERVER_MetricFamily* family2;
+  TRITONSERVER_MetricFamily* family2 = nullptr;
   const char* description2 = "second description";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family2, kind, name, description2),
       "Creating new metric family2");
 
   // Assert MetricFamily is not reported until metrics are added to them
-  std::string metrics_str;
-  GetMetrics(server_, &metrics_str);
-  int num_matches1 = CountMatches(metrics_str, description1);
-  int num_matches2 = CountMatches(metrics_str, description2);
-  ASSERT_EQ(num_matches1, 0);
-  ASSERT_EQ(num_matches2, 0);
+  AssertNumMetricMatches(server_, description1, 0);
+  AssertNumMetricMatches(server_, description2, 0);
 
   // Add metric to family1
   std::vector<const TRITONSERVER_Parameter*> labels;
-  TRITONSERVER_Metric* metric1;
+  TRITONSERVER_Metric* metric1 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric1, family1, labels.data(), labels.size()),
       "Creating new metric1");
 
   // Add metric for family2
-  TRITONSERVER_Metric* metric2;
+  TRITONSERVER_Metric* metric2 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric2, family2, labels.data(), labels.size()),
       "Creating new metric2");
 
   // Assert MetricFamily is reported exactly once
   // This confirms attempting to add a duplicate returns the existing family
-  GetMetrics(server_, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  num_matches1 = CountMatches(metrics_str, description1);
-  num_matches2 = CountMatches(metrics_str, description2);
+  AssertNumMetricMatches(server_, description1, 1);
   // The first description will be taken/kept if adding a duplicate
   /// metric family name, even with a different description
-  ASSERT_EQ(num_matches1, 1);
-  ASSERT_EQ(num_matches2, 0);
+  AssertNumMetricMatches(server_, description2, 0);
+
+  // Delete one of the metric family references
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family1), "delete family1");
+
+  // Assert custom metric/family remains when there's still a reference to it
+  AssertNumMetricMatches(server_, description1, 1);
+
+  // Delete the last metric reference
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family2), "delete family2");
+
+  // Assert custom metric/family unregistered after last reference deleted
+  AssertNumMetricMatches(server_, description1, 0);
 }
 
 // Test that adding a duplicate metric family will reuse the original
@@ -419,7 +473,7 @@ TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffDescription)
 TEST_F(MetricsApiTest, TestDupeMetricFamily)
 {
   // Create metric family
-  TRITONSERVER_MetricFamily* family1;
+  TRITONSERVER_MetricFamily* family1 = nullptr;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
   const char* name = "dupe_metric_family_test";
   const char* description = "dupe metric family description";
@@ -428,37 +482,42 @@ TEST_F(MetricsApiTest, TestDupeMetricFamily)
       "Creating new metric family1");
 
   // Create duplicate metric family
-  TRITONSERVER_MetricFamily* family2;
+  TRITONSERVER_MetricFamily* family2 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family2, kind, name, description),
       "Creating new metric family2");
 
   // Assert MetricFamily is not reported until metrics are added to them
-  std::string metrics_str;
-  GetMetrics(server_, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  int num_matches = CountMatches(metrics_str, description);
-  ASSERT_EQ(num_matches, 0);
+  AssertNumMetricMatches(server_, description, 0);
 
   // Add metric to family1
   std::vector<const TRITONSERVER_Parameter*> labels;
-  TRITONSERVER_Metric* metric1;
+  TRITONSERVER_Metric* metric1 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric1, family1, labels.data(), labels.size()),
       "Creating new metric1");
 
   // Add metric for family2
-  TRITONSERVER_Metric* metric2;
+  TRITONSERVER_Metric* metric2 = nullptr;
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricNew(&metric2, family2, labels.data(), labels.size()),
       "Creating new metric2");
 
   // Assert MetricFamily is reported exactly once
   // This confirms attempting to add a duplicate returns the existing family
-  GetMetrics(server_, &metrics_str);
-  std::cout << metrics_str << std::endl;
-  num_matches = CountMatches(metrics_str, description);
-  ASSERT_EQ(num_matches, 1);
+  AssertNumMetricMatches(server_, description, 1);
+
+  // Delete one of the metric family references
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family1), "delete family1");
+
+  // Assert custom metric/family remains when there's still a reference to it
+  AssertNumMetricMatches(server_, description, 1);
+
+  // Delete the last metric reference
+  FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family2), "delete family2");
+
+  // Assert custom metric/family unregistered after last reference deleted
+  AssertNumMetricMatches(server_, description, 0);
 }
 
 // Test that adding a duplicate metric will refer to the same
@@ -471,7 +530,7 @@ TEST_F(MetricsApiTest, TestDupeMetricLabels)
   labels.emplace_back(TRITONSERVER_ParameterNew(
       "example2", TRITONSERVER_PARAMETER_STRING, "label2"));
 
-  DupeMetricHelper(labels);
+  DupeMetricHelper(server_, labels);
 
   // Cleanup
   for (const auto label : labels) {
@@ -484,7 +543,7 @@ TEST_F(MetricsApiTest, TestDupeMetricLabels)
 TEST_F(MetricsApiTest, TestDupeMetricEmptyLabels)
 {
   std::vector<const TRITONSERVER_Parameter*> labels;
-  DupeMetricHelper(labels);
+  DupeMetricHelper(server_, labels);
 }
 
 }  // namespace

--- a/src/test/metrics_api_test.cc
+++ b/src/test/metrics_api_test.cc
@@ -43,8 +43,12 @@ namespace {
         << TRITONSERVER_ErrorMessage(err__.get());                            \
   } while (false)
 
-// Helpers
-void PrintMetrics(TRITONSERVER_Server* server, std::string substr) {
+/* Helpers */
+
+// Get serialized metrics string from C API
+void
+GetMetrics(TRITONSERVER_Server* server, std::string* metrics_str)
+{
   // Check metrics via C API
   ASSERT_NE(server, nullptr);
   TRITONSERVER_Metrics* metrics = nullptr;
@@ -56,17 +60,82 @@ void PrintMetrics(TRITONSERVER_Server* server, std::string substr) {
       TRITONSERVER_MetricsFormatted(
           metrics, TRITONSERVER_METRIC_PROMETHEUS, &base, &byte_size),
       "format metrics string");
-  auto metrics_str = std::string(base, byte_size);
+  *metrics_str = std::string(base, byte_size);
+}
 
-  // Only print substr if provided and found in output
-  if (!substr.empty()) {
-      auto found = metrics_str.find(std::string(substr));
-      ASSERT_NE(found, std::string::npos);
-      std::cout << "======" << std::endl;
-      std::cout << metrics_str.substr(found, std::string::npos) << std::endl;
-  } else {
-      std::cout << metrics_str << std::endl;
+// Count number of times substr appears in s
+int
+CountMatches(const std::string s, const std::string substr)
+{
+  int num_matches = 0;
+  std::string::size_type pos = 0;
+  while ((pos = s.find(substr, pos)) != std::string::npos) {
+    num_matches++;
+    pos += substr.length();
   }
+  return num_matches;
+}
+
+// Add two metrics with the same labels from the same metric family
+// and verify they refer to the same metric/value
+void
+DupeMetricHelper(std::vector<const TRITONSERVER_Parameter*> labels)
+{
+  // Create metric family
+  TRITONSERVER_MetricFamily* family;
+  TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
+  const char* name = "dupe_metric_test";
+  const char* description = "dupe metric description";
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricFamilyNew(&family, kind, name, description),
+      "Creating new metric family1");
+
+  // Create metric
+  TRITONSERVER_Metric* metric1;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricNew(&metric1, family, labels.data(), labels.size()),
+      "Creating new metric");
+
+  // Create duplicate metric
+  TRITONSERVER_Metric* metric2;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricNew(&metric2, family, labels.data(), labels.size()),
+      "Creating new metric");
+
+  // Verify dupe metrics are different pointers
+  ASSERT_NE(metric1, metric2);
+
+  // Verify dupe metrics reference same underlying metric
+  double value1 = -1;
+  double value2 = -1;
+  double inc = 7.5;
+
+  // Verify initial values of zero
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricValue(metric1, &value1),
+      "query metric value after increment");
+  ASSERT_EQ(value1, 0);
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricValue(metric2, &value2),
+      "query metric value after increment");
+  ASSERT_EQ(value2, 0);
+
+  // Increment metric 1, check metric 2 == metric 1
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricIncrement(metric1, inc), "increase metric value");
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricValue(metric1, &value1),
+      "query metric value after increment");
+  // Verify increment worked
+  ASSERT_EQ(value1, inc);
+
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricValue(metric2, &value2),
+      "query metric value after increment");
+  // Verify metric values are equal
+  ASSERT_EQ(value1, value2);
+  std::cout << "metric1 value: " << value1 << " == metric2 value: " << value2
+            << std::endl;
 }
 
 // Test Fixture
@@ -107,8 +176,6 @@ class MetricsApiTest : public ::testing::Test {
         "deleting server options");
   }
 
-  // TODO: See if prometheus registry is actually getting cleared or not across
-  // server deletions.
   // Run after each test
   void TearDown() override
   {
@@ -131,7 +198,7 @@ TEST_F(MetricsApiTest, TestCounterEndToEnd)
   // Create metric family
   TRITONSERVER_MetricFamily* family;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
-  const char* name = "api_counter_example";
+  const char* name = "custom_counter_example";
   const char* description = "this is an example counter metric added via API.";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family, kind, name, description),
@@ -182,25 +249,12 @@ TEST_F(MetricsApiTest, TestCounterEndToEnd)
       TRITONSERVER_GetMetricKind(metric, &kind_tmp), "query metric kind");
   ASSERT_EQ(kind_tmp, kind);
 
-  // Check metrics via C API
-  ASSERT_NE(server_, nullptr);
-  TRITONSERVER_Metrics* metrics = nullptr;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerMetrics(server_, &metrics), "fetch metrics");
-  const char* base;
-  size_t byte_size;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricsFormatted(
-          metrics, TRITONSERVER_METRIC_PROMETHEUS, &base, &byte_size),
-      "format metrics string");
-  auto metrics_str = std::string(base, byte_size);
-
   // Assert custom metric is reported and found in output
-  auto found = metrics_str.find(std::string("# HELP ") + name);
+  std::string metrics_str;
+  GetMetrics(server_, &metrics_str);
   std::cout << metrics_str << std::endl;
-  ASSERT_NE(found, std::string::npos);
-  std::cout << "======" << std::endl;
-  std::cout << metrics_str.substr(found, std::string::npos) << std::endl;
+  const int num_matches = CountMatches(metrics_str, description);
+  ASSERT_EQ(num_matches, 1);
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
@@ -214,7 +268,7 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
   // Create metric family
   TRITONSERVER_MetricFamily* family;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_GAUGE;
-  const char* name = "api_gauge_example";
+  const char* name = "custom_gauge_example";
   const char* description = "this is an example gauge metric added via API.";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family, kind, name, description),
@@ -273,25 +327,11 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
       TRITONSERVER_GetMetricKind(metric, &kind_tmp), "query metric kind");
   ASSERT_EQ(kind_tmp, kind);
 
-  // Check metrics via C API
-  ASSERT_NE(server_, nullptr);
-  TRITONSERVER_Metrics* metrics = nullptr;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_ServerMetrics(server_, &metrics), "fetch metrics");
-  const char* base;
-  size_t byte_size;
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricsFormatted(
-          metrics, TRITONSERVER_METRIC_PROMETHEUS, &base, &byte_size),
-      "format metrics string");
-  auto metrics_str = std::string(base, byte_size);
-
   // Assert custom metric is reported and found in output
-  auto found = metrics_str.find(std::string("# HELP ") + name);
-  std::cout << metrics_str << std::endl;
-  ASSERT_NE(found, std::string::npos);
-  std::cout << "======" << std::endl;
-  std::cout << metrics_str.substr(found, std::string::npos) << std::endl;
+  std::string metrics_str;
+  GetMetrics(server_, &metrics_str);
+  const int num_matches = CountMatches(metrics_str, description);
+  ASSERT_EQ(num_matches, 1);
 
   // Cleanup
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric), "delete metric");
@@ -299,67 +339,90 @@ TEST_F(MetricsApiTest, TestGaugeEndToEnd)
       TRITONSERVER_MetricFamilyDelete(family), "delete metric family");
 }
 
-// Test duplicate metric family names with different descriptions
+// Test that a duplicate metric family can't be added
+// with a conflicting type/kind
+TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffKind)
+{
+  // Create metric family
+  TRITONSERVER_MetricFamily* family1;
+  TRITONSERVER_MetricKind kind1 = TRITONSERVER_METRIC_KIND_COUNTER;
+  const char* name = "diff_kind_test";
+  const char* description = "diff kind description";
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricFamilyNew(&family1, kind1, name, description),
+      "Creating new metric family1");
+
+  // Create duplicate metric family with different kind
+  TRITONSERVER_MetricFamily* family2;
+  TRITONSERVER_MetricKind kind2 = TRITONSERVER_METRIC_KIND_GAUGE;
+  // Expect this to fail, can't have duplicate name of different kind
+  auto err = TRITONSERVER_MetricFamilyNew(&family2, kind2, name, description);
+  ASSERT_NE(err, nullptr);
+}
+
+// Test that a duplicate metric family name will still
+// return the original metric family even if the description
+// is changed
 TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffDescription)
 {
   // Create metric family
   TRITONSERVER_MetricFamily* family1;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
-  const char* name = "api_counter_example";
-  const char* description1 = "this is an example counter metric added via API.";
+  const char* name = "diff_description_test";
+  const char* description1 = "first description";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family1, kind, name, description1),
       "Creating new metric family1");
 
   // Create duplicate metric family
   TRITONSERVER_MetricFamily* family2;
-  const char* description2 = "this is a different description.";
+  const char* description2 = "second description";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family2, kind, name, description2),
       "Creating new metric family2");
 
-  std::cout << "family1 address: 0x" << family1 << std::endl;
-  std::cout << "family2 address: 0x" << family2 << std::endl;
-  // TODO
-  ASSERT_NE(family1, family2);
-  PrintMetrics(server_, "");
+  // Assert MetricFamily is not reported until metrics are added to them
+  std::string metrics_str;
+  GetMetrics(server_, &metrics_str);
+  int num_matches1 = CountMatches(metrics_str, description1);
+  int num_matches2 = CountMatches(metrics_str, description2);
+  ASSERT_EQ(num_matches1, 0);
+  ASSERT_EQ(num_matches2, 0);
+
+  // Add metric to family1
+  std::vector<const TRITONSERVER_Parameter*> labels;
+  TRITONSERVER_Metric* metric1;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricNew(&metric1, family1, labels.data(), labels.size()),
+      "Creating new metric1");
+
+  // Add metric for family2
+  TRITONSERVER_Metric* metric2;
+  FAIL_TEST_IF_ERR(
+      TRITONSERVER_MetricNew(&metric2, family2, labels.data(), labels.size()),
+      "Creating new metric2");
+
+  // Assert MetricFamily is reported exactly once
+  // This confirms attempting to add a duplicate returns the existing family
+  GetMetrics(server_, &metrics_str);
+  std::cout << metrics_str << std::endl;
+  num_matches1 = CountMatches(metrics_str, description1);
+  num_matches2 = CountMatches(metrics_str, description2);
+  // The first description will be taken/kept if adding a duplicate
+  /// metric family name, even with a different description
+  ASSERT_EQ(num_matches1, 1);
+  ASSERT_EQ(num_matches2, 0);
 }
 
-// Test duplicate metric family names with different descriptions
-TEST_F(MetricsApiTest, TestDupeMetricFamilyDiffKind)
-{
-  // Create metric family
-  TRITONSERVER_MetricFamily* family1;
-  TRITONSERVER_MetricKind kind1 = TRITONSERVER_METRIC_KIND_COUNTER;
-  const char* name = "api_example";
-  const char* description = "this is an example counter metric added via API.";
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricFamilyNew(&family1, kind1, name, description),
-      "Creating new metric family1");
-
-  // Create duplicate metric family
-  TRITONSERVER_MetricFamily* family2;
-  TRITONSERVER_MetricKind kind2 = TRITONSERVER_METRIC_KIND_GAUGE;
-  // TODO: THIS SHOULD FAIL
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricFamilyNew(&family2, kind2, name, description),
-      "Creating new metric family2");
-
-  std::cout << "family1 address: 0x" << family1 << std::endl;
-  std::cout << "family2 address: 0x" << family2 << std::endl;
-  // TODO
-  ASSERT_NE(family1, family2);
-  PrintMetrics(server_, "");
-}
-
-// Test duplicate metric family objects
+// Test that adding a duplicate metric family will reuse the original
+// and not add another entry to registry
 TEST_F(MetricsApiTest, TestDupeMetricFamily)
 {
   // Create metric family
   TRITONSERVER_MetricFamily* family1;
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
-  const char* name = "api_counter_example";
-  const char* description = "this is an example counter metric added via API.";
+  const char* name = "dupe_metric_family_test";
+  const char* description = "dupe metric family description";
   FAIL_TEST_IF_ERR(
       TRITONSERVER_MetricFamilyNew(&family1, kind, name, description),
       "Creating new metric family1");
@@ -370,90 +433,58 @@ TEST_F(MetricsApiTest, TestDupeMetricFamily)
       TRITONSERVER_MetricFamilyNew(&family2, kind, name, description),
       "Creating new metric family2");
 
-  std::cout << "family1 address: 0x" << family1 << std::endl;
-  std::cout << "family2 address: 0x" << family2 << std::endl;
-  // TODO
-  ASSERT_NE(family1, family2);
-  PrintMetrics(server_, "");
-}
+  // Assert MetricFamily is not reported until metrics are added to them
+  std::string metrics_str;
+  GetMetrics(server_, &metrics_str);
+  std::cout << metrics_str << std::endl;
+  int num_matches = CountMatches(metrics_str, description);
+  ASSERT_EQ(num_matches, 0);
 
-// Test duplicate metric objects
-TEST_F(MetricsApiTest, TestDupeMetricLabels)
-{
-  // Create metric family
-  TRITONSERVER_MetricFamily* family;
-  TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
-  const char* name = "api_counter_example";
-  const char* description = "this is an example counter metric added via API.";
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricFamilyNew(&family, kind, name, description),
-      "Creating new metric family1");
-
-  // Create metric
-  TRITONSERVER_Metric* metric1;
+  // Add metric to family1
   std::vector<const TRITONSERVER_Parameter*> labels;
-  labels.emplace_back(TRITONSERVER_ParameterNew(
-      "example1", TRITONSERVER_PARAMETER_STRING, "counter_label1"));
-  labels.emplace_back(TRITONSERVER_ParameterNew(
-      "example2", TRITONSERVER_PARAMETER_STRING, "counter_label2"));
+  TRITONSERVER_Metric* metric1;
   FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricNew(&metric1, family, labels.data(), labels.size()),
-      "Creating new metric");
+      TRITONSERVER_MetricNew(&metric1, family1, labels.data(), labels.size()),
+      "Creating new metric1");
 
-  // Create duplicate metric
+  // Add metric for family2
   TRITONSERVER_Metric* metric2;
   FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricNew(&metric2, family, labels.data(), labels.size()),
-      "Creating new metric");
+      TRITONSERVER_MetricNew(&metric2, family2, labels.data(), labels.size()),
+      "Creating new metric2");
+
+  // Assert MetricFamily is reported exactly once
+  // This confirms attempting to add a duplicate returns the existing family
+  GetMetrics(server_, &metrics_str);
+  std::cout << metrics_str << std::endl;
+  num_matches = CountMatches(metrics_str, description);
+  ASSERT_EQ(num_matches, 1);
+}
+
+// Test that adding a duplicate metric will refer to the same
+// underlying metric, and all instances will be updated
+TEST_F(MetricsApiTest, TestDupeMetricLabels)
+{
+  std::vector<const TRITONSERVER_Parameter*> labels;
+  labels.emplace_back(TRITONSERVER_ParameterNew(
+      "example1", TRITONSERVER_PARAMETER_STRING, "label1"));
+  labels.emplace_back(TRITONSERVER_ParameterNew(
+      "example2", TRITONSERVER_PARAMETER_STRING, "label2"));
+
+  DupeMetricHelper(labels);
 
   // Cleanup
   for (const auto label : labels) {
     TRITONSERVER_ParameterDelete(const_cast<TRITONSERVER_Parameter*>(label));
   }
-
-  std::cout << "metric1 address: 0x" << metric1 << std::endl;
-  std::cout << "metric2 address: 0x" << metric2 << std::endl;
-  // Verify dupe metrics are different pointers
-  ASSERT_NE(metric1, metric2);
-
-  // Verify dupe metrics reference same underlying metric
-  double value1 = -1;
-  double value2 = -1;
-  double inc = 7.5;
-
-  // Verify initial values of zero
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricValue(metric1, &value1),
-      "query metric value after increment");
-  ASSERT_EQ(value1, 0);
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricValue(metric2, &value2),
-      "query metric value after increment");
-  ASSERT_EQ(value2, 0);
-
-  // Increment metric 1, check metric 2 == metric 1
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricIncrement(metric1, inc), "increase metric value");
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricValue(metric1, &value1),
-      "query metric value after increment");
-  // Verify increment worked
-  ASSERT_EQ(value1, inc);
-
-  FAIL_TEST_IF_ERR(
-      TRITONSERVER_MetricValue(metric2, &value2),
-      "query metric value after increment");
-  // Verify metric values are equal
-  ASSERT_EQ(value1, value2);
-  std::cout << "metric1 value: " << value1 << " == metric2 value: " << value2
-            << std::endl;
 }
 
-// Test duplicate metric objects without labels
-TEST_F(MetricsApiTest, TestDupeMetricNoLabels)
+// Test that adding a duplicate metric will refer to the same
+// underlying metric, and all instances will be updated
+TEST_F(MetricsApiTest, TestDupeMetricEmptyLabels)
 {
-  // TODO: same as above with empty labels
-  ASSERT_EQ(true, false);
+  std::vector<const TRITONSERVER_Parameter*> labels;
+  DupeMetricHelper(labels);
 }
 
 }  // namespace

--- a/src/test/metrics_api_test.cc
+++ b/src/test/metrics_api_test.cc
@@ -28,11 +28,14 @@
 
 #include <iostream>
 #include <thread>
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "triton/common/logging.h"
 #include "triton/core/tritonserver.h"
 
 namespace {
+
+using ::testing::HasSubstr;
 
 #define FAIL_TEST_IF_ERR(X, MSG)                                              \
   do {                                                                        \
@@ -570,6 +573,9 @@ TEST_F(MetricsApiTest, TestOutOfOrderDelete)
   // This should return an error but still delete the object
   auto err = TRITONSERVER_MetricDelete(metric);
   ASSERT_NE(err, nullptr);
+  EXPECT_THAT(
+      TRITONSERVER_ErrorMessage(err),
+      HasSubstr("Must call MetricDelete before dependent MetricFamilyDelete"));
 }
 
 }  // namespace

--- a/src/test/metrics_api_test.cc
+++ b/src/test/metrics_api_test.cc
@@ -150,13 +150,10 @@ DupeMetricHelper(
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric1), "delete metric1");
   ASSERT_EQ(NumMetricMatches(server, description), 1);
 
-  // Assert custom metric/family unregistered after last reference deleted
+  // Assert custom metric/family not displayed after all metrics are deleted
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricDelete(metric2), "delete metric2");
   ASSERT_EQ(NumMetricMatches(server, description), 0);
-
-  // Assert custom metric/family unregistered after last reference deleted
   FAIL_TEST_IF_ERR(TRITONSERVER_MetricFamilyDelete(family), "delete family");
-  ASSERT_EQ(NumMetricMatches(server, description), 0);
 }
 
 

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1221,15 +1221,14 @@ TRITONSERVER_ServerOptionsSetLogFile(
 {
 #ifdef TRITON_ENABLE_LOGGING
   std::string out_file;
-  if(file != nullptr) {
+  if (file != nullptr) {
     out_file = std::string(file);
   }
   const std::string& error = LOG_SET_OUT_FILE(out_file);
-  if(!error.empty()) {
-    return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_INTERNAL, (error).c_str());
+  if (!error.empty()) {
+    return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, (error).c_str());
   }
-  return nullptr; // Success
+  return nullptr;  // Success
 #else
   return TRITONSERVER_ErrorNew(
       TRITONSERVER_ERROR_UNSUPPORTED, "logging not supported");
@@ -1404,12 +1403,11 @@ TRITONSERVER_ServerOptionsSetModelLoadDeviceLimit(
   TritonServerOptions* loptions =
       reinterpret_cast<TritonServerOptions*>(options);
   switch (kind) {
-    case TRITONSERVER_INSTANCEGROUPKIND_GPU:
-      {
-        static std::string key_prefix = "model-load-gpu-limit-device-";
-        return loptions->AddBackendConfig(
-            "", key_prefix + std::to_string(device_id), std::to_string(fraction));
-      }
+    case TRITONSERVER_INSTANCEGROUPKIND_GPU: {
+      static std::string key_prefix = "model-load-gpu-limit-device-";
+      return loptions->AddBackendConfig(
+          "", key_prefix + std::to_string(device_id), std::to_string(fraction));
+    }
     default:
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
@@ -2962,8 +2960,16 @@ TRITONSERVER_Error*
 TRITONSERVER_MetricDelete(TRITONSERVER_Metric* metric)
 {
 #ifdef TRITON_ENABLE_METRICS
-  delete reinterpret_cast<tc::Metric*>(metric);
-  return nullptr;  // Success
+  auto lmetric = reinterpret_cast<tc::Metric*>(metric);
+  if (lmetric->Family() == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL,
+        "MetricFamily reference was invalidated before Metric was deleted. "
+        "Must call MetricDelete before dependent MetricFamilyDelete.");
+  }
+
+  delete lmetric;
+  return nullptr;  // success
 #else
   return TRITONSERVER_ErrorNew(
       TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2918,7 +2918,7 @@ TRITONSERVER_MetricFamilyDelete(TRITONSERVER_MetricFamily* family)
 {
 #ifdef TRITON_ENABLE_METRICS
   auto lfamily = reinterpret_cast<tc::MetricFamily*>(family);
-  if (lfamily->HasMetrics()) {
+  if (lfamily->NumMetrics() > 0) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INTERNAL,
         "Must call MetricDelete on all dependent metrics before calling "


### PR DESCRIPTION
- [x] Update Prometheus API usage for new prometheus-cpp version for metter support in managing duplicate metrics/metric families. Before this bump:
    - Duplicately named metric families of different types (counter, gauge, etc.) could be added to the registry which is against the prometheus spec
    - Duplicately named metric families (even of same type) would keep being added as separate objects to registry. Now duplicates will return a reference to the same family.
- [x] Update unit tests to more thoroughly test duplicates and edge cases
- [x] Think about out-of-order deletion: i.e. calling `MetricFamilyDelete()` before `MetricDelete()` where `Metric->family_->Remove()` reference is called in destructor even though `family_` should be invalid memory now.
- [x] Check if existing metric families from core (nv_request..., nv_gpu_util..., etc.) can be inadvertently removed by creating a duplicate MF with Metrics API and then calling registry->Remove() on it in destructor
    - it can, delaying registry removal until explicitly asked for, see DLIS-4072
 