### PR TITLE
Remove naming collision for GetObject

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -25,6 +25,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#ifdef _WIN32
+// Remove GetObject definition from windows.h, which prevents calls to
+// RapidJSON's GetObject.
+// https://github.com/Tencent/rapidjson/issues/1448
+#undef GetObject
+#endif  // _WIN32
+
 #include <string>
 #include "google/protobuf/message.h"
 #include "status.h"

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #ifdef _WIN32
-// Remove GetObject definition from windows.h, which prevents calls to
-// RapidJSON's GetObject.
+// Remove GetObject definition from windows.h, which can cause
+// a naming collision when GetObject is called.
 // https://github.com/Tencent/rapidjson/issues/1448
 #undef GetObject
 #endif  // _WIN32


### PR DESCRIPTION
Non-Docker Windows compilation fails on some machines due to a preprocessor macro for GetObject redefining GetObject to GetObjectA/GetObjectW in windows.h.
Undefining the preprocessor macro resolves this compilation failure for Windows machines.

See issue thread here: https://github.com/Tencent/rapidjson/issues/1448

This fix was merged to the 22.11 branch. This is for the main branch.