### PR TITLE
Fix L0_response_cache

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -92,6 +92,23 @@ NullRequestComplete(
 
 }  // namespace
 
+InferenceRequest::InferenceRequest(
+    const std::shared_ptr<Model>& model, const int64_t requested_model_version)
+    : InferenceRequest(model.get(), requested_model_version)
+{
+  model_shared_ = model;
+}
+
+InferenceRequest::InferenceRequest(
+    Model* model, const int64_t requested_model_version)
+    : needs_normalization_(true), model_raw_(model),
+      requested_model_version_(requested_model_version), flags_(0),
+      correlation_id_(0), batch_size_(0), timeout_us_(0), collect_stats_(true)
+{
+  inference_request_count_++;
+  SetPriority(0);
+}
+
 const std::string&
 InferenceRequest::ModelName() const
 {

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -275,20 +275,9 @@ class InferenceRequest {
   // (because we aren't using shared_from_this).
   InferenceRequest(
       const std::shared_ptr<Model>& model,
-      const int64_t requested_model_version)
-      : InferenceRequest(model.get(), requested_model_version)
-  {
-    model_shared_ = model;
-  }
+      const int64_t requested_model_version);
 
-  InferenceRequest(Model* model, const int64_t requested_model_version)
-      : needs_normalization_(true), model_raw_(model),
-        requested_model_version_(requested_model_version), flags_(0),
-        correlation_id_(0), batch_size_(0), timeout_us_(0), collect_stats_(true)
-  {
-    inference_request_count_++;
-    SetPriority(0);
-  }
+  InferenceRequest(Model* model, const int64_t requested_model_version);
 
   const std::string& ModelName() const;
   int64_t RequestedModelVersion() const { return requested_model_version_; }

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -58,8 +58,9 @@ InferenceRequest::InferenceRequest(
       requested_model_version_(requested_model_version), flags_(0),
       correlation_id_(0), batch_size_(0), timeout_us_(0), collect_stats_(true)
 {
-  // Unit test doesn't need actual Response Factory logic
-  // or other priority/request_counting logic
+  // Unit test doesn't need actual response factory logic
+  // or other priority/request_counting logic, it just needs
+  // a non-null reponse factory object.
   response_factory_.reset(new InferenceResponseFactory());
 }
 
@@ -459,7 +460,6 @@ class RequestResponseCacheTest : public ::testing::Test {
 
     // Generate a set of unique requests to use for parallelism tests
     for (size_t idx = 0; idx < thread_count; idx++) {
-      // Use idx to enforce uniqueness
       std::vector<int> data(thread_count, static_cast<int>(idx));
       std::vector<Tensor> inputs{Tensor{"input" + std::to_string(idx), data}};
 


### PR DESCRIPTION
- Fix L0_response_cache test
    - Recent changes gave InferenceResponseFactory a `nullptr` default value without setting a response callback
    - Remove random data logic to avoid possible collisions in requests and simplify code
- Move InferenceRequest constructor implementations into `infer_request.cc` so they can be mocked in unit test
    - Needed to easily set ResponseFactory() to valid default