### PR TITLE
Fix possible segfault when unloading model that uses dynamic batching

### DIFF
--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -113,6 +113,9 @@ class DynamicBatchScheduler : public Scheduler {
   TritonModel* model_;
   TritonModelInstance* model_instance_;
 
+  // Name of the model.
+  std::string model_name_;
+
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;
 


### PR DESCRIPTION
The issue was happening because we were trying to access model_ object during its destruction from within BatcherThread while trying to print the verbose logs in L425.

L0_model_control_stress has been enhanced to cover the testing of this case.

Fixes https://github.com/triton-inference-server/server/issues/4924
