### PR TITLE
Improve PriorityQueue performance with large priority_levels

### DIFF
--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -247,11 +247,18 @@ PriorityQueue::PolicyQueue::TimeoutAt(size_t idx)
   }
 }
 
-PriorityQueue::PriorityQueue()
-    : size_(0), front_priority_level_(0), last_priority_level_(0)
+bool
+PriorityQueue::PolicyQueue::ReadyForErasure()
 {
-  inference::ModelQueuePolicy default_policy;
-  queues_.emplace(0, PolicyQueue(default_policy));
+  size_t total_size = Size() + rejected_queue_.size();
+  return !keep_instantiated_ && total_size == 0;
+}
+
+PriorityQueue::PriorityQueue()
+    : size_(0), front_priority_level_(0), last_priority_level_(0),
+      default_policy_()
+{
+  queues_.emplace(0, PolicyQueue(default_policy_, true));
   front_priority_level_ = queues_.begin()->first;
   ResetCursor();
 }
@@ -259,21 +266,24 @@ PriorityQueue::PriorityQueue()
 PriorityQueue::PriorityQueue(
     const inference::ModelQueuePolicy& default_queue_policy,
     uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
-    : size_(0), last_priority_level_(priority_levels)
+    : size_(0), last_priority_level_(priority_levels),
+      default_policy_(default_queue_policy)
 {
+  // Permanently instantiate PolicyQueue with keep_instantiate=true
+  // to prevent them from being erased & created during scheduling
   if (priority_levels == 0) {
-    queues_.emplace(0, PolicyQueue(default_queue_policy));
+    // Only default policy is instantiated
+    queues_.emplace(0, PolicyQueue(default_policy_, true));
   } else {
-    for (uint32_t level = 1; level <= priority_levels; level++) {
-      auto it = queue_policy_map.find(level);
-      if (it == queue_policy_map.end()) {
-        queues_.emplace(level, PolicyQueue(default_queue_policy));
-      } else {
-        queues_.emplace(level, PolicyQueue(it->second));
-      }
+    // All priorities with user-given policy are instantiated. We do not
+    // permanently add default PolicyQueue because those will be dynamically
+    // created and erased to keep memory footprint low
+    for (auto it = queue_policy_map.begin(); it != queue_policy_map.end();
+         ++it) {
+      queues_.emplace((uint32_t)it->first, PolicyQueue(it->second, true));
     }
   }
-  front_priority_level_ = queues_.begin()->first;
+  front_priority_level_ = queues_.empty() ? 0 : queues_.begin()->first;
   ResetCursor();
 }
 
@@ -281,7 +291,10 @@ Status
 PriorityQueue::Enqueue(
     uint32_t priority_level, std::unique_ptr<InferenceRequest>& request)
 {
-  auto status = queues_[priority_level].Enqueue(request);
+  // Get corresponding PolicyQueue if it exists, otherwise insert it
+  // via emplace with the default policy
+  auto it = queues_.insert(std::make_pair(priority_level, default_policy_));
+  auto status = it.first->second.Enqueue(request);
   if (status.IsOk()) {
     size_++;
     front_priority_level_ = std::min(front_priority_level_, priority_level);
@@ -303,38 +316,43 @@ Status
 PriorityQueue::Dequeue(std::unique_ptr<InferenceRequest>* request)
 {
   pending_cursor_.valid_ = false;
-  while (true) {
-    if (!queues_[front_priority_level_].Empty()) {
-      RETURN_IF_ERROR(queues_[front_priority_level_].Dequeue(request));
+  auto it_start = queues_.lower_bound(front_priority_level_);
+  for (auto it = it_start; it != queues_.end(); ++it) {
+    if (!it->second.Empty()) {
+      front_priority_level_ = it->first;
+      RETURN_IF_ERROR(it->second.Dequeue(request));
       size_--;
+      if (it->second.ReadyForErasure()) {
+        queues_.erase(it);
+      }
       return Status::Success;
-    } else if (front_priority_level_ != last_priority_level_) {
-      front_priority_level_++;
-      continue;
     }
-
-    // Control reach here if the queue for last priority level is also
-    // empty, then return error below.
-    break;
   }
-
-  return Status(
-      Status::Code::UNAVAILABLE,
-      (*request)->LogRequest() + "dequeue on empty queue");
+  return Status(Status::Code::UNAVAILABLE, "dequeue on empty queue");
 }
 
 void
 PriorityQueue::ReleaseRejectedRequests(
     std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>*
-        requests)
+    requests)
 {
   auto res = std::make_shared<
       std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>(
       queues_.size());
   size_t idx = 0;
-  for (auto& queue : queues_) {
-    queue.second.ReleaseRejectedQueue(&((*res)[idx]));
+  for (auto it = queues_.begin(); it != queues_.end(); ) {
+    it->second.ReleaseRejectedQueue(&((*res)[idx]));
     idx++;
+    if (it->second.ReadyForErasure()) {
+      // Invalidate the pending batch cursor if it points to
+      // the item to be erased
+      if (it->first == pending_cursor_.curr_it_->first) {
+        pending_cursor_.valid_ = false;
+      }
+      it = queues_.erase(it); // returns iterator following removed element
+    } else {
+      ++it;
+    }
   }
 
   requests->swap(res);

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -301,9 +301,10 @@ PriorityQueue::Enqueue(
     // within the pending batch. At the same priority level the request is
     // guaranteed to be after pending batch if the batch hasn't reached
     // delayed queue.
-    if ((priority_level < pending_cursor_.curr_it_->first) ||
-        ((priority_level == pending_cursor_.curr_it_->first) &&
-         (pending_cursor_.at_delayed_queue_))) {
+    if (pending_cursor_.valid_ &&
+        ((priority_level < pending_cursor_.curr_it_->first) ||
+         ((priority_level == pending_cursor_.curr_it_->first) &&
+          (pending_cursor_.at_delayed_queue_)))) {
       pending_cursor_.valid_ = false;
     }
   }
@@ -345,7 +346,8 @@ PriorityQueue::ReleaseRejectedRequests(
     if (it->second.ReadyForErasure()) {
       // Invalidate the pending batch cursor if it points to
       // the item to be erased
-      if (it->first == pending_cursor_.curr_it_->first) {
+      if (pending_cursor_.valid_ &&
+          it->first == pending_cursor_.curr_it_->first) {
         pending_cursor_.valid_ = false;
       }
       it = queues_.erase(it); // returns iterator following removed element

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -278,9 +278,8 @@ PriorityQueue::PriorityQueue(
     // All priorities with user-given policy are instantiated. We do not
     // permanently add default PolicyQueue because those will be dynamically
     // created and erased to keep memory footprint low
-    for (auto it = queue_policy_map.begin(); it != queue_policy_map.end();
-         ++it) {
-      queues_.emplace((uint32_t)it->first, PolicyQueue(it->second, true));
+    for (const auto& qp : queue_policy_map) {
+      queues_.emplace((uint32_t)qp.first, PolicyQueue(qp.second, true));
     }
   }
   front_priority_level_ = queues_.empty() ? 0 : queues_.begin()->first;

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -155,16 +155,18 @@ class PriorityQueue {
     PolicyQueue()
         : timeout_action_(inference::ModelQueuePolicy::REJECT),
           default_timeout_us_(0), allow_timeout_override_(false),
-          max_queue_size_(0)
+          max_queue_size_(0), keep_instantiated_(false)
     {
     }
 
     // Construct a policy queue with given 'policy'.
-    PolicyQueue(const inference::ModelQueuePolicy& policy)
+    PolicyQueue(const inference::ModelQueuePolicy& policy,
+                bool keep_instantiated = false)
         : timeout_action_(policy.timeout_action()),
           default_timeout_us_(policy.default_timeout_microseconds()),
           allow_timeout_override_(policy.allow_timeout_override()),
-          max_queue_size_(policy.max_queue_size())
+          max_queue_size_(policy.max_queue_size()),
+          keep_instantiated_(keep_instantiated)
     {
     }
 
@@ -209,12 +211,17 @@ class PriorityQueue {
     // Return the number of unexpired requests in the queue
     size_t UnexpiredSize() { return queue_.size(); }
 
+    // Return whether this PolicyQueue can be erased, i.e. when all queues
+    // are empty and should not be kept instantiated
+    bool ReadyForErasure();
+
    private:
     // Variables that define the policy for the queue
     const inference::ModelQueuePolicy::TimeoutAction timeout_action_;
     const uint64_t default_timeout_us_;
     const bool allow_timeout_override_;
     const uint32_t max_queue_size_;
+    const bool keep_instantiated_;
 
     std::deque<uint64_t> timeout_timestamp_ns_;
     std::deque<std::unique_ptr<InferenceRequest>> queue_;
@@ -248,6 +255,7 @@ class PriorityQueue {
   // is at to avoid traversing 'queues_'
   uint32_t front_priority_level_;
   uint32_t last_priority_level_;
+  inference::ModelQueuePolicy default_policy_;
 
   Cursor pending_cursor_;
   Cursor current_mark_;


### PR DESCRIPTION
Modify PriorityQueue to dynamically create/remove PolicyQueue items instead of instantiating them in the constructor. User-given PolicyQueue (defined in priority_queue_policy) are instantiated in constructor and are kept instantiated. Thus only default PolicyQueue are affected by this PR.

This PR results in significant performance boost when priority_levels takes a large value (above ~100k). Next step would be to have the priority_ variable of InferenceRequest to be expressed in uint64_t instead of uint32_t.