### PR TITLE
Release scope lock for parallel model loading

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -174,6 +174,7 @@ TritonModel::Create(
   // library attempts to load additional shared libaries.
   if (backend->ModelInitFn() != nullptr) {
     {
+      // FIXME: fix lock fight DLIS-4300
       std::unique_ptr<SharedLibrary> slib;
       RETURN_IF_ERROR(SharedLibrary::Acquire(&slib));
       RETURN_IF_ERROR(slib->SetLibraryDirectory(backend->Directory()));
@@ -183,6 +184,7 @@ TritonModel::Create(
         reinterpret_cast<TRITONBACKEND_Model*>(raw_local_model));
 
     {
+      // FIXME: fix lock fight DLIS-4300
       std::unique_ptr<SharedLibrary> slib;
       RETURN_IF_ERROR(SharedLibrary::Acquire(&slib));
       RETURN_IF_ERROR(slib->ResetLibraryDirectory());

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -173,14 +173,20 @@ TritonModel::Create(
   // path to point to the backend directory in case the backend
   // library attempts to load additional shared libaries.
   if (backend->ModelInitFn() != nullptr) {
-    std::unique_ptr<SharedLibrary> slib;
-    RETURN_IF_ERROR(SharedLibrary::Acquire(&slib));
-    RETURN_IF_ERROR(slib->SetLibraryDirectory(backend->Directory()));
+    {
+      std::unique_ptr<SharedLibrary> slib;
+      RETURN_IF_ERROR(SharedLibrary::Acquire(&slib));
+      RETURN_IF_ERROR(slib->SetLibraryDirectory(backend->Directory()));
+    }
 
     TRITONSERVER_Error* err = backend->ModelInitFn()(
         reinterpret_cast<TRITONBACKEND_Model*>(raw_local_model));
 
-    RETURN_IF_ERROR(slib->ResetLibraryDirectory());
+    {
+      std::unique_ptr<SharedLibrary> slib;
+      RETURN_IF_ERROR(SharedLibrary::Acquire(&slib));
+      RETURN_IF_ERROR(slib->ResetLibraryDirectory());
+    }
     RETURN_IF_TRITONSERVER_ERROR(err);
   }
 

--- a/src/ensemble_utils.cc
+++ b/src/ensemble_utils.cc
@@ -242,7 +242,7 @@ ValidateTensorMapping(
 
 Status
 ValidateEnsembleConfig(
-    ModelRepositoryManager* model_repository_manager,
+    const ModelRepositoryManager* model_repository_manager,
     ModelRepositoryManager::DependencyNode* ensemble)
 {
   const auto& ensemble_config = ensemble->model_config_;

--- a/src/ensemble_utils.h
+++ b/src/ensemble_utils.h
@@ -42,7 +42,7 @@ namespace triton { namespace core {
 /// \param ensemble The ensemble to be validated.
 /// \return The error status.
 Status ValidateEnsembleConfig(
-    ModelRepositoryManager* model_repository_manager,
+    const ModelRepositoryManager* model_repository_manager,
     ModelRepositoryManager::DependencyNode* ensemble);
 
 }}  // namespace triton::core

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -419,49 +419,63 @@ ModelRepositoryManager::PollAndUpdate()
 Status
 ModelRepositoryManager::PollAndUpdateInternal(bool* all_models_polled)
 {
-  // Serialize all operations that change model state
-  std::lock_guard<std::mutex> lock(poll_mu_);
+  // Do not modify model data structures in place to allow easy rollback due to
+  // any error or in transition dependencies during processing.
+  ModelInfoMap new_infos;
+  DependencyGraph new_dependency_graph;
 
   std::set<std::string> added, deleted, modified, unmodified;
+  {
+    std::lock_guard<std::mutex> lock(poll_mu_);
 
-  // We don't modify 'infos_' in place to minimize how long we need to
-  // hold the lock and also prevent any partial changes to do an error
-  // during processing.
-  ModelInfoMap new_infos;
+    // Each subdirectory of repository path is a model directory from
+    // which we read the model configuration.
+    std::unordered_map<std::string, std::vector<const InferenceParameter*>>
+        subdirs;
+    RETURN_IF_ERROR(Poll(
+        subdirs, &added, &deleted, &modified, &unmodified, &new_infos,
+        all_models_polled));
 
-  // Each subdirectory of repository path is a model directory from
-  // which we read the model configuration.
-  std::unordered_map<std::string, std::vector<const InferenceParameter*>>
-      subdirs;
-  RETURN_IF_ERROR(Poll(
-      subdirs, &added, &deleted, &modified, &unmodified, &new_infos,
-      all_models_polled));
-
-  // Anything in 'infos_' that is not in "added", "modified", or
-  // "unmodified" is deleted.
-  for (const auto& pr : infos_) {
-    if ((added.find(pr.first) == added.end()) &&
-        (modified.find(pr.first) == modified.end()) &&
-        (unmodified.find(pr.first) == unmodified.end())) {
-      deleted.insert(pr.first);
+    // Anything in 'infos_' that is not in "added", "modified", or
+    // "unmodified" is deleted.
+    for (const auto& pr : infos_) {
+      if ((added.find(pr.first) == added.end()) &&
+          (modified.find(pr.first) == modified.end()) &&
+          (unmodified.find(pr.first) == unmodified.end())) {
+        deleted.insert(pr.first);
+      }
     }
+
+    // Nothing to do if no model adds, deletes or modifies.
+    if (added.empty() && deleted.empty() && modified.empty()) {
+      return Status::Success;
+    }
+
+    // Update dependencies 
+    RETURN_IF_ERROR(UpdateDependencyGraph(
+        added, deleted, modified, new_infos, &new_dependency_graph));
+    UpdateTransition(new_dependency_graph, added, true);
+    UpdateTransition(new_dependency_graph, deleted, true);
+    UpdateTransition(new_dependency_graph, modified, true);
+
+    // Write intermediate state
+    infos_.swap(new_infos);
+    dependency_graph_.swap(new_dependency_graph);
   }
-
-  // Nothing to do if no model adds, deletes or modifies.
-  if (added.empty() && deleted.empty() && modified.empty()) {
-    return Status::Success;
-  }
-
-  infos_.swap(new_infos);
-
-  UpdateDependencyGraph(added, deleted, modified);
 
   for (const auto& name : deleted) {
     model_life_cycle_->AsyncUnload(name);
   }
-
   // model loading / unloading error will be printed but ignored
   LoadModelByDependency();
+
+  // mark in transition models as completed
+  {
+    std::lock_guard<std::mutex> lock(poll_mu_);
+    UpdateTransition(dependency_graph_, added, false);
+    UpdateTransition(dependency_graph_, deleted, false);
+    UpdateTransition(dependency_graph_, modified, false);
+  }
 
   return Status::Success;
 }
@@ -555,9 +569,6 @@ ModelRepositoryManager::LoadUnloadModel(
         "explicit load / unload multiple models is not currently supported");
   }
 
-  // Serialize all operations that change model state
-  std::lock_guard<std::mutex> lock(poll_mu_);
-
   bool polled = true;
   RETURN_IF_ERROR(LoadUnloadModels(models, type, unload_dependents, &polled));
   // Check if model is loaded / unloaded properly
@@ -611,9 +622,17 @@ ModelRepositoryManager::LoadUnloadModels(
 {
   auto status = Status::Success;
   *all_models_polled = true;
+
+  // Do not modify model data structures in place to allow easy rollback due to
+  // any error or in transition dependencies during processing.
+  ModelInfoMap new_infos;
+  DependencyGraph new_dependency_graph;
+
   // Update ModelInfo related to file system accordingly
-  std::set<std::string> added, deleted, modified, unmodified;
+  std::set<std::string> added, deleted, modified, unmodified, deleted_dependents;
   {
+    std::lock_guard<std::mutex> lock(poll_mu_);
+
     if (type == ActionType::UNLOAD) {
       for (const auto& model : models) {
         deleted.insert(model.first);
@@ -627,7 +646,6 @@ ModelRepositoryManager::LoadUnloadModels(
         checked_models.emplace(model.first);
       }
 
-      ModelInfoMap new_infos;
 #ifdef TRITON_ENABLE_ENSEMBLE
       bool first_iteration = true;
 #endif  // TRITON_ENABLE_ENSEMBLE
@@ -665,35 +683,57 @@ ModelRepositoryManager::LoadUnloadModels(
       }
 
       // Only update the infos when all validation is completed
+      ModelInfoMap current_infos;
+      CopyModelInfos(&current_infos);
       for (const auto& model_name : added) {
         auto nitr = new_infos.find(model_name);
-        infos_.emplace(model_name, std::move(nitr->second));
+        current_infos.emplace(model_name, std::move(nitr->second));
       }
       for (const auto& model_name : modified) {
         auto nitr = new_infos.find(model_name);
-        auto itr = infos_.find(model_name);
+        auto itr = current_infos.find(model_name);
         itr->second = std::move(nitr->second);
       }
+      new_infos.swap(current_infos);
     }
+
+    // Update dependency graph and load
+    RETURN_IF_ERROR(UpdateDependencyGraph(
+        added, deleted, modified, new_infos, &new_dependency_graph,
+        unload_dependents ? &deleted_dependents : nullptr));
+    UpdateTransition(dependency_graph_, added, true);
+    UpdateTransition(dependency_graph_, deleted, true);
+    UpdateTransition(dependency_graph_, modified, true);
+    UpdateTransition(dependency_graph_, deleted_dependents, true);
+
+    // The models are in 'deleted' either when they are asked to be unloaded or
+    // they are not found / are duplicated across all model repositories.
+    // In all cases, should unload them and remove from 'infos_' explicitly.
+    for (const auto& name : (unload_dependents ? deleted_dependents : deleted)) {
+      new_infos.erase(name);
+    }
+
+    // Write intermediate state
+    infos_.swap(new_infos);
+    dependency_graph_.swap(new_dependency_graph);
   }
-  std::set<std::string> deleted_dependents;
 
-  // Update dependency graph and load
-  UpdateDependencyGraph(
-      added, deleted, modified,
-      unload_dependents ? &deleted_dependents : nullptr);
-
-  // The models are in 'deleted' either when they are asked to be unloaded or
-  // they are not found / are duplicated across all model repositories.
-  // In all cases, should unload them and remove from 'infos_' explicitly.
   for (const auto& name : (unload_dependents ? deleted_dependents : deleted)) {
-    infos_.erase(name);
     model_life_cycle_->AsyncUnload(name);
   }
-
   // load / unload the models affected, and check the load status of
   // the requested models
   const auto& load_status = LoadModelByDependency();
+
+  // mark in transition models as completed
+  {
+    std::lock_guard<std::mutex> lock(poll_mu_);
+    UpdateTransition(dependency_graph_, added, false);
+    UpdateTransition(dependency_graph_, deleted, false);
+    UpdateTransition(dependency_graph_, modified, false);
+    UpdateTransition(dependency_graph_, deleted_dependents, false);
+  }
+
   if (status.IsOk() && (type == ActionType::LOAD)) {
     std::string load_error_message = "";
     for (const auto& model : models) {
@@ -852,7 +892,7 @@ ModelRepositoryManager::Poll(
         std::string, std::vector<const InferenceParameter*>>& models,
     std::set<std::string>* added, std::set<std::string>* deleted,
     std::set<std::string>* modified, std::set<std::string>* unmodified,
-    ModelInfoMap* updated_infos, bool* all_models_polled)
+    ModelInfoMap* updated_infos, bool* all_models_polled) const
 {
   *all_models_polled = true;
   // empty path is the special case to indicate the model should be loaded
@@ -1010,7 +1050,7 @@ ModelRepositoryManager::Poll(
 
 bool
 ModelRepositoryManager::ModelDirectoryOverride(
-    const std::vector<const InferenceParameter*>& model_params)
+    const std::vector<const InferenceParameter*>& model_params) const
 {
   for (const auto& param : model_params) {
     if (param->Name().rfind(file_prefix, 0) == 0) {
@@ -1025,7 +1065,7 @@ Status
 ModelRepositoryManager::InitializeModelInfo(
     const std::string& name, const std::string& path,
     const std::vector<const InferenceParameter*>& params,
-    std::unique_ptr<ModelInfo>* info)
+    std::unique_ptr<ModelInfo>* info) const
 {
   std::unique_ptr<ModelInfo> linfo(new ModelInfo());
   linfo->model_path_ = path;
@@ -1191,25 +1231,34 @@ ModelRepositoryManager::InitializeModelInfo(
 Status
 ModelRepositoryManager::UpdateDependencyGraph(
     const std::set<std::string>& added, const std::set<std::string>& deleted,
-    const std::set<std::string>& modified,
-    std::set<std::string>* deleted_dependents)
+    const std::set<std::string>& modified, const ModelInfoMap& model_infos,
+    DependencyGraph* updated_graph, std::set<std::string>* deleted_dependents) const
 {
   // update dependency graph, if the state of a node is changed, all its
   // downstreams will be affected
 
-  // deleted, drop from dependency_graph, add to missing_nodes if downstreams is
-  // not empty affected_nodes are all ensembles as only ensembles are depending
-  // on other models
-  std::set<DependencyNode*> affected_nodes;
-  std::set<DependencyNode*> updated_nodes;
+  // deep copy the dependency graph for update
+  CopyDependencyGraph(updated_graph);
+
+  // present nodes and missing nodes of the dependency graph
+  auto& present_nodes = updated_graph->first;
+  auto& missing_nodes = updated_graph->second;
+
+  // deleted, drop from present_nodes, and add to missing_nodes if downstreams
+  // is not empty
+  // affected_nodes are all ensembles as only ensembles are depending on other
+  // models
+  std::set<DependencyNode*> affected_nodes, updated_nodes;
   std::set<std::string> current_deleted = deleted;
   while (!current_deleted.empty()) {
     std::set<std::string> next_deleted;
     for (const auto& model_name : current_deleted) {
-      auto it = dependency_graph_.find(model_name);
-      if (it != dependency_graph_.end()) {
+      auto it = present_nodes.find(model_name);
+      if (it != present_nodes.end()) {
+        RETURN_IF_ERROR(InTransit(it->second.get()));
         // remove this node from its upstreams
         for (auto& upstream : it->second->upstreams_) {
+          RETURN_IF_ERROR(InTransit(upstream.first));
           upstream.first->downstreams_.erase(it->second.get());
           // Check if the upstream should be removed as well
           if ((deleted_dependents != nullptr) &&
@@ -1226,13 +1275,13 @@ ModelRepositoryManager::UpdateDependencyGraph(
           for (auto& downstream : it->second->downstreams_) {
             downstream->missing_upstreams_.emplace(it->second.get());
           }
-          missing_nodes_.emplace(
+          missing_nodes.emplace(
               std::make_pair(model_name, std::move(it->second)));
         }
 
         // Make sure deleted node will not be in affected nodes
         affected_nodes.erase(it->second.get());
-        dependency_graph_.erase(it);
+        present_nodes.erase(it);
       }
       if (deleted_dependents != nullptr) {
         deleted_dependents->emplace(model_name);
@@ -1243,15 +1292,17 @@ ModelRepositoryManager::UpdateDependencyGraph(
 
   // modified, invalidate (uncheck) all downstreams
   for (const auto& model_name : modified) {
-    auto it = dependency_graph_.find(model_name);
-    if (it != dependency_graph_.end()) {
+    auto it = present_nodes.find(model_name);
+    if (it != present_nodes.end()) {
+      RETURN_IF_ERROR(InTransit(it->second.get()));
       UncheckDownstream(&it->second->downstreams_, &affected_nodes);
       ModelInfo* info = nullptr;
-      GetModelInfo(model_name, &info);
+      GetModelInfo(model_infos, model_name, &info);
       it->second->model_config_ = info->model_config_;
       it->second->explicitly_load_ = info->explicitly_load_;
       // remove this node from its upstream node
       for (auto& upstream : it->second->upstreams_) {
+        RETURN_IF_ERROR(InTransit(upstream.first));
         upstream.first->downstreams_.erase(it->second.get());
       }
       it->second->upstreams_.clear();
@@ -1265,8 +1316,9 @@ ModelRepositoryManager::UpdateDependencyGraph(
   // and associate all downstreams, remove from missing_node
   for (const auto& model_name : added) {
     std::unique_ptr<DependencyNode> added_node;
-    auto it = missing_nodes_.find(model_name);
-    if (it != missing_nodes_.end()) {
+    auto it = missing_nodes.find(model_name);
+    if (it != missing_nodes.end()) {
+      RETURN_IF_ERROR(InTransit(it->second.get()));
       UncheckDownstream(&it->second->downstreams_, &affected_nodes);
       // remove this node from missing upstream node in its downstream nodes
       for (auto& downstream : it->second->downstreams_) {
@@ -1275,25 +1327,34 @@ ModelRepositoryManager::UpdateDependencyGraph(
 
       it->second->checked_ = false;
       added_node = std::move(it->second);
-      missing_nodes_.erase(it);
+      missing_nodes.erase(it);
     } else {
       // Right now, nothing is going to be filled until validation
       added_node.reset(new DependencyNode(model_name));
     }
     ModelInfo* info = nullptr;
-    GetModelInfo(model_name, &info);
+    GetModelInfo(model_infos, model_name, &info);
     added_node->model_config_ = info->model_config_;
     added_node->explicitly_load_ = info->explicitly_load_;
     updated_nodes.emplace(added_node.get());
-    dependency_graph_.emplace(
+    present_nodes.emplace(
         std::make_pair(model_name, std::move(added_node)));
   }
 
   auto& affected_ensembles = affected_nodes;
   for (auto& updated_node : updated_nodes) {
-    bool is_ensemble = ConnectDependencyGraph(updated_node);
+    bool is_ensemble = ConnectDependencyGraph(updated_graph, updated_node);
     if (is_ensemble) {
       affected_ensembles.emplace(updated_node);
+    }
+  }
+
+  // check if affected_ensembles are in transition
+  for (auto& affected_ensemble : affected_ensembles) {
+    RETURN_IF_ERROR(InTransit(affected_ensemble));
+    // also check the upstreams of affected_ensembles
+    for (auto& upstream : affected_ensemble->upstreams_) {
+      RETURN_IF_ERROR(InTransit(upstream.first));
     }
   }
 
@@ -1302,6 +1363,7 @@ ModelRepositoryManager::UpdateDependencyGraph(
   for (auto& ensemble : affected_ensembles) {
     if (ensemble->status_.IsOk()) {
       if (!ensemble->missing_upstreams_.empty()) {
+        // Set error status
         std::string name_list;
         for (auto it = ensemble->missing_upstreams_.begin();
              it != ensemble->missing_upstreams_.end(); it++) {
@@ -1411,7 +1473,7 @@ ModelRepositoryManager::UnregisterModelRepository(const std::string& repository)
 
 Status
 ModelRepositoryManager::CircularcyCheck(
-    DependencyNode* current_node, const DependencyNode* start_node)
+    DependencyNode* current_node, const DependencyNode* start_node) const
 {
   for (auto& downstream : current_node->downstreams_) {
     if (downstream->model_name_ == start_node->model_name_) {
@@ -1432,8 +1494,61 @@ ModelRepositoryManager::CircularcyCheck(
 }
 
 void
+ModelRepositoryManager::CopyDependencyGraph(DependencyGraph* new_graph) const
+{
+  // clear graph
+  new_graph->first.clear();
+  new_graph->second.clear();
+  // copy nodes
+  for (auto& pair : dependency_graph_.first) {
+    new_graph->first.emplace(pair.first, std::make_unique<DependencyNode>(*pair.second));
+  }
+  for (auto& pair : dependency_graph_.second) {
+    new_graph->second.emplace(pair.first, std::make_unique<DependencyNode>(*pair.second));
+  }
+  // re-map pointers to new nodes
+  ReMapDependencyGraphPointers(&new_graph->second, &new_graph->first);
+  ReMapDependencyGraphPointers(&new_graph->first, &new_graph->second);
+}
+
+void
+ModelRepositoryManager::ReMapDependencyGraphPointers(
+    const std::unordered_map<std::string, std::unique_ptr<DependencyNode>>* ref_nodes,
+    std::unordered_map<std::string, std::unique_ptr<DependencyNode>>* new_nodes) const
+{
+  // lambda to find if the name is in ref_nodes or new_nodes
+  auto find_nodes = [ref_nodes, new_nodes](const std::string& name) {
+    return new_nodes->find(name) == new_nodes->end() ? ref_nodes : new_nodes;
+  };
+  // re-map pointers in new_nodes
+  for (auto& pair : *new_nodes) {
+    // missing_upstreams_
+    std::set<DependencyNode*> new_missing_upstreams;
+    for (auto& node : pair.second->missing_upstreams_) {
+      const std::string& name = node->model_name_;
+      new_missing_upstreams.emplace(find_nodes(name)->at(name).get());
+    }
+    pair.second->missing_upstreams_.swap(new_missing_upstreams);
+    // upstreams_
+    std::unordered_map<DependencyNode*, std::set<int64_t>> new_upstreams;
+    for (auto& p : pair.second->upstreams_) {
+      const std::string& name = p.first->model_name_;
+      new_upstreams.emplace(find_nodes(name)->at(name).get(), p.second);
+    }
+    pair.second->upstreams_.swap(new_upstreams);
+    // downstreams_
+    std::set<DependencyNode*> new_downstreams;
+    for (auto& node : pair.second->downstreams_) {
+      const std::string& name = node->model_name_;
+      new_downstreams.emplace(find_nodes(name)->at(name).get());
+    }
+    pair.second->downstreams_.swap(new_downstreams);
+  }
+}
+
+void
 ModelRepositoryManager::UncheckDownstream(
-    NodeSet* downstreams, NodeSet* updated_nodes)
+    NodeSet* downstreams, NodeSet* updated_nodes) const
 {
   // Mark downstream nodes as unchecked recursively
   for (auto& node : *downstreams) {
@@ -1447,8 +1562,12 @@ ModelRepositoryManager::UncheckDownstream(
 }
 
 bool
-ModelRepositoryManager::ConnectDependencyGraph(DependencyNode* updated_node)
+ModelRepositoryManager::ConnectDependencyGraph(
+    DependencyGraph* graph, DependencyNode* updated_node) const
 {
+  // present nodes and missing nodes of the dependency graph
+  auto& present_nodes = graph->first;
+  auto& missing_nodes = graph->second;
   // Check the node's model config to determine if it depends on other models
   // and if those models are present
   updated_node->upstreams_.clear();
@@ -1458,13 +1577,13 @@ ModelRepositoryManager::ConnectDependencyGraph(DependencyNode* updated_node)
          updated_node->model_config_.ensemble_scheduling().step()) {
       DependencyNode* upstream_node = nullptr;
       const auto& model_name = step.model_name();
-      auto dit = dependency_graph_.find(model_name);
-      if (dit == dependency_graph_.end()) {
-        auto mit = missing_nodes_.find(model_name);
-        if (mit == missing_nodes_.end()) {
+      auto dit = present_nodes.find(model_name);
+      if (dit == present_nodes.end()) {
+        auto mit = missing_nodes.find(model_name);
+        if (mit == missing_nodes.end()) {
           std::unique_ptr<DependencyNode> node(new DependencyNode(model_name));
           updated_node->missing_upstreams_.emplace(node.get());
-          mit = missing_nodes_.emplace(model_name, std::move(node)).first;
+          mit = missing_nodes.emplace(model_name, std::move(node)).first;
         }
         // Add the node to missing node's downstream so that when the missing
         // node is added, the downstreams can be found easily.
@@ -1489,16 +1608,49 @@ ModelRepositoryManager::ConnectDependencyGraph(DependencyNode* updated_node)
 
 Status
 ModelRepositoryManager::GetModelInfo(
-    const std::string& name, ModelInfo** model_info)
+    const ModelInfoMap& model_infos, const std::string& name, ModelInfo** model_info) const
 {
-  const auto itr = infos_.find(name);
-  if (itr == infos_.end()) {
+  const auto itr = model_infos.find(name);
+  if (itr == model_infos.end()) {
     return Status(
         Status::Code::NOT_FOUND, "no configuration for model '" + name + "'");
   }
 
   *model_info = itr->second.get();
   return Status::Success;
+}
+
+void
+ModelRepositoryManager::CopyModelInfos(ModelInfoMap* new_infos) const
+{
+  new_infos->clear();
+  for (auto& pair : infos_) {
+    new_infos->emplace(pair.first, std::make_unique<ModelInfo>(*pair.second));
+  }
+}
+
+Status
+ModelRepositoryManager::InTransit(const DependencyNode* dependency_node) const
+{
+  if (dependency_node->in_transition_) {
+    return Status(Status::Code::INVALID_ARG, "a related model '" + dependency_node->model_name_ + "' to a load/unload request is currently loading or unloading");
+  }
+  return Status::Success;
+}
+
+void
+ModelRepositoryManager::UpdateTransition(const DependencyGraph& graph, const std::set<std::string>& names, bool transition) const
+{
+  for (auto& name : names) {
+    auto it = graph.first.find(name);
+    if (it != graph.first.end()) {
+      it->second->in_transition_ = transition;
+    }
+    it = graph.second.find(name);
+    if (it != graph.second.end()) {
+      it->second->in_transition_ = transition;
+    }
+  }
 }
 
 std::pair<ModelRepositoryManager::NodeSet, ModelRepositoryManager::NodeSet>
@@ -1508,7 +1660,7 @@ ModelRepositoryManager::ModelsToLoadUnload(const NodeSet& loaded_models)
   std::pair<NodeSet, NodeSet> res;
   // first call to this function
   if (loaded_models.empty()) {
-    for (auto& pair : dependency_graph_) {
+    for (auto& pair : dependency_graph_.first) {
       auto node = pair.second.get();
       // only care about nodes that are affected by the update
       if (!node->checked_) {

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -482,12 +482,18 @@ ModelRepositoryManager::PollAndUpdateInternal(bool* all_models_polled)
     UpdateTransition(dependency_graph_, added, false);
     UpdateTransition(dependency_graph_, deleted, false);
     UpdateTransition(dependency_graph_, modified, false);
-    // save checked_
+    // save state changes
     for (auto& name : added) {
+      infos_.at(name)->mtime_nsec_ = new_infos.at(name)->mtime_nsec_;
+      dependency_graph_.first.at(name)->status_ = new_dependency_graph.first.at(name)->status_;
       dependency_graph_.first.at(name)->checked_ = new_dependency_graph.first.at(name)->checked_;
+      dependency_graph_.first.at(name)->loaded_versions_ = new_dependency_graph.first.at(name)->loaded_versions_;
     }
     for (auto& name : modified) {
+      infos_.at(name)->mtime_nsec_ = new_infos.at(name)->mtime_nsec_;
+      dependency_graph_.first.at(name)->status_ = new_dependency_graph.first.at(name)->status_;
       dependency_graph_.first.at(name)->checked_ = new_dependency_graph.first.at(name)->checked_;
+      dependency_graph_.first.at(name)->loaded_versions_ = new_dependency_graph.first.at(name)->loaded_versions_;
     }
   }
 
@@ -758,12 +764,18 @@ ModelRepositoryManager::LoadUnloadModels(
     UpdateTransition(dependency_graph_, deleted, false);
     UpdateTransition(dependency_graph_, modified, false);
     UpdateTransition(dependency_graph_, deleted_dependents, false);
-    // save checked_
+    // save state changes
     for (auto& name : added) {
+      infos_.at(name)->mtime_nsec_ = new_infos.at(name)->mtime_nsec_;
+      dependency_graph_.first.at(name)->status_ = new_dependency_graph.first.at(name)->status_;
       dependency_graph_.first.at(name)->checked_ = new_dependency_graph.first.at(name)->checked_;
+      dependency_graph_.first.at(name)->loaded_versions_ = new_dependency_graph.first.at(name)->loaded_versions_;
     }
     for (auto& name : modified) {
+      infos_.at(name)->mtime_nsec_ = new_infos.at(name)->mtime_nsec_;
+      dependency_graph_.first.at(name)->status_ = new_dependency_graph.first.at(name)->status_;
       dependency_graph_.first.at(name)->checked_ = new_dependency_graph.first.at(name)->checked_;
+      dependency_graph_.first.at(name)->loaded_versions_ = new_dependency_graph.first.at(name)->loaded_versions_;
     }
   }
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -183,7 +183,7 @@ class ModelRepositoryManager {
   /// \return error status.
   Status GetModel(
       const std::string& model_name, const int64_t model_version,
-      std::shared_ptr<Model>* model);
+      std::shared_ptr<Model>* model) const;
 
   // Register model repository path.
   /// \param repository Path to model repository.
@@ -273,7 +273,7 @@ class ModelRepositoryManager {
   /// \param infos The model infos.
   /// \param dependency_graph The dependency graph.
   /// \return The status of the model loads.
-  std::map<std::string, Status> LoadModelByDependency();
+  std::map<std::string, Status> LoadModelByDependency(const ModelInfoMap& infos, const DependencyGraph& dependency_graph) const;
 
   /// Helper function to update the dependency graph based on the poll result
   /// \param added The names of the models added to the repository.
@@ -345,14 +345,14 @@ class ModelRepositoryManager {
   /// Unloaded models will be represented as models with no loaded versions.
   /// \return A pair of node set containing models to be loaded and models to be
   /// unloaded for the next iteration.
-  std::pair<NodeSet, NodeSet> ModelsToLoadUnload(const NodeSet& loaded_models);
+  std::pair<NodeSet, NodeSet> ModelsToLoadUnload(const DependencyGraph& dependency_graph, const NodeSet& loaded_models) const;
 
   /// Check if the node is ready for the next iteration. A node is ready if the
   /// node is invalid (containing invalid model config or its depdencies failed
   /// to load) or all of its dependencies are satisfied.
   /// \param node The node to be checked.
   /// \return True if the node is ready. False otherwise.
-  bool CheckNode(DependencyNode* node);
+  bool CheckNode(DependencyNode* node) const;
 
   Status CircularcyCheck(
       DependencyNode* current_node, const DependencyNode* start_node) const;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -302,6 +302,10 @@ class ModelRepositoryManager {
   /// to new nodes.
   /// The function search for matching pointers in the new_nodes first, if not
   /// found, then the matching pointer must be in the ref_nodes.
+  /// The dependency graph is split into present nodes and missing nodes,
+  /// pointers from the missing nodes can reference into present nodes and vice
+  /// versa. Thus, ref_nodes and new_nodes must come from the same dependency
+  /// graph, and must not be any arbitrary nodes.
   /// \param ref_nodes The reference nodes for pointers not in new_nodes
   /// \param new_nodes The new nodes to be re-mapped
   void ReMapDependencyGraphPointers(
@@ -347,7 +351,7 @@ class ModelRepositoryManager {
   /// \param names The name of models to be in transition
   /// \param transition True for loading, False for unloading
   void UpdateTransition(
-      const DependencyGraph& graph, const std::set<std::string>& names,
+      DependencyGraph& graph, const std::set<std::string>& names,
       bool transition) const;
 
   /// Write updated state into the main model infos and dependency graph
@@ -387,8 +391,10 @@ class ModelRepositoryManager {
   const bool model_control_enabled_;
   const double min_compute_capability_;
 
-  std::mutex poll_mu_;
+  // Protects all the data structures defined in this class
+  std::mutex mu_;
 
+  // FIXME: These two objects and their functions do not belong here DLIS-4303
   ModelInfoMap infos_;
   DependencyGraph dependency_graph_;
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -74,7 +74,8 @@ class ModelRepositoryManager {
   /// repository manager.
   struct DependencyNode {
     DependencyNode(const std::string& model_name)
-        : model_name_(model_name), status_(Status::Success), checked_(false), in_transition_(false)
+        : model_name_(model_name), status_(Status::Success), checked_(false),
+          in_transition_(false)
     {
     }
 
@@ -207,8 +208,9 @@ class ModelRepositoryManager {
       std::unordered_map<std::string, std::unique_ptr<ModelInfo>>;
   // Dependency between models <present nodes, missing nodes>, where each of
   // the two nodes maps model name -> DependencyNode
-  using DependencyGraph =
-      std::pair<std::unordered_map<std::string, std::unique_ptr<DependencyNode>>, std::unordered_map<std::string, std::unique_ptr<DependencyNode>>>;
+  using DependencyGraph = std::pair<
+      std::unordered_map<std::string, std::unique_ptr<DependencyNode>>,
+      std::unordered_map<std::string, std::unique_ptr<DependencyNode>>>;
 
   // Set of DependencyNode
   using NodeSet = std::set<DependencyNode*>;
@@ -273,7 +275,8 @@ class ModelRepositoryManager {
   /// \param infos The model infos.
   /// \param dependency_graph The dependency graph.
   /// \return The status of the model loads.
-  std::map<std::string, Status> LoadModelByDependency(const ModelInfoMap& infos, const DependencyGraph& dependency_graph) const;
+  std::map<std::string, Status> LoadModelByDependency(
+      const ModelInfoMap& infos, const DependencyGraph& dependency_graph) const;
 
   /// Helper function to update the dependency graph based on the poll result
   /// \param added The names of the models added to the repository.
@@ -287,8 +290,9 @@ class ModelRepositoryManager {
   /// \return The error status.
   Status UpdateDependencyGraph(
       const std::set<std::string>& added, const std::set<std::string>& deleted,
-      const std::set<std::string>& modified, const ModelInfoMap& model_infos, 
-      DependencyGraph* updated_graph, std::set<std::string>* deleted_dependents = nullptr) const;
+      const std::set<std::string>& modified, const ModelInfoMap& model_infos,
+      DependencyGraph* updated_graph,
+      std::set<std::string>* deleted_dependents = nullptr) const;
 
   /// Helper function to deep copy the dependency graph
   /// \param new_graph The new graph to be cleared and copied into
@@ -301,8 +305,10 @@ class ModelRepositoryManager {
   /// \param ref_nodes The reference nodes for pointers not in new_nodes
   /// \param new_nodes The new nodes to be re-mapped
   void ReMapDependencyGraphPointers(
-      const std::unordered_map<std::string, std::unique_ptr<DependencyNode>>* ref_nodes,
-      std::unordered_map<std::string, std::unique_ptr<DependencyNode>>* new_nodes) const;
+      const std::unordered_map<std::string, std::unique_ptr<DependencyNode>>*
+          ref_nodes,
+      std::unordered_map<std::string, std::unique_ptr<DependencyNode>>*
+          new_nodes) const;
 
   /// Helper function to uncheck the nodes because the model that they depends
   /// on has changed. The unchecked nodes will be validated again.
@@ -315,14 +321,17 @@ class ModelRepositoryManager {
   /// \param graph The dependency graph.
   /// \param updated_node The node that is newly added or modified.
   /// \return True if the node represents an ensemble model. False otherwise.
-  bool ConnectDependencyGraph(DependencyGraph* graph, DependencyNode* updated_node) const;
+  bool ConnectDependencyGraph(
+      DependencyGraph* graph, DependencyNode* updated_node) const;
 
   /// Get the model info for a named model.
   /// \param model_infos Map of model names to its infomation.
   /// \param name The model name.
   /// \param model_info Returns the model information.
   /// \return OK if found, NOT_FOUND otherwise.
-  Status GetModelInfo(const ModelInfoMap& model_infos, const std::string& name, ModelInfo** model_info) const;
+  Status GetModelInfo(
+      const ModelInfoMap& model_infos, const std::string& name,
+      ModelInfo** model_info) const;
 
   /// Helper function to deep copy the model infos
   /// \param new_infos The new model infos to be cleared and copied into
@@ -337,7 +346,17 @@ class ModelRepositoryManager {
   /// \param graph The dependency graph
   /// \param names The name of models to be in transition
   /// \param transition True for loading, False for unloading
-  void UpdateTransition(const DependencyGraph& graph, const std::set<std::string>& names, bool transition) const;
+  void UpdateTransition(
+      const DependencyGraph& graph, const std::set<std::string>& names,
+      bool transition) const;
+
+  /// Write updated state into the main model infos and dependency graph
+  /// \param names The name of models updated
+  /// \param infos Model infos with the update state
+  /// \param graph Dependency graph with the update state
+  void UpdateState(
+      const std::set<std::string>& names, const ModelInfoMap& infos,
+      const DependencyGraph& graph);
 
   /// Get the models to be loaded / unloaded based on the model loaded in
   /// previous iteration.
@@ -345,7 +364,9 @@ class ModelRepositoryManager {
   /// Unloaded models will be represented as models with no loaded versions.
   /// \return A pair of node set containing models to be loaded and models to be
   /// unloaded for the next iteration.
-  std::pair<NodeSet, NodeSet> ModelsToLoadUnload(const DependencyGraph& dependency_graph, const NodeSet& loaded_models) const;
+  std::pair<NodeSet, NodeSet> ModelsToLoadUnload(
+      const DependencyGraph& dependency_graph,
+      const NodeSet& loaded_models) const;
 
   /// Check if the node is ready for the next iteration. A node is ready if the
   /// node is invalid (containing invalid model config or its depdencies failed
@@ -370,11 +391,6 @@ class ModelRepositoryManager {
 
   ModelInfoMap infos_;
   DependencyGraph dependency_graph_;
-
-  //std::unordered_map<std::string, std::unique_ptr<DependencyNode>>
-  //    dependency_graph_;
-  //std::unordered_map<std::string, std::unique_ptr<DependencyNode>>
-  //    missing_nodes_;
 
   // Mappings from (overridden) model names to a pair of their repository and
   // absolute path

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -207,7 +207,12 @@ class ModelRepositoryManager {
   using ModelInfoMap =
       std::unordered_map<std::string, std::unique_ptr<ModelInfo>>;
   // Dependency between models <present nodes, missing nodes>, where each of
-  // the two nodes maps model name -> DependencyNode
+  // the two nodes maps model name -> DependencyNode.
+  // Nodes from both present and missing nodes forms the complete dependency
+  // graph. Present nodes are models that are loaded or will be loaded. Missing
+  // nodes are models that need to be loaded, but are currently missing.
+  // Missing nodes can move into present nodes during graph operation as they
+  // are discovered.
   using DependencyGraph = std::pair<
       std::unordered_map<std::string, std::unique_ptr<DependencyNode>>,
       std::unordered_map<std::string, std::unique_ptr<DependencyNode>>>;
@@ -341,17 +346,12 @@ class ModelRepositoryManager {
   /// \param new_infos The new model infos to be cleared and copied into
   void CopyModelInfos(ModelInfoMap* new_infos) const;
 
-  /// Check if a dependency node (model) is currently loading/unloading
-  /// \param dependency_node The dependency node to check
-  /// \return OK if NOT in transit, INVALID_ARG if in transit
-  Status InTransit(const DependencyNode* dependency_node) const;
-
   /// Mark the nodes (model) in dependency graph to currently loading/unloading
   /// \param graph The dependency graph
   /// \param names The name of models to be in transition
   /// \param transition True for loading, False for unloading
   void UpdateTransition(
-      DependencyGraph& graph, const std::set<std::string>& names,
+      DependencyGraph* graph, const std::set<std::string>& names,
       bool transition) const;
 
   /// Write updated state into the main model infos and dependency graph


### PR DESCRIPTION
Refactored model_repository_manager to allow parallel loading of models.
Server PR: https://github.com/triton-inference-server/server/pull/5032