### PR TITLE
Adding the fixes for arm32

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -1170,7 +1170,7 @@ TRITONBACKEND_InputBuffer(
   InferenceRequest::Input* ti =
       reinterpret_cast<InferenceRequest::Input*>(input);
   Status status = ti->DataBuffer(
-      index, buffer, buffer_byte_size, memory_type, memory_type_id);
+      index, buffer, reinterpret_cast<size_t*>(buffer_byte_size), memory_type, memory_type_id);
   if (!status.IsOk()) {
     *buffer = nullptr;
     *buffer_byte_size = 0;
@@ -1210,9 +1210,9 @@ TRITONBACKEND_InputBufferForHostPolicy(
   Status status =
       (host_policy_name == nullptr)
           ? ti->DataBuffer(
-                index, buffer, buffer_byte_size, memory_type, memory_type_id)
+                index, buffer, reinterpret_cast<size_t*>(buffer_byte_size), memory_type, memory_type_id)
           : ti->DataBufferForHostPolicy(
-                index, buffer, buffer_byte_size, memory_type, memory_type_id,
+                index, buffer, reinterpret_cast<size_t*>(buffer_byte_size), memory_type, memory_type_id,
                 host_policy_name);
   if (!status.IsOk()) {
     *buffer = nullptr;


### PR DESCRIPTION
I intend on using the Triton Inference server on 3 devices (amd64, arm64 and arm/v7). After trying to build the server for my arm/v7 device, I noticed that there where casting errors. I realized that I needed to make similar fixes in the backend and server repositories as well. Once all the casting issues have been solved in the 3 repos, I was able to correctly run inferences on all three of my devices.
