### PR TITLE
Fix error checking for converting from JSON to protobuf message

### DIFF
--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -2100,8 +2100,12 @@ JsonToModelConfig(
   ::google::protobuf::util::JsonParseOptions options;
   options.case_insensitive_enum_parsing = true;
   options.ignore_unknown_fields = false;
-  ::google::protobuf::util::JsonStringToMessage(
+  auto err = ::google::protobuf::util::JsonStringToMessage(
       json_config, protobuf_config, options);
+  if (!err.ok()) {
+    return Status(Status::Code::INVALID_ARG, std::string(err.message()));
+  }
+
   return Status::Success;
 }
 

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1089,8 +1089,13 @@ ModelRepositoryManager::InitializeModelInfo(
       unmodified = false;
 
       const std::string& override_config = override_parameter->ValueString();
-      RETURN_IF_ERROR(JsonToModelConfig(
-          override_config, 1 /* config_version */, &linfo->model_config_));
+      auto err = JsonToModelConfig(
+          override_config, 1 /* config_version */, &linfo->model_config_);
+      if (!err.IsOk()) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "Unrecognized config override: " + std::string(err.Message()));
+      }
       parsed_config = true;
       break;
     } else if (override_parameter->Name().rfind(file_prefix, 0) != 0) {

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -1094,7 +1094,7 @@ ModelRepositoryManager::InitializeModelInfo(
       if (!err.IsOk()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "Unrecognized config override: " + std::string(err.Message()));
+            "Invalid config override: " + std::string(err.Message()));
       }
       parsed_config = true;
       break;


### PR DESCRIPTION
Example error message:
```
E1006 01:01:06.603161 2315 model_repository_manager.cc:996] Poll failed for model directory 'simple': Invalid config override: Parsing terminated before end of input.
"parameters": {"config": {{"max_
            ^
```
Testing related PRs:
Server: https://github.com/triton-inference-server/server/pull/4948
Client: https://github.com/triton-inference-server/client/pull/170