### PR TITLE
Fix payload race condition in dynamic batch scheduler

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -141,6 +141,7 @@ DynamicBatchScheduler::Create(
 
   sched->scheduler_thread_exit_.store(false);
   if (dynamic_batching_enabled) {
+    sched->NewPayload();
     sched->scheduler_thread_ =
         std::thread([dyna_sched, nice]() { dyna_sched->BatcherThread(nice); });
   }
@@ -304,7 +305,6 @@ DynamicBatchScheduler::BatcherThread(const int nice)
   auto wait_for_slots = [this]() {
     return model_->Server()->GetRateLimiter()->PayloadSlotAvailable(model_);
   };
-  NewPayload();
   const uint64_t default_wait_microseconds = 500 * 1000;
 
   while (!scheduler_thread_exit_.load()) {


### PR DESCRIPTION
The dynamic batch scheduler maintains a current payload that accumulates requests. The background thread of the scheduler periodically submits all of these requests as a batch and resets the payload to build the next batch of requests. The scheduler creates this background thread and immediately starts accepting requests, which means that some requests may already be received before the background thread has started running.

In the current implementation this situation results in a segmentation fault because the initial payload does not exist (`nullptr`) until the thread has started. I've fixed this problem by creating the initial payload immediately when the scheduler itself is created, rather than doing it in the background thread.

I've tested this fix and confirmed that it solves the problem in https://github.com/triton-inference-server/server/issues/4925. I believe the sequence scheduler suffers from the same race condition and may need to be fixed as well, but I wasn't able to confirm this since we aren't using it.