### PR TITLE
Make the finalize_mtx_ scheduler specific

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -667,8 +667,7 @@ DynamicBatchScheduler::FinalizeResponses()
 {
   // Need exclusive access of the function to ensure responses are sent
   // in order
-  static std::mutex finalize_mtx;
-  std::lock_guard<std::mutex> lock(finalize_mtx);
+  std::lock_guard<std::mutex> lock(finalize_mtx_);
   // Finalize the completed payloads in-order as far as possible
   std::deque<std::pair<std::unique_ptr<InferenceResponse>, const uint32_t>>
       responses;

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -169,6 +169,9 @@ class DynamicBatchScheduler : public Scheduler {
   // Lock to protect the completion_queues_
   std::mutex completion_queue_mtx_;
 
+  // Preserves the order in which responses are finalized
+  std::mutex finalize_mtx_;
+
   // Reporter for metrics, or nullptr if no metrics should be reported
   std::shared_ptr<MetricModelReporter> reporter_;
 };


### PR DESCRIPTION
If trying to send the response within the response callback of another model that holds the finalize_mtx_ lock, the thread will run into deadlock as it tries to re-acquire the lock.

The change move the ordering mutexes specific to the scheduler object.