### PR TITLE
Fix Payload Queues Race Condition

### DIFF
--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -26,8 +26,8 @@
 
 #include "rate_limiter.h"
 
-#include "triton/common/logging.h"
 #include <limits>
+#include "triton/common/logging.h"
 
 namespace triton { namespace core {
 
@@ -107,8 +107,11 @@ RateLimiter::UnregisterModel(const TritonModel* model)
     RETURN_IF_ERROR(resource_manager_->UpdateResourceLimits());
   }
 
-  if (payload_queues_.find(model) != payload_queues_.end()) {
-    payload_queues_.erase(model);
+  {
+    std::lock_guard<std::mutex> lk1(payload_queues_mu_);
+    if (payload_queues_.find(model) != payload_queues_.end()) {
+      payload_queues_.erase(model);
+    }
   }
 
   return Status::Success;
@@ -227,7 +230,7 @@ RateLimiter::GetPayload(
   std::shared_ptr<Payload> payload;
 
   if (max_payload_bucket_count_ > 0) {
-    std::lock_guard<std::mutex> lock(alloc_mu_);
+    std::lock_guard<std::mutex> lock(payload_mu_);
 
     if (!payload_bucket_.empty()) {
       payload = payload_bucket_.back();
@@ -256,7 +259,7 @@ RateLimiter::PayloadRelease(std::shared_ptr<Payload>& payload)
 {
   payload->OnRelease();
   if (max_payload_bucket_count_ > 0) {
-    std::lock_guard<std::mutex> lock(alloc_mu_);
+    std::lock_guard<std::mutex> lock(payload_mu_);
 
     if (payloads_in_use_.size() + payload_bucket_.size() <
         max_payload_bucket_count_) {

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -281,8 +281,11 @@ class RateLimiter {
   // Manager to keep track of the resource allocations
   std::unique_ptr<ResourceManager> resource_manager_;
 
-  // Mutex to serialize Payload allocation
-  std::mutex alloc_mu_;
+  // Mutex to serialize Payload [de]allocation
+  std::mutex payload_mu_;
+
+  // Mutex to serialize Payload Queues deallocation
+  std::mutex payload_queue_mu_;
 
   // Keep some number of Payload objects for reuse to avoid the overhead
   // of creating a Payload for every new request.

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -285,7 +285,7 @@ class RateLimiter {
   std::mutex payload_mu_;
 
   // Mutex to serialize Payload Queues deallocation
-  std::mutex payload_queue_mu_;
+  std::mutex payload_queues_mu_;
 
   // Keep some number of Payload objects for reuse to avoid the overhead
   // of creating a Payload for every new request.


### PR DESCRIPTION
Locking the payload queues when deallocating to prevent concurrent deletion of models by multiple threads. The prevents a potential segfault during model unregistering.