### PR TITLE
Add tritoncache APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message("Using MSVC as compiler, default target on Windows 10. "
 		  "If the target system is not Windows 10, please update _WIN32_WINNT "
 		  "to corresponding value.")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
   target_compile_options(
     triton-core-serverstub
     PRIVATE

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -129,9 +129,6 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
 TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheEvict(
-    TRITONCACHE_Cache* cache);
-
 /* CacheEntry Lifetime Management */
 
 // TODO: Add API descriptions

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -157,15 +157,22 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
 
 // TODO: Add API descriptions
 
-// Sets items in entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetItems(
-    TRITONCACHE_CacheEntry* entry, void* items, size_t* byte_sizes,
-    size_t num_items);
+// Get number of items in entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
+    TRITONCACHE_CacheEntry* entry, size_t* count);
 
-// Gets items from entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItems(
-    TRITONCACHE_CacheEntry* entry, void** items, size_t** byte_sizes,
-    size_t* num_items);
+// Gets the index'th item from entry where 0 <= index < count where
+// 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItem(
+    TRITONCACHE_CacheEntry* entry, size_t index, void** item, size_t* byte_size);
+
+// Adds item to entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
+    TRITONCACHE_CacheEntry* entry, void* item, size_t byte_size);
+
+/* Not currently used, may be added in the future for grouping
+   cache entries for actions like evicting all entries associated
+   with certain model, tags, etc.
 
 // Sets tags in entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetTags(
@@ -174,6 +181,8 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetTags(
 // Gets tags from entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryTags(
     TRITONCACHE_CacheEntry* entry, char*** tags, size_t* num_tags);
+
+*/
 
 #ifdef __cplusplus
 }

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -55,6 +55,7 @@ extern "C" {
 #endif
 
 struct TRITONCACHE_Cache;
+struct TRITONCACHE_CacheEntry;
 
 ///
 /// TRITONCACHE API Version
@@ -98,6 +99,8 @@ struct TRITONCACHE_Cache;
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
     uint32_t* major, uint32_t* minor);
 
+/* Cache Lifetime Management */
+
 /// Create a new cache object. The caller takes ownership of the
 /// TRITONCACHE_Cache object and must call
 /// TRITONCACHE_CacheDelete to release the object.
@@ -115,18 +118,62 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
     TRITONCACHE_Cache* cache);
 
-// TODO
+/* Cache Usage */
+
+// TODO: Add API descriptions
+
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
-    TRITONCACHE_Cache* cache);
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
-// TODO
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, const char* key, void** entries, size_t** sizes,
-    size_t* num_entries);
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry** entry);
 
-// TODO
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEvict(
     TRITONCACHE_Cache* cache);
+
+/* CacheEntry Lifetime Management */
+
+/* Cache Entry implementation example
+**
+** TODO: Move to tritoncache.cc or similar
+**
+** struct CacheEntry {
+**   void*  items;         // blobs of data to insert or retrieve with cache
+**   size_t* byte_sizes;   // size of each item in items
+**   size_t  num_items;    // number of items and byte_sizes
+**   char**  tags;         // (optional) tags to associate entry, groups, etc.
+**   size_t  num_tags;     // (optional) number of tags provided
+** }
+*/
+
+// TODO: Add API descriptions
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
+    TRITONCACHE_CacheEntry** entry);
+
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
+    TRITONCACHE_CacheEntry* entry);
+
+/* CacheEntry Field Management */
+
+// TODO: Add API descriptions
+
+// Sets items in entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetItems(
+    TRITONCACHE_CacheEntry* entry, void* items, size_t* byte_sizes,
+    size_t num_items);
+
+// Gets items from entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItems(
+    TRITONCACHE_CacheEntry* entry, void** items, size_t** byte_sizes,
+    size_t* num_items);
+
+// Sets tags in entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetTags(
+    TRITONCACHE_CacheEntry* entry, char** tags, size_t num_tags);
+
+// Gets tags from entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryTags(
+    TRITONCACHE_CacheEntry* entry, char*** tags, size_t* num_tags);
 
 #ifdef __cplusplus
 }

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -100,7 +100,9 @@ struct TRITONCACHE_CacheEntryItem;
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
     uint32_t* major, uint32_t* minor);
 
-/* Cache Lifetime Management */
+///
+/// Cache Lifetime Management
+///
 
 /// Create a new cache object. The caller takes ownership of the
 /// TRITONCACHE_Cache object and must call
@@ -119,7 +121,9 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
 TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
     TRITONCACHE_Cache* cache);
 
-/* Cache Usage */
+///
+/// Cache Usage
+///
 
 // TODO: Add API descriptions
 
@@ -129,18 +133,19 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
 TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
-/* CacheEntry Lifetime Management */
+///
+/// CacheEntry Lifetime Management
+///
 
-// TODO: Add API descriptions
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
     TRITONCACHE_CacheEntry** entry);
 
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
     TRITONCACHE_CacheEntry* entry);
 
-/* CacheEntry Field Management */
-
-// TODO: Add API descriptions
+///
+/// CacheEntry Field Management
+///
 
 // Get number of items in entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
@@ -156,16 +161,19 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryGetItem(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, TRITONCACHE_CacheEntryItem* item);
 
-/* CacheEntryItem Lifetime Management */
+///
+/// CacheEntryItem Lifetime Management
+///
 
-// TODO: flesh out
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemNew(
     TRITONCACHE_CacheEntryItem** item);
 
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
     TRITONCACHE_CacheEntryItem* item);
 
-/* CacheEntryItem Field Management */
+///
+/// CacheEntryItem Field Management
+///
 
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
     TRITONCACHE_CacheEntryItem* item, size_t* count);
@@ -179,7 +187,8 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
     size_t* byte_size);
 
-/* Not currently used, may be added in the future for grouping
+/*
+   Not currently used, may be added in the future for grouping
    cache entries for actions like evicting all entries associated
    with certain model, tags, etc.
 
@@ -190,7 +199,6 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetTags(
 // Gets tags from entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryTags(
     TRITONCACHE_CacheEntry* entry, char*** tags, size_t* num_tags);
-
 */
 
 #ifdef __cplusplus

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -164,11 +164,11 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
 // Gets the index'th item from entry where 0 <= index < count where
 // 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItem(
-    TRITONCACHE_CacheEntry* entry, size_t index, void** item, size_t* byte_size);
+    TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size);
 
 // Adds item to entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
-    TRITONCACHE_CacheEntry* entry, void* item, size_t byte_size);
+    TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size);
 
 /* Not currently used, may be added in the future for grouping
    cache entries for actions like evicting all entries associated

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -158,6 +158,28 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItem(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size);
 
+/*
+
+// TODO : May benefit from another level of indirection, one less copy
+          by passing list of pointers rather than forming contiguous buffer
+
+// Get number of buffers in item
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
+    TRITONCACHE_CacheEntryItem* item, size_t* count);
+
+// Gets the index'th buffer from item where 0 <= index < count where
+// 'count' is the value returned by TRITONCACHE_CacheItemBufferCount
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBuffer(
+    TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
+    size_t* byte_size);
+
+// Adds item to entry
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
+    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size);
+
+*/
+
+
 /* Not currently used, may be added in the future for grouping
    cache entries for actions like evicting all entries associated
    with certain model, tags, etc.

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -121,7 +121,7 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
 
 // TODO
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, char* key, void** entries, size_t** sizes,
+    TRITONCACHE_Cache* cache, const char* key, void** entries, size_t** sizes,
     size_t* num_entries);
 
 // TODO

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -164,7 +164,8 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
 // Gets the index'th item from entry where 0 <= index < count where
 // 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItem(
-    TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size);
+    TRITONCACHE_CacheEntry* entry, size_t index, void** base,
+    size_t* byte_size);
 
 // Adds item to entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
@@ -185,5 +186,5 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryTags(
 */
 
 #ifdef __cplusplus
-}
+}  // extern C
 #endif

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -101,57 +101,40 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
     uint32_t* major, uint32_t* minor);
 
 ///
-/// CacheEntry Lifetime Management
-///
-
-// TODO: Currently not using EntryNew/EntryDelete APIs at all. Instead
-//       we are creating an Entry in TritonCacheManager and passing an opaque
-//       pointer to it for cache to add Items/Buffers to over C APIs. See
-//       TritonCache::Lookup as an example. This ownership flow should be
-//       clarified/cleaned up.
-
-/// Create a new cache entry object. The caller takes ownership of the
-/// TRITONCACHE_CacheEntry object and must call
-/// TRITONCACHE_CacheEntryDelete to release the object.
-///
-/// \param entry Returns the new cache entry object.
-/// \return a TRITONSERVER_Error indicating success or failure.
-
-// TODO: Not currently using this API. See TritonCache Lookup/Insert
-// for explanation. Should clean up / clarify the expected ownerships here.
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
-    TRITONCACHE_CacheEntry** entry);
-
-/// Delete a cache entry object.
-///
-/// \param entry The cache entry object to delete.
-/// \return a TRITONSERVER_Error indicating success or failure.
-
-// TODO: Not currently using this API. See TritonCache Lookup/Insert
-// for explanation. Should clean up / clarify the expected ownerships here.
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
-    TRITONCACHE_CacheEntry* entry);
-
-///
 /// CacheEntry Field Management
 ///
 
-// TODO: Proper API descriptions, lifetimes, copies, etc.
-
-// Get number of items in entry
+/// Get the number of items available in the entry.
+///
+/// \param entry The CacheEntry object to query.
+/// \param count Returns the number of items in entry.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
     TRITONCACHE_CacheEntry* entry, size_t* count);
 
-// Adds item to entry
+/// Adds item to the entry.
+///
+/// TODO: ownership/lifetime
+///
+/// \param entry The CacheEntry object to add item to.
+/// \param item The CacheEntryItem being added to entry.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, TRITONCACHE_CacheEntryItem* item);
 
-// Gets item at index from entry where 0 <= index < count and
-// 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
+/// Gets the item at index from entry.
+///
+/// The caller does not own the returned item and must not modify or delete it.
+/// The lifetime of the item extends until 'entry' or 'item' is deleted.
+///
+/// \param entry The CacheEntry object.
+/// \param index The index of the item, must be 0 <= index < count, where
+/// 'count' is the value returned by TRITONCACHE_CacheEntryItemCount.
+/// \param item The item at index that is returned.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryGetItem(
     TRITONCACHE_CacheEntry* entry, size_t index,
     TRITONCACHE_CacheEntryItem** item);
-
 
 ///
 /// CacheEntryItem Lifetime Management
@@ -173,6 +156,8 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemNew(
 
 // TODO: Not currently using this API. See TritonCache Lookup/Insert
 // for explanation. Should clean up / clarify the expected ownerships here.
+// However, should keep this API in case someone creates an item without
+// adding it to a entry / transferring ownership, to allow manual cleanup.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
     TRITONCACHE_CacheEntryItem* item);
 
@@ -189,16 +174,15 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
 // Adds buffer of specified memory_type/id to item. Only CPU memory supported
 // currently.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
-    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size,
-    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id);
+    TRITONCACHE_CacheEntryItem* item, const void* base,
+    TRITONSERVER_BufferAttributes* buffer_attributes);
 
 // Gets buffer at index from item where 0 <= index < count and
 // 'count' is the value returned by TRITONCACHE_CacheEntryItemBufferCount
 // and returns the memory_type info of the buffer
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
-    size_t* byte_size, TRITONSERVER_MemoryType* memory_type,
-    int64_t* memory_type_id);
+    TRITONSERVER_BufferAttributes* buffer_attributes);
 
 ///
 /// The following functions can be implemented by a cache. Functions

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -108,43 +108,30 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
 /// \param cache Returns the new cache object.
 /// \param config The config options to initialize the cache with.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
     TRITONCACHE_Cache** cache, TRITONSERVER_Message* config);
 
 /// Delete a cache object.
 ///
 /// \param cache The cache object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
     TRITONCACHE_Cache* cache);
 
 /* Cache Usage */
 
 // TODO: Add API descriptions
 
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEvict(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheEvict(
     TRITONCACHE_Cache* cache);
 
 /* CacheEntry Lifetime Management */
-
-/* Cache Entry implementation example
-**
-** TODO: Move to tritoncache.cc or similar
-**
-** struct CacheEntry {
-**   void*  items;         // blobs of data to insert or retrieve with cache
-**   size_t* byte_sizes;   // size of each item in items
-**   size_t  num_items;    // number of items and byte_sizes
-**   char**  tags;         // (optional) tags to associate entry, groups, etc.
-**   size_t  num_tags;     // (optional) number of tags provided
-** }
-*/
 
 // TODO: Add API descriptions
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -126,7 +126,7 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry** entry);
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEvict(
     TRITONCACHE_Cache* cache);

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -171,15 +171,19 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
     TRITONCACHE_CacheEntryItem* item, size_t* count);
 
-// Adds buffer to item
+// Adds buffer of specified memory_type/id to item. Only CPU memory supported
+// currently.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
-    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size);
+    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size,
+    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id);
 
 // Gets buffer at index from item where 0 <= index < count and
 // 'count' is the value returned by TRITONCACHE_CacheEntryItemBufferCount
+// and returns the memory_type info of the buffer
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
-    size_t* byte_size);
+    size_t* byte_size, TRITONSERVER_MemoryType* memory_type,
+    int64_t* memory_type_id);
 
 ///
 /// The following functions can be implemented by a cache. Functions

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -56,6 +56,7 @@ extern "C" {
 
 struct TRITONCACHE_Cache;
 struct TRITONCACHE_CacheEntry;
+struct TRITONCACHE_CacheEntryItem;
 
 ///
 /// TRITONCACHE API Version
@@ -150,35 +151,36 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
 
 // Gets the index'th item from entry where 0 <= index < count where
 // 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItem(
-    TRITONCACHE_CacheEntry* entry, size_t index, void** base,
-    size_t* byte_size);
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryGetItem(
+    TRITONCACHE_CacheEntry* entry, size_t index,
+    TRITONCACHE_CacheEntryItem** item);
 
 // Adds item to entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
-    TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size);
+    TRITONCACHE_CacheEntry* entry, TRITONCACHE_CacheEntryItem* item);
 
-/*
+/* CacheEntryItem Lifetime Management */
 
-// TODO : May benefit from another level of indirection, one less copy
-          by passing list of pointers rather than forming contiguous buffer
+// TODO: flesh out
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemNew(
+    TRITONCACHE_CacheEntryItem** item);
 
-// Get number of buffers in item
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
+    TRITONCACHE_CacheEntryItem* item);
+
+/* CacheEntryItem Field Management */
+
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
     TRITONCACHE_CacheEntryItem* item, size_t* count);
 
-// Gets the index'th buffer from item where 0 <= index < count where
-// 'count' is the value returned by TRITONCACHE_CacheItemBufferCount
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBuffer(
-    TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
-    size_t* byte_size);
-
-// Adds item to entry
+// Adds buffer to item
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
     TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size);
 
-*/
-
+// Gets buffer at index from item
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
+    TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
+    size_t* byte_size);
 
 /* Not currently used, may be added in the future for grouping
    cache entries for actions like evicting all entries associated

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -104,12 +104,21 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
 /// CacheEntry Lifetime Management
 ///
 
+// TODO: Currently not using EntryNew/EntryDelete APIs at all. Instead
+//       we are creating an Entry in TritonCacheManager and passing an opaque
+//       pointer to it for cache to add Items/Buffers to over C APIs. See
+//       TritonCache::Lookup as an example. This ownership flow should be
+//       clarified/cleaned up.
+
 /// Create a new cache entry object. The caller takes ownership of the
 /// TRITONCACHE_CacheEntry object and must call
 /// TRITONCACHE_CacheEntryDelete to release the object.
 ///
 /// \param entry Returns the new cache entry object.
 /// \return a TRITONSERVER_Error indicating success or failure.
+
+// TODO: Not currently using this API. See TritonCache Lookup/Insert
+// for explanation. Should clean up / clarify the expected ownerships here.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
     TRITONCACHE_CacheEntry** entry);
 
@@ -117,6 +126,9 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
 ///
 /// \param entry The cache entry object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
+
+// TODO: Not currently using this API. See TritonCache Lookup/Insert
+// for explanation. Should clean up / clarify the expected ownerships here.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
     TRITONCACHE_CacheEntry* entry);
 
@@ -158,6 +170,9 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemNew(
 ///
 /// \param item The cache entry item object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
+
+// TODO: Not currently using this API. See TritonCache Lookup/Insert
+// for explanation. Should clean up / clarify the expected ownerships here.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
     TRITONCACHE_CacheEntryItem* item);
 

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -101,81 +101,6 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
     uint32_t* major, uint32_t* minor);
 
 ///
-/// Cache Lifetime Management
-///
-
-/// Create a new cache object. The caller takes ownership of the
-/// TRITONCACHE_Cache object and must call
-/// TRITONCACHE_CacheDelete to release the object.
-///
-/// This API is implemented by the user-provided cache implementation,
-/// so specific details will be found within the cache implementation.
-///
-/// \param cache Returns the new cache object.
-/// \param config The config options to initialize the cache with.
-/// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
-    TRITONCACHE_Cache** cache, TRITONSERVER_Message* config);
-
-/// Delete a cache object.
-///
-/// This API is implemented by the user-provided cache implementation,
-/// so specific details will be found within the cache implementation.
-///
-/// \param cache The cache object to delete.
-/// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
-    TRITONCACHE_Cache* cache);
-
-///
-/// Cache Usage
-///
-
-/// Inserts entry into cache at specified key, unless key already exists.
-///
-/// This API is implemented by the user-provided cache implementation,
-/// so specific details will be found within the cache implementation.
-///
-/// \param cache The object that is used to communicate with the cache
-///              implementation through a shared library.
-/// \param entry The entry to be inserted into the cache.
-/// \return a TRITONSERVER_Error indicating success or failure.
-///         Specific errors will be up the cache implementation, but general
-///         error best practices that should be followed are as follows:
-///         - TRITONSERVER_ERROR_INVALID_ARG
-///           - bad argument passed, nullptr, etc.
-///         - TRITONSERVER_ERROR_ALREADY_EXISTS
-///           - key already exists and will not be inserted again
-///         - TRITONSERVER_ERROR_INTERNAL
-///           - internal errors
-///         - nullptr
-///           - success
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
-
-/// Retrieves entry from cache at specified key, if key exists.
-///
-/// This API is implemented by the user-provided cache implementation,
-/// so specific details will be found within the cache implementation.
-///
-/// \param cache The object that is used to communicate with the cache
-///              implementation through a shared library.
-/// \param entry The entry to be retrieved from the cache.
-/// \return a TRITONSERVER_Error indicating success or failure.
-///         Specific errors will be up the cache implementation, but general
-///         error best practices that should be followed are as follows:
-///         - TRITONSERVER_ERROR_INVALID_ARG
-///           - bad argument passed, nullptr, etc.
-///         - TRITONSERVER_ERROR_NOT_FOUND
-///           - key not found in cache
-///         - TRITONSERVER_ERROR_INTERNAL
-///           - other internal errors
-///         - nullptr
-///           - success
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
-
-///
 /// CacheEntry Lifetime Management
 ///
 
@@ -255,6 +180,95 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
     size_t* byte_size);
+
+///
+/// The following functions can be implemented by a cache. Functions
+/// indicated as required must be implemented or the cache will fail
+/// to load.
+///
+
+/// Create a new cache object.
+///
+/// This function is required to be implemented by the cache.
+///
+/// The caller takes ownership of the
+/// TRITONCACHE_Cache object and must call
+/// TRITONCACHE_CacheDelete to release the object.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache Returns the new cache object.
+/// \param config The config options to initialize the cache with.
+///               This will be passed as-is to the cache implementation, so
+///               the expected format and parsing is up to the cache as well.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
+    TRITONCACHE_Cache** cache, const char* config);
+
+/// Delete a cache object.
+///
+/// This function is required to be implemented by the cache.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache The cache object to delete.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
+    TRITONCACHE_Cache* cache);
+
+/// Inserts entry into cache at specified key, unless key already exists.
+///
+/// This function is required to be implemented by the cache.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache The object that is used to communicate with the cache
+///              implementation through a shared library.
+/// \param key The key used to access the cache. Generally, this is some
+///            unique value or hash representing the entry to avoid collisions.
+/// \param entry The entry to be inserted into the cache.
+/// \return a TRITONSERVER_Error indicating success or failure.
+///         Specific errors will be up the cache implementation, but general
+///         error best practices that should be followed are as follows:
+///         - TRITONSERVER_ERROR_INVALID_ARG
+///           - bad argument passed, nullptr, etc.
+///         - TRITONSERVER_ERROR_ALREADY_EXISTS
+///           - key already exists and will not be inserted again
+///         - TRITONSERVER_ERROR_INTERNAL
+///           - internal errors
+///         - nullptr
+///           - success
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
+
+/// Retrieves entry from cache at specified key, if key exists.
+///
+/// This function is required to be implemented by the cache.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache The object that is used to communicate with the cache
+///              implementation through a shared library.
+/// \param key The key used to access the cache. Generally, this is some
+///            unique value or hash representing the entry to avoid collisions.
+/// \param entry The entry to be retrieved from the cache.
+/// \return a TRITONSERVER_Error indicating success or failure.
+///         Specific errors will be up the cache implementation, but general
+///         error best practices that should be followed are as follows:
+///         - TRITONSERVER_ERROR_INVALID_ARG
+///           - bad argument passed, nullptr, etc.
+///         - TRITONSERVER_ERROR_NOT_FOUND
+///           - key not found in cache
+///         - TRITONSERVER_ERROR_INTERNAL
+///           - other internal errors
+///         - nullptr
+///           - success
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
 #ifdef __cplusplus
 }  // extern C

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -206,7 +206,7 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
 ///               This will be passed as-is to the cache implementation, so
 ///               the expected format and parsing is up to the cache as well.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInitialize(
     TRITONCACHE_Cache** cache, const char* config);
 
 /// Delete a cache object.
@@ -218,7 +218,7 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
 ///
 /// \param cache The cache object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
+TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheFinalize(
     TRITONCACHE_Cache* cache);
 
 /// Inserts entry into cache at specified key, unless key already exists.

--- a/include/triton/core/tritoncache.h
+++ b/include/triton/core/tritoncache.h
@@ -108,6 +108,9 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_ApiVersion(
 /// TRITONCACHE_Cache object and must call
 /// TRITONCACHE_CacheDelete to release the object.
 ///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
 /// \param cache Returns the new cache object.
 /// \param config The config options to initialize the cache with.
 /// \return a TRITONSERVER_Error indicating success or failure.
@@ -115,6 +118,9 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheNew(
     TRITONCACHE_Cache** cache, TRITONSERVER_Message* config);
 
 /// Delete a cache object.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
 ///
 /// \param cache The cache object to delete.
 /// \return a TRITONSERVER_Error indicating success or failure.
@@ -125,11 +131,47 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheDelete(
 /// Cache Usage
 ///
 
-// TODO: Add API descriptions
-
+/// Inserts entry into cache at specified key, unless key already exists.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache The object that is used to communicate with the cache
+///              implementation through a shared library.
+/// \param entry The entry to be inserted into the cache.
+/// \return a TRITONSERVER_Error indicating success or failure.
+///         Specific errors will be up the cache implementation, but general
+///         error best practices that should be followed are as follows:
+///         - TRITONSERVER_ERROR_INVALID_ARG
+///           - bad argument passed, nullptr, etc.
+///         - TRITONSERVER_ERROR_ALREADY_EXISTS
+///           - key already exists and will not be inserted again
+///         - TRITONSERVER_ERROR_INTERNAL
+///           - internal errors
+///         - nullptr
+///           - success
 TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheInsert(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
+/// Retrieves entry from cache at specified key, if key exists.
+///
+/// This API is implemented by the user-provided cache implementation,
+/// so specific details will be found within the cache implementation.
+///
+/// \param cache The object that is used to communicate with the cache
+///              implementation through a shared library.
+/// \param entry The entry to be retrieved from the cache.
+/// \return a TRITONSERVER_Error indicating success or failure.
+///         Specific errors will be up the cache implementation, but general
+///         error best practices that should be followed are as follows:
+///         - TRITONSERVER_ERROR_INVALID_ARG
+///           - bad argument passed, nullptr, etc.
+///         - TRITONSERVER_ERROR_NOT_FOUND
+///           - key not found in cache
+///         - TRITONSERVER_ERROR_INTERNAL
+///           - other internal errors
+///         - nullptr
+///           - success
 TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
 
@@ -137,9 +179,19 @@ TRITONCACHE_ISPEC TRITONSERVER_Error* TRITONCACHE_CacheLookup(
 /// CacheEntry Lifetime Management
 ///
 
+/// Create a new cache entry object. The caller takes ownership of the
+/// TRITONCACHE_CacheEntry object and must call
+/// TRITONCACHE_CacheEntryDelete to release the object.
+///
+/// \param entry Returns the new cache entry object.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryNew(
     TRITONCACHE_CacheEntry** entry);
 
+/// Delete a cache entry object.
+///
+/// \param entry The cache entry object to delete.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
     TRITONCACHE_CacheEntry* entry);
 
@@ -147,27 +199,40 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryDelete(
 /// CacheEntry Field Management
 ///
 
+// TODO: Proper API descriptions, lifetimes, copies, etc.
+
 // Get number of items in entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemCount(
     TRITONCACHE_CacheEntry* entry, size_t* count);
-
-// Gets the index'th item from entry where 0 <= index < count where
-// 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryGetItem(
-    TRITONCACHE_CacheEntry* entry, size_t index,
-    TRITONCACHE_CacheEntryItem** item);
 
 // Adds item to entry
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, TRITONCACHE_CacheEntryItem* item);
 
+// Gets item at index from entry where 0 <= index < count and
+// 'count' is the value returned by TRITONCACHE_CacheEntryItemCount
+TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryGetItem(
+    TRITONCACHE_CacheEntry* entry, size_t index,
+    TRITONCACHE_CacheEntryItem** item);
+
+
 ///
 /// CacheEntryItem Lifetime Management
 ///
 
+/// Create a new cache entry item object. The caller takes ownership of the
+/// TRITONCACHE_CacheEntryItem object and must call
+/// TRITONCACHE_CacheEntryItemDelete to release the object.
+///
+/// \param item Returns the new cache entry item object.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemNew(
     TRITONCACHE_CacheEntryItem** item);
 
+/// Delete a cache entry item object.
+///
+/// \param item The cache entry item object to delete.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
     TRITONCACHE_CacheEntryItem* item);
 
@@ -175,6 +240,9 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemDelete(
 /// CacheEntryItem Field Management
 ///
 
+// TODO: Proper API descriptions, lifetimes, copies, etc.
+
+// Returns number of buffers held by item
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
     TRITONCACHE_CacheEntryItem* item, size_t* count);
 
@@ -182,24 +250,11 @@ TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemBufferCount(
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemAddBuffer(
     TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size);
 
-// Gets buffer at index from item
+// Gets buffer at index from item where 0 <= index < count and
+// 'count' is the value returned by TRITONCACHE_CacheEntryItemBufferCount
 TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
     size_t* byte_size);
-
-/*
-   Not currently used, may be added in the future for grouping
-   cache entries for actions like evicting all entries associated
-   with certain model, tags, etc.
-
-// Sets tags in entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntrySetTags(
-    TRITONCACHE_CacheEntry* entry, char** tags, size_t num_tags);
-
-// Gets tags from entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error* TRITONCACHE_CacheEntryTags(
-    TRITONCACHE_CacheEntry* entry, char*** tags, size_t* num_tags);
-*/
 
 #ifdef __cplusplus
 }  // extern C

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1697,16 +1697,34 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size);
 
-/// Set the cache config that will be used to initialize the TritonCache
-/// and corresponding cache implementation.
+/// Set the cache config that will be used to initialize the cache
+/// implementation for "cache_name".
+///
+/// Examples:
+///   std::string config_json = R"({"size": 1048576})"
+///   std::string config_json = "{\"size\": 1048576}"
 ///
 /// \param options The server options object.
-/// \param base The base of the serialized JSON.
-/// \param byte_size The size, in bytes, of the serialized JSON.
+/// FIXME: Included for future extensibility, but not currently used.
+/// \param cache_name The name of the cache.
+/// \param config_json The string representation of config JSON.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCacheConfig(
-    TRITONSERVER_ServerOptions* options, const char* base, size_t byte_size);
+    TRITONSERVER_ServerOptions* options, const char* cache_name,
+    const char* config_json);
+
+/// Set the directory containing cache shared libraries. This
+/// directory is searched when looking for cache implementations.
+/// If the cache is named 'local', the directory
+/// searched is 'cache_dir'/local/libtritoncache_local.so.
+///
+/// \param options The server options object.
+/// \param repoagent_dir The full path of the cache directory.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetCacheDirectory(
+    TRITONSERVER_ServerOptions* options, const char* cache_dir);
 
 /// Set the minimum support CUDA compute capability in a server
 /// options.
@@ -1874,7 +1892,7 @@ TRITONSERVER_ServerOptionsSetBackendDirectory(
 
 /// Set the directory containing repository agent shared libraries. This
 /// directory is searched when looking for the repository agent shared
-/// library for a model. If the backend is named 'ra' the directory
+/// library for a model. If the repo agent is named 'ra' the directory
 /// searched is 'repoagent_dir'/ra/libtritonrepoagent_ra.so.
 ///
 /// \param options The server options object.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1692,13 +1692,8 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCudaMemoryPoolByteSize(
     TRITONSERVER_ServerOptions* options, int gpu_device, uint64_t size);
 
-/// Set the total response cache byte size that the server can allocate in CPU
-/// memory. The response cache will be shared across all inference requests and
-/// across all models.
-///
-/// \param options The server options object.
-/// \param size The total response cache byte size.
-/// \return a TRITONSERVER_Error indicating success or failure.
+// Deprecated. Use "config" parameter in TRITONCACHE_CacheNew to configure cache
+// implementation specific fields.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size);

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1716,11 +1716,11 @@ TRITONSERVER_ServerOptionsSetCacheConfig(
 
 /// Set the directory containing cache shared libraries. This
 /// directory is searched when looking for cache implementations.
-/// If the cache is named 'local', the directory
-/// searched is 'cache_dir'/local/libtritoncache_local.so.
+/// Currently, it is expected that this directory contains a file
+/// specifically named "libtritoncache.so"/"tritoncache.dll".
 ///
 /// \param options The server options object.
-/// \param repoagent_dir The full path of the cache directory.
+/// \param cache_dir The full path of the cache directory.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCacheDirectory(

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1692,7 +1692,15 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCudaMemoryPoolByteSize(
     TRITONSERVER_ServerOptions* options, int gpu_device, uint64_t size);
 
-// Deprecated. See TRITONSERVER_ServerOptionsSetCacheConfig instead.
+/// Deprecated. See TRITONSERVER_ServerOptionsSetCacheConfig instead.
+///
+/// Set the total response cache byte size that the server can allocate in CPU
+/// memory. The response cache will be shared across all inference requests and
+/// across all models.
+///
+/// \param options The server options object.
+/// \param size The total response cache byte size.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size);
@@ -1705,7 +1713,7 @@ TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
 ///   std::string config_json = "{\"size\": 1048576}"
 ///
 /// \param options The server options object.
-/// FIXME: Included for future extensibility, but not currently used.
+/// FIXME: cache_name included for future extensibility, but not currently used.
 /// \param cache_name The name of the cache.
 /// \param config_json The string representation of config JSON.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1692,11 +1692,21 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCudaMemoryPoolByteSize(
     TRITONSERVER_ServerOptions* options, int gpu_device, uint64_t size);
 
-// Deprecated. Use "config" parameter in TRITONCACHE_CacheNew to configure cache
-// implementation specific fields.
+// Deprecated. See TRITONSERVER_ServerOptionsSetCacheConfig instead.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size);
+
+/// Set the cache config that will be used to initialize the TritonCache
+/// and corresponding cache implementation.
+///
+/// \param options The server options object.
+/// \param base The base of the serialized JSON.
+/// \param byte_size The size, in bytes, of the serialized JSON.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetCacheConfig(
+    TRITONSERVER_ServerOptions* options, const char* base, size_t byte_size);
 
 /// Set the minimum support CUDA compute capability in a server
 /// options.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 17
+#define TRITONSERVER_API_VERSION_MINOR 18
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,8 +139,8 @@ set(
   server.cc
   shared_library.cc
   status.cc
-  tritonserver.cc
   tritoncache.cc
+  tritonserver.cc
 )
 
 set(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,8 +111,8 @@ set(
   backend_model.cc
   backend_model_instance.cc
   buffer_attributes.cc
-  cache_entry.cc # TODO
-  cache_manager.cc # TODO
+  cache_entry.cc
+  cache_manager.cc
   cuda_utils.cc
   dynamic_batch_scheduler.cc
   ensemble_scheduler.cc
@@ -156,8 +156,8 @@ set(
   backend_model.h
   backend_model_instance.h
   buffer_attributes.h
-  cache_entry.h # TODO
-  cache_manager.h # TODO
+  cache_entry.h
+  cache_manager.h
   constants.h
   cuda_utils.h
   dynamic_batch_scheduler.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,7 +62,7 @@ endif() # TRITON_ENABLE_GPU
 #
 # Boost
 #
-find_package(Boost REQUIRED)
+find_package(Boost 1.78 REQUIRED)
 message(STATUS "Using Boost ${Boost_VERSION}")
 
 #
@@ -106,6 +106,7 @@ set(
   backend_model.cc
   backend_model_instance.cc
   buffer_attributes.cc
+  cache_entry.cc # TODO
   cache_manager.cc # TODO
   cuda_utils.cc
   dynamic_batch_scheduler.cc
@@ -139,6 +140,7 @@ set(
   shared_library.cc
   status.cc
   tritonserver.cc
+  tritoncache.cc
 )
 
 set(
@@ -149,6 +151,7 @@ set(
   backend_model.h
   backend_model_instance.h
   buffer_attributes.h
+  cache_entry.h # TODO
   cache_manager.h # TODO
   constants.h
   cuda_utils.h
@@ -225,7 +228,7 @@ add_library(
   TritonCore::triton-core ALIAS triton-core
 )
 
-target_compile_features(triton-core PRIVATE cxx_std_11)
+target_compile_features(triton-core PRIVATE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message("Using MSVC as compiler, default target on Windows 10. "
 		  "If the target system is not Windows 10, please update _WIN32_WINNT "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,8 @@
 cmake_minimum_required(VERSION 3.18)
 
 project(libtritonserver LANGUAGES C CXX)
-set (CMAKE_CXX_STANDARD 17) # TODO: better way?
-set(CMAKE_CXX_STANDARD_REQUIRED ON) # TODO: better way?
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,8 @@
 cmake_minimum_required(VERSION 3.18)
 
 project(libtritonserver LANGUAGES C CXX)
+set (CMAKE_CXX_STANDARD 17) # TODO: better way?
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # TODO: better way?
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -238,6 +238,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message("Using MSVC as compiler, default target on Windows 10. "
 		  "If the target system is not Windows 10, please update _WIN32_WINNT "
 		  "to corresponding value.")
+  # WAR for target_compile_features not applying correctly to MSVC.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
   target_compile_options(
     triton-core
     PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,9 @@ endif() # TRITON_ENABLE_GPU
 #
 # Boost
 #
+# Minimum of 1.78 required for use of boost::span. This can eventually be 
+# relaxed and replaced with std::span in C++20.
+#
 find_package(Boost 1.78 REQUIRED)
 message(STATUS "Using Boost ${Boost_VERSION}")
 

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -70,7 +70,6 @@ CacheEntryItem::Buffers()
   return buffers_;
 }
 
-// TODO: DLIS-4401 - Cleanup, add memory type awareness
 void
 CacheEntryItem::AddBuffer(const void* base, size_t byte_size)
 {

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -3,16 +3,61 @@
 
 namespace triton { namespace core {
 
+/* CacheEntry */
+
+size_t
+CacheEntry::ItemCount()
+{
+  // TODO: lock?
+  return items_.size();
+}
+
+// TODO: smart ptr, etc.
+std::vector<std::shared_ptr<CacheEntryItem>>
+CacheEntry::Items()
+{
+  // TODO: lock?
+  return items_;
+}
+
 void
-CacheEntry::AddItem(boost::span<const std::byte> byte_span)
+CacheEntry::AddItem(const CacheEntryItem& item)
+{
+  // TODO: lock?
+  std::cout << "[DEBUG] [cache_entry.cc] items_.size() before: "
+            << items_.size() << std::endl;
+  // Move?
+  items_.emplace_back(std::make_shared<CacheEntryItem>(item));
+  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after: " << items_.size()
+            << std::endl;
+}
+
+/* CacheEntryItem */
+
+size_t
+CacheEntryItem::BufferCount()
+{
+  // TODO: lock?
+  return buffers_.size();
+}
+
+std::vector<Buffer>
+CacheEntryItem::Buffers()
+{
+  // TODO: lock?
+  return buffers_;
+}
+
+void
+CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
 {
   // TODO: lock?
   // Make a vector byte copy for cache to own
-  std::cout << "[DEBUG] [cache_entry.cc] items_.size() before: "
-            << items_.size() << std::endl;
-  items_.emplace_back(byte_span.begin(), byte_span.end());
-  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after: " << items_.size()
-            << std::endl;
+  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() before: "
+            << buffers_.size() << std::endl;
+  buffers_.emplace_back(byte_span.begin(), byte_span.end());
+  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() after: "
+            << buffers_.size() << std::endl;
 }
 
 }}  // namespace triton::core

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -1,0 +1,11 @@
+#include "cache_entry.h"
+
+namespace triton { namespace core {
+
+void CacheEntry::AddItem(boost::span<std::byte> byte_span) {
+  // TODO: lock?
+  // Make a vector byte copy for cache to own
+  items_.emplace_back(byte_span.begin(), byte_span.end());
+}
+
+}}  // namespace triton::core

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -2,7 +2,7 @@
 
 namespace triton { namespace core {
 
-void CacheEntry::AddItem(boost::span<std::byte> byte_span) {
+void CacheEntry::AddItem(boost::span<const std::byte> byte_span) {
   // TODO: lock?
   // Make a vector byte copy for cache to own
   items_.emplace_back(byte_span.begin(), byte_span.end());

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -1,4 +1,5 @@
 #include "cache_entry.h"
+#include <iostream>  // debug
 
 namespace triton { namespace core {
 
@@ -7,7 +8,11 @@ CacheEntry::AddItem(boost::span<const std::byte> byte_span)
 {
   // TODO: lock?
   // Make a vector byte copy for cache to own
+  std::cout << "[DEBUG] [cache_entry.cc] items_.size() before: "
+            << items_.size() << std::endl;
   items_.emplace_back(byte_span.begin(), byte_span.end());
+  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after: " << items_.size()
+            << std::endl;
 }
 
 }}  // namespace triton::core

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -211,12 +211,13 @@ CacheEntryItem::ToBytes(const InferenceResponse::Output& output)
   // Fetch output buffer details
   const void* output_base = nullptr;
   size_t output_byte_size = 0;
-  TRITONSERVER_MemoryType memory_type;
-  int64_t memory_type_id;
-  void* userp;
+  TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
+  int64_t memory_type_id = 0;
+  void* userp = nullptr;
   RETURN_NULLOPT_IF_STATUS_ERROR(output.DataBuffer(
       &output_base, &output_byte_size, &memory_type, &memory_type_id, &userp));
 
+  // DLIS-2673: Add better memory_type support
   if (memory_type != TRITONSERVER_MEMORY_CPU &&
       memory_type != TRITONSERVER_MEMORY_CPU_PINNED) {
     LOG_ERROR

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -24,12 +24,10 @@ void
 CacheEntry::AddItem(const CacheEntryItem& item)
 {
   // TODO: lock?
-  std::cout << "[DEBUG] [cache_entry.cc] items_.size() before: "
-            << items_.size() << std::endl;
-  // Move?
+  // std::move?
   items_.emplace_back(std::make_shared<CacheEntryItem>(item));
-  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after: " << items_.size()
-            << std::endl;
+  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after AddItem(): "
+            << items_.size() << std::endl;
 }
 
 /* CacheEntryItem */
@@ -52,11 +50,9 @@ void
 CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
 {
   // TODO: lock?
-  // Make a vector byte copy for cache to own
-  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() before: "
-            << buffers_.size() << std::endl;
+  // Make a copy for cache to own
   buffers_.emplace_back(byte_span.begin(), byte_span.end());
-  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() after: "
+  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() after AddBuffer(): "
             << buffers_.size() << std::endl;
 }
 

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -1,3 +1,29 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "cache_entry.h"
 #include <iostream>
 

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -70,8 +70,9 @@ CacheEntryItem::Buffers()
   return buffers_;
 }
 
+
 void
-CacheEntryItem::AddBuffer(const void* base, size_t byte_size)
+CacheEntryItem::AddBufferCopy(const void* base, size_t byte_size)
 {
   std::unique_lock lk(buffer_mu_);
   // COPY: Make a copy of buffer for Triton to own
@@ -81,35 +82,27 @@ CacheEntryItem::AddBuffer(const void* base, size_t byte_size)
 }
 
 void
+CacheEntryItem::AddBufferCopy(boost::span<const std::byte> byte_span)
+{
+  const void* base = static_cast<const void*>(byte_span.data());
+  AddBufferCopy(base, byte_span.size());
+}
+
+void
 CacheEntryItem::AddBuffer(void* base, size_t byte_size, bool copy)
 {
   std::unique_lock lk(buffer_mu_);
   if (copy) {
-    void* new_base = malloc(byte_size);
-    memcpy(new_base, base, byte_size);
-    buffers_.emplace_back(std::make_pair(new_base, byte_size));
+    AddBufferCopy(base, byte_size);
   } else {
     buffers_.emplace_back(std::make_pair(base, byte_size));
   }
 }
 
 void
-CacheEntryItem::AddBuffer(std::pair<void*, size_t> buffer_pair, bool copy)
+CacheEntryItem::AddBuffer(Buffer buffer, bool copy)
 {
-  AddBuffer(buffer_pair.first, buffer_pair.second, copy);
-}
-
-void
-CacheEntryItem::AddBuffer(std::pair<void*, size_t> buffer_pair)
-{
-  AddBuffer(buffer_pair.first, buffer_pair.second, true /* copy */);
-}
-
-void
-CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
-{
-  const void* base = static_cast<const void*>(byte_span.data());
-  AddBuffer(base, byte_span.size());
+  AddBuffer(buffer.first, buffer.second, copy);
 }
 
 CacheEntryItem::~CacheEntryItem()
@@ -134,8 +127,8 @@ CacheEntryItem::FromResponse(const InferenceResponse* response)
   for (const auto& output : response->Outputs()) {
     auto buffer = Buffer(nullptr, 0);
     RETURN_IF_ERROR(ToBytes(output, &buffer));
-    bool copy = false;  // ToBytes allocated new memory, we pass it through
-    AddBuffer(buffer, copy);
+    // ToBytes allocated new memory, so we pass it through: no copy here
+    AddBuffer(buffer, false /* copy */);
   }
 
   return Status::Success;

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -55,7 +55,6 @@ CacheEntry::AddItem(std::shared_ptr<CacheEntryItem> item)
   // CacheEntry will take ownership of item pointer
   // Items will be cleaned up when CacheEntry is cleaned up
   items_.push_back(std::move(item));
-  LOG_VERBOSE(2) << "[DEBUG] items_.size() after AddItem(): " << items_.size();
 }
 
 /* CacheEntryItem */
@@ -83,8 +82,6 @@ CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
   std::unique_lock lk(buffer_mu_);
   // Make a copy of buffer for Triton to own
   buffers_.emplace_back(byte_span.begin(), byte_span.end());
-  LOG_VERBOSE(2) << "[DEBUG] buffers_.size() after AddBuffer(): "
-                 << buffers_.size();
 }
 
 /* CacheResponseOutput */

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -34,23 +34,20 @@ namespace triton { namespace core {
 size_t
 CacheEntry::ItemCount()
 {
-  // Read-only, can be shared
-  std::shared_lock lk(item_mu_);
+  std::unique_lock lk(item_mu_);
   return items_.size();
 }
 
 std::vector<std::shared_ptr<CacheEntryItem>>
 CacheEntry::Items()
 {
-  // Read-only, can be shared
-  std::shared_lock lk(item_mu_);
+  std::unique_lock lk(item_mu_);
   return items_;
 }
 
 void
 CacheEntry::AddItem(std::shared_ptr<CacheEntryItem> item)
 {
-  // Read-write, cannot be shared
   std::unique_lock lk(item_mu_);
   // TODO: Look at this flow, ownership, etc. - Currently, cache needs to not
   // delete/invalidate the item.
@@ -62,16 +59,14 @@ CacheEntry::AddItem(std::shared_ptr<CacheEntryItem> item)
 size_t
 CacheEntryItem::BufferCount()
 {
-  // Read-only, can be shared
-  std::shared_lock lk(buffer_mu_);
+  std::unique_lock lk(buffer_mu_);
   return buffers_.size();
 }
 
 std::vector<Buffer>
 CacheEntryItem::Buffers()
 {
-  // Read-only, can be shared
-  std::shared_lock lk(buffer_mu_);
+  std::unique_lock lk(buffer_mu_);
   return buffers_;
 }
 
@@ -79,7 +74,6 @@ CacheEntryItem::Buffers()
 void
 CacheEntryItem::AddBuffer(const void* base, size_t byte_size)
 {
-  // Read-write, cannot be shared
   std::unique_lock lk(buffer_mu_);
   // COPY: Make a copy of buffer for Triton to own
   void* new_base = malloc(byte_size);

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -1,7 +1,33 @@
 #include "cache_entry.h"
-#include <iostream>  // debug
+#include <iostream>
 
 namespace triton { namespace core {
+
+// For debugging
+void
+printBytes(boost::span<const std::byte> buffer)
+{
+  // Capture blank std::cout state
+  std::ios oldState(nullptr);
+  oldState.copyfmt(std::cout);
+
+  std::cout << "[DEBUG] [cache_entry.cc] [LOOKUP] Buffer bytes: ";
+  for (const auto& byte : buffer) {
+    std::cout << std::hex << "0x" << std::to_integer<int>(byte) << " ";
+  }
+  std::cout << std::endl;
+
+  // Reset std::cout state
+  std::cout.copyfmt(oldState);
+}
+
+/* Helpers */
+
+void
+AppendBytes(Buffer& dst, boost::span<const std::byte> src)
+{
+  dst.insert(dst.end(), src.begin(), src.end());
+}
 
 /* CacheEntry */
 
@@ -13,7 +39,7 @@ CacheEntry::ItemCount()
   return items_.size();
 }
 
-const std::vector<std::shared_ptr<CacheEntryItem>>&
+std::vector<std::shared_ptr<CacheEntryItem>>
 CacheEntry::Items()
 {
   // Read-only, can be shared
@@ -29,8 +55,7 @@ CacheEntry::AddItem(std::shared_ptr<CacheEntryItem> item)
   // CacheEntry will take ownership of item pointer
   // Items will be cleaned up when CacheEntry is cleaned up
   items_.push_back(std::move(item));
-  std::cout << "[DEBUG] [cache_entry.cc] items_.size() after AddItem(): "
-            << items_.size() << std::endl;
+  LOG_VERBOSE(2) << "[DEBUG] items_.size() after AddItem(): " << items_.size();
 }
 
 /* CacheEntryItem */
@@ -58,8 +83,8 @@ CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
   std::unique_lock lk(buffer_mu_);
   // Make a copy of buffer for Triton to own
   buffers_.emplace_back(byte_span.begin(), byte_span.end());
-  std::cout << "[DEBUG] [cache_entry.cc] buffers_.size() after AddBuffer(): "
-            << buffers_.size() << std::endl;
+  LOG_VERBOSE(2) << "[DEBUG] buffers_.size() after AddBuffer(): "
+                 << buffers_.size();
 }
 
 /* CacheResponseOutput */
@@ -67,14 +92,14 @@ CacheEntryItem::AddBuffer(boost::span<const std::byte> byte_span)
 Status
 CacheEntryItem::FromResponse(const InferenceResponse* response)
 {
-  // TODO: pass const ref
+  // TODO: pass const ref?
   if (!response) {
     return Status(Status::Code::INTERNAL, "response was nullptr");
   }
 
   // Build cache entry item from response outputs
   for (const auto& output : response->Outputs()) {
-    const auto buffer = ResponseOutputToBytes(output);
+    auto buffer = ToBytes(output);
     if (!buffer.has_value()) {
       return Status(
           Status::Code::INTERNAL, "failed to convert output to bytes");
@@ -85,17 +110,74 @@ CacheEntryItem::FromResponse(const InferenceResponse* response)
   return Status::Success;
 }
 
+Status
+CacheEntryItem::ToResponse(InferenceResponse* response)
+{
+  if (!response) {
+    return Status(Status::Code::INTERNAL, "response was nullptr");
+  }
+
+  const auto buffers = Buffers();
+  for (const auto& buffer : buffers) {
+    auto opt_cache_output = FromBytes(buffer);
+    if (!opt_cache_output.has_value()) {
+      return Status(
+          Status::Code::INTERNAL, "failed to convert bytes to response output");
+    }
+    const auto& cache_output = opt_cache_output.value();
+
+    InferenceResponse::Output* response_output = nullptr;
+    RETURN_IF_ERROR(response->AddOutput(
+        cache_output.name_, cache_output.dtype_, cache_output.shape_,
+        &response_output));
+
+    if (response_output == nullptr) {
+      return Status(
+          Status::Code::INTERNAL,
+          "InferenceResponse::Output pointer as nullptr");
+    }
+
+    TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
+    int64_t memory_type_id = 0;
+
+    // Allocate buffer for inference response
+    void* output_buffer;
+    RETURN_IF_ERROR(response_output->AllocateDataBuffer(
+        &output_buffer, cache_output.buffer_.size(), &memory_type,
+        &memory_type_id));
+
+    if (memory_type != TRITONSERVER_MEMORY_CPU &&
+        memory_type != TRITONSERVER_MEMORY_CPU_PINNED) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Only input buffers in CPU memory are allowed in cache currently");
+    }
+
+    if (!output_buffer) {
+      return Status(
+          Status::Code::INTERNAL,
+          "failed to allocate buffer for output '" + cache_output.name_ + "'");
+    }
+    // Copy cached output buffer to allocated response output buffer
+    std::memcpy(
+        output_buffer, cache_output.buffer_.data(),
+        cache_output.buffer_.size());
+  }
+
+  return Status::Success;
+}
+
 std::optional<Buffer>
-CacheEntryItem::ResponseOutputToBytes(const InferenceResponse::Output& output)
+CacheEntryItem::ToBytes(const InferenceResponse::Output& output)
 {
   // Fetch output buffer details
-  const void* base = nullptr;
-  size_t byte_size = 0;
+  const void* output_base = nullptr;
+  size_t output_byte_size = 0;
   TRITONSERVER_MemoryType memory_type;
   int64_t memory_type_id;
   void* userp;
   RETURN_NULLOPT_IF_STATUS_ERROR(output.DataBuffer(
-      &base, &byte_size, &memory_type, &memory_type_id, &userp));
+      &output_base, &output_byte_size, &memory_type, &memory_type_id, &userp));
 
   if (memory_type != TRITONSERVER_MEMORY_CPU &&
       memory_type != TRITONSERVER_MEMORY_CPU_PINNED) {
@@ -105,32 +187,135 @@ CacheEntryItem::ResponseOutputToBytes(const InferenceResponse::Output& output)
   }
 
   // Exit early if response buffer from output is invalid
-  if (!base) {
+  if (!output_base) {
     LOG_ERROR << "Response buffer from output was nullptr";
     return std::nullopt;
   }
 
-  // TODO: Aggregate metadata
-  // const auto name_ = output.Name();
-  // const auto dtype_ = output.DType();
-  // const auto shape_ = output.Shape();
-  // const auto buffer_size_ = static_cast<uint64_t>(byte_size);*/
+  // TODO: Magic number at start to indicate this is actually a response
+  //       packed into bytes and not some other data?
+  Buffer packed_bytes;
 
-  // TODO: Use span to copy buffer data
-  // boost::span<std::byte> bs{reinterpret_cast<const std::byte*>(base),
-  // byte_size};
+  // Name
+  std::string name = output.Name();
+  uint32_t name_byte_size = name.size();
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(&name_byte_size), sizeof(uint32_t)});
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(name.data()), name_byte_size});
 
-  // TODO: unused variables
-  std::cout << "Unused vars: " << base << byte_size << memory_type_id << userp
-            << std::endl;
+  // Dtype
+  std::string dtype = triton::common::DataTypeToProtocolString(output.DType());
+  uint32_t dtype_byte_size = dtype.size();
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(&dtype_byte_size), sizeof(uint32_t)});
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(dtype.data()), dtype_byte_size});
 
-  Buffer serial_bytes;
-  // TODO: Form output into byte buffer
-  // serial_bytes.insert(serial_bytes.end(), span.begin(), span.end());
-  // serial_bytes.insert(serial_bytes.end(), span.begin(), span.end());
-  // serial_bytes.insert(serial_bytes.end(), span.begin(), span.end());
+  // Shape
+  std::vector<int64_t> shape = output.Shape();
+  uint32_t shape_byte_size = shape.size() * sizeof(int64_t);
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(&shape_byte_size), sizeof(uint32_t)});
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(shape.data()), shape_byte_size});
 
-  return serial_bytes;
+  // Output Buffer
+  // Convert size_t to uint64_t for a fixed-size guarantee
+  uint64_t u64_output_byte_size = static_cast<uint64_t>(output_byte_size);
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<std::byte*>(&u64_output_byte_size), sizeof(uint64_t)});
+  AppendBytes(
+      packed_bytes,
+      {reinterpret_cast<const std::byte*>(output_base), u64_output_byte_size});
+
+  // TODO: Remove
+  LOG_VERBOSE(2) << "[ENCODE] name_byte_size=" << name_byte_size;
+  LOG_VERBOSE(2) << "[ENCODE] name=" << name;
+  LOG_VERBOSE(2) << "[ENCODE] dtype_byte_size=" << dtype_byte_size;
+  LOG_VERBOSE(2) << "[ENCODE] dtype=" << dtype;
+  LOG_VERBOSE(2) << "[ENCODE] shape_byte_size=" << shape_byte_size;
+  LOG_VERBOSE(2) << "[ENCODE] u64_output_byte_size=" << u64_output_byte_size;
+  LOG_VERBOSE(2) << "[ENCODE] output=";
+  printBytes(
+      {reinterpret_cast<const std::byte*>(output_base), u64_output_byte_size});
+  return packed_bytes;
+}
+
+std::optional<CacheOutput>
+CacheEntryItem::FromBytes(boost::span<const std::byte> packed_bytes)
+{
+  // Name
+  size_t position = 0;
+  uint32_t name_byte_size = 0;
+  memcpy(&name_byte_size, packed_bytes.begin() + position, sizeof(uint32_t));
+  position += sizeof(uint32_t);
+
+  std::string name(name_byte_size, 'x');
+  memcpy(name.data(), packed_bytes.begin() + position, name_byte_size);
+  position += name_byte_size;
+
+  // Dtype
+  uint32_t dtype_byte_size = 0;
+  memcpy(&dtype_byte_size, packed_bytes.begin() + position, sizeof(uint32_t));
+  position += sizeof(uint32_t);
+
+  std::string dtype(dtype_byte_size, 'x');
+  memcpy(dtype.data(), packed_bytes.begin() + position, dtype_byte_size);
+  position += dtype_byte_size;
+
+  // Shape
+  uint32_t shape_byte_size = 0;
+  memcpy(&shape_byte_size, packed_bytes.begin() + position, sizeof(uint32_t));
+  position += sizeof(uint32_t);
+
+  std::vector<int64_t> shape(shape_byte_size / sizeof(int64_t), 0);
+  memcpy(shape.data(), packed_bytes.begin() + position, shape_byte_size);
+  position += shape_byte_size;
+
+  // Output Buffer
+  uint64_t output_byte_size = 0;
+  memcpy(&output_byte_size, packed_bytes.begin() + position, sizeof(uint64_t));
+  position += sizeof(uint64_t);
+
+  Buffer output_buffer(output_byte_size);
+  memcpy(
+      output_buffer.data(), packed_bytes.begin() + position, output_byte_size);
+  position += output_byte_size;
+
+  if (packed_bytes.begin() + position != packed_bytes.end()) {
+    LOG_ERROR << "Unexpected number of bytes. Received " << packed_bytes.size()
+              << ", expected: " << position;
+    return std::nullopt;
+  }
+
+  // TODO: Remove
+  LOG_VERBOSE(2) << "[DECODE] name_byte_size=" << name_byte_size;
+  LOG_VERBOSE(2) << "[DECODE] name=" << name;
+  LOG_VERBOSE(2) << "[DECODE] dtype_byte_size=" << dtype_byte_size;
+  LOG_VERBOSE(2) << "[DECODE] dtype=" << dtype;
+  LOG_VERBOSE(2) << "[DECODE] shape_byte_size=" << shape_byte_size;
+  LOG_VERBOSE(2) << "[DECODE] shape=";
+  for (const auto& dim : shape) {
+    LOG_VERBOSE(2) << dim << " ";
+  }
+  LOG_VERBOSE(2) << "[DECODE] output_byte_size=" << output_byte_size;
+  LOG_VERBOSE(2) << "[DECODE] output=";
+  printBytes(output_buffer);
+
+  auto output = CacheOutput();
+  output.name_ = name;
+  output.dtype_ = triton::common::ProtocolStringToDataType(dtype);
+  output.shape_ = shape;
+  output.buffer_ = output_buffer;
+  return output;
 }
 
 }}  // namespace triton::core

--- a/src/cache_entry.cc
+++ b/src/cache_entry.cc
@@ -2,7 +2,9 @@
 
 namespace triton { namespace core {
 
-void CacheEntry::AddItem(boost::span<const std::byte> byte_span) {
+void
+CacheEntry::AddItem(boost::span<const std::byte> byte_span)
+{
   // TODO: lock?
   // Make a vector byte copy for cache to own
   items_.emplace_back(byte_span.begin(), byte_span.end());

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -83,11 +83,10 @@ class CacheEntryItem {
   Status ToResponse(InferenceResponse* response);
   std::vector<Buffer> Buffers();
   size_t BufferCount();
-  void AddBuffer(boost::span<const std::byte> buffer);
-  void AddBuffer(const void* base, size_t byte_size);
-  void AddBuffer(std::pair<void*, size_t> buffer_pair);
-  void AddBuffer(std::pair<void*, size_t> buffer_pair, bool copy);
+  void AddBufferCopy(boost::span<const std::byte> buffer);
+  void AddBufferCopy(const void* base, size_t byte_size);
   void AddBuffer(void* base, size_t byte_size, bool copy);
+  void AddBuffer(Buffer buffer, bool copy);
 
  private:
   // Returns bytes buffer in buffer arg

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -57,7 +57,7 @@ namespace triton { namespace core {
 
 struct CacheOutput {
   // Inference Response output name
-  std::string name_;
+  std::string name_ = "";
   // Inference Response output datatype
   inference::DataType dtype_;
   // Inference Response output shape
@@ -65,9 +65,9 @@ struct CacheOutput {
   // Inference Response output buffer
   // NOTE: Cache Output will only temporarily store pointer, it will managed by
   //       CacheEntryItem, and will be copied into InferenceResponse object
-  void* buffer_;
+  void* buffer_ = nullptr;
   // Inference Response output buffer size
-  uint64_t byte_size_;
+  uint64_t byte_size_ = 0;
 };
 
 // A Buffer is an arbitrary data blob whose type need not be known
@@ -90,8 +90,8 @@ class CacheEntryItem {
   void AddBuffer(void* base, size_t byte_size, bool copy);
 
  private:
-  std::optional<Buffer> ToBytes(const InferenceResponse::Output& output);
-  std::optional<CacheOutput> FromBytes(
+  std::pair<Status, Buffer> ToBytes(const InferenceResponse::Output& output);
+  std::pair<Status, CacheOutput> FromBytes(
       boost::span<const std::byte> packed_bytes);
 
   // NOTE: performance gain may be possible by removing this mutex and

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,3 +1,29 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 #include <boost/core/span.hpp>
 #include <memory>

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -16,6 +16,7 @@ using Buffer = std::vector<std::byte>;
 // A CacheEntry may have several Items associated with it
 // ex: 1 request has multiple responses
 //   using Item = std::vector<Buffer>;
+//   std::vector<Item> items_;
 
 class CacheEntry {
  public:
@@ -24,6 +25,7 @@ class CacheEntry {
   void AddItem(boost::span<const std::byte> buffer);
 
  private:
+  // TODO: Pointer to be more lightweight depending on usage?
   std::vector<Buffer> items_;
 };
 

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,5 +1,5 @@
-#include <vector>
 #include <boost/core/span.hpp>
+#include <vector>
 #include "triton/core/tritoncache.h"
 #include "triton/core/tritonserver.h"
 
@@ -7,24 +7,25 @@ namespace triton { namespace core {
 
 // A Buffer is an arbitrary data blob, whose type need not be known
 // by the cache for storage and retrieval
-//using Buffer = std::pair<void*, size_t>;
+// using Buffer = std::pair<void*, size_t>;
 using Buffer = std::vector<std::byte>;
 
 // An Item may have several Buffers associated with it
 // ex: 1 response has multiple outputs
 // NOTE: For now, Item's will be a single continuous buffer
-// Multiple buffers can be concatenated as needed 
+// Multiple buffers can be concatenated as needed
 // A CacheEntry may have several Items associated with it
 // ex: 1 request has multiple responses
 //   using Item = std::vector<Buffer>;
 
 class CacheEntry {
-  public:
-    std::vector<Buffer> Items() { return items_; }
-    size_t Count() { return items_.size(); }
-    void AddItem(boost::span<const std::byte> buffer);
-  private:
-    std::vector<Buffer> items_;
+ public:
+  std::vector<Buffer> Items() { return items_; }
+  size_t Count() { return items_.size(); }
+  void AddItem(boost::span<const std::byte> buffer);
+
+ private:
+  std::vector<Buffer> items_;
 };
 
 }}  // namespace triton::core

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -56,22 +56,22 @@
 namespace triton { namespace core {
 
 struct CacheOutput {
-  ~CacheOutput()
-  {
-    if (buffer_) {
-      free(buffer_);
-    }
-  }
+  // Inference Response output name
   std::string name_;
+  // Inference Response output datatype
   inference::DataType dtype_;
+  // Inference Response output shape
   std::vector<int64_t> shape_;
+  // Inference Response output buffer
+  // NOTE: Cache Output will only temporarily store pointer, it will managed by
+  //       CacheEntryItem, and will be copied into InferenceResponse object
   void* buffer_;
+  // Inference Response output buffer size
   uint64_t byte_size_;
 };
 
-// A Buffer is an arbitrary data blob, whose type need not be known
+// A Buffer is an arbitrary data blob whose type need not be known
 // by the cache for storage and retrieval.
-// using Buffer = std::vector<std::byte>;
 using Buffer = std::pair<void*, size_t>;
 
 // A CacheEntryItem may have several Buffers associated with it

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <boost/core/span.hpp>
 #include <memory>
+#include <shared_mutex>
 #include <vector>
 #include "tritonserver_apis.h"
 
@@ -28,17 +29,21 @@ class CacheEntryItem {
   void AddBuffer(boost::span<const std::byte> buffer);
 
  private:
+  // Shared mutex to support read-only and read-write locks
+  std::shared_mutex buffer_mu_;
   // TODO: Pointer to be more lightweight depending on usage?
   std::vector<Buffer> buffers_;
 };
 
 class CacheEntry {
  public:
-  std::vector<std::shared_ptr<CacheEntryItem>> Items();
+  const std::vector<std::shared_ptr<CacheEntryItem>>& Items();
   size_t ItemCount();
-  void AddItem(const CacheEntryItem& item);
+  void AddItem(std::shared_ptr<CacheEntryItem> item);
 
  private:
+  // Shared mutex to support read-only and read-write locks
+  std::shared_mutex item_mu_;
   // TODO: Pointer to be more lightweight depending on usage?
   std::vector<std::shared_ptr<CacheEntryItem>> items_;
 };

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,0 +1,30 @@
+#include <vector>
+#include <boost/core/span.hpp>
+#include "triton/core/tritoncache.h"
+#include "triton/core/tritonserver.h"
+
+namespace triton { namespace core {
+
+// A Buffer is an arbitrary data blob, whose type need not be known
+// by the cache for storage and retrieval
+//using Buffer = std::pair<void*, size_t>;
+using Buffer = std::vector<std::byte>;
+
+// An Item may have several Buffers associated with it
+// ex: 1 response has multiple outputs
+// NOTE: For now, Item's will be a single continuous buffer
+// Multiple buffers can be concatenated as needed 
+// A CacheEntry may have several Items associated with it
+// ex: 1 request has multiple responses
+//   using Item = std::vector<Buffer>;
+
+class CacheEntry {
+  public:
+    std::vector<Buffer> Items() { return items_; }
+    size_t Count() { return items_.size(); }
+    void AddItem(boost::span<std::byte> buffer);
+  private:
+    std::vector<Buffer> items_;
+};
+
+}}  // namespace triton::core

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,7 +1,6 @@
 #include <boost/core/span.hpp>
 #include <vector>
-#include "triton/core/tritoncache.h"
-#include "triton/core/tritonserver.h"
+#include "tritonserver_apis.h"
 
 namespace triton { namespace core {
 

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -27,30 +27,30 @@
 #pragma once
 #include <boost/core/span.hpp>
 #include <memory>
-#include <shared_mutex>
+#include <mutex>
 #include <vector>
 #include "infer_response.h"
 #include "triton/common/logging.h"
 #include "tritonserver_apis.h"
 
 // If TRITONSERVER error is non-OK, return std::nullopt for failed optional.
-#define RETURN_NULLOPT_IF_TRITONSERVER_ERROR(E)      \
-  do {                                               \
-    TRITONSERVER_Error* err__ = (E);                 \
-    if (err__ != nullptr) {                          \
-      LOG_ERROR << TRITONSERVER_ErrorMessage(err__); \
-      TRITONSERVER_ErrorDelete(err__);               \
-      return std::nullopt;                           \
-    }                                                \
+#define RETURN_NULLOPT_IF_TRITONSERVER_ERROR(E)           \
+  do {                                                    \
+    TRITONSERVER_Error* err__ = (E);                      \
+    if (err__ != nullptr) {                               \
+      LOG_VERBOSE(1) << TRITONSERVER_ErrorMessage(err__); \
+      TRITONSERVER_ErrorDelete(err__);                    \
+      return std::nullopt;                                \
+    }                                                     \
   } while (false)
 
-#define RETURN_NULLOPT_IF_STATUS_ERROR(S) \
-  do {                                    \
-    const Status& status__ = (S);         \
-    if (!status__.IsOk()) {               \
-      LOG_ERROR << status__.Message();    \
-      return std::nullopt;                \
-    }                                     \
+#define RETURN_NULLOPT_IF_STATUS_ERROR(S)   \
+  do {                                      \
+    const Status& status__ = (S);           \
+    if (!status__.IsOk()) {                 \
+      LOG_VERBOSE(1) << status__.Message(); \
+      return std::nullopt;                  \
+    }                                       \
   } while (false)
 
 namespace triton { namespace core {
@@ -101,7 +101,7 @@ class CacheEntryItem {
   //   TRITONCACHE_CacheEntryItemBuffer on the same item in parallel.
   //   This will remain for simplicity until further profiling is done.
   // Shared mutex to support read-only and read-write locks
-  std::shared_mutex buffer_mu_;
+  std::mutex buffer_mu_;
   std::vector<Buffer> buffers_;
 };
 
@@ -120,8 +120,7 @@ class CacheEntry {
   //   implementation should not call TRITONCACHE_CacheEntryAddItem or
   //   TRITONCACHE_CacheEntryItem on the same entry in parallel.
   //   This will remain for simplicity until further profiling is done.
-  // Shared mutex to support read-only and read-write locks
-  std::shared_mutex item_mu_;
+  std::mutex item_mu_;
   std::vector<std::shared_ptr<CacheEntryItem>> items_;
 };
 

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -90,9 +90,11 @@ class CacheEntryItem {
   void AddBuffer(void* base, size_t byte_size, bool copy);
 
  private:
-  std::pair<Status, Buffer> ToBytes(const InferenceResponse::Output& output);
-  std::pair<Status, CacheOutput> FromBytes(
-      boost::span<const std::byte> packed_bytes);
+  // Returns bytes buffer in buffer arg
+  Status ToBytes(const InferenceResponse::Output& output, Buffer* buffer);
+  // Returns cache output in output arg
+  Status FromBytes(
+      boost::span<const std::byte> packed_bytes, CacheOutput* output);
 
   // NOTE: performance gain may be possible by removing this mutex and
   //   guaranteeing that no two threads will access/modify an item

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -22,7 +22,7 @@ class CacheEntry {
   public:
     std::vector<Buffer> Items() { return items_; }
     size_t Count() { return items_.size(); }
-    void AddItem(boost::span<std::byte> buffer);
+    void AddItem(boost::span<const std::byte> buffer);
   private:
     std::vector<Buffer> items_;
 };

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -29,6 +29,9 @@
 
 namespace triton { namespace core {
 
+// For debugging
+void printBytes(boost::span<const std::byte> buffer);
+
 struct CacheOutput {
   std::string name_;
   inference::DataType dtype_;

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -55,19 +55,18 @@
 
 namespace triton { namespace core {
 
-// For debugging
-void printBytes(boost::span<const std::byte> buffer);
-
 struct CacheOutput {
   std::string name_;
   inference::DataType dtype_;
   std::vector<int64_t> shape_;
-  std::vector<std::byte> buffer_;
+  void* buffer_;
+  uint64_t byte_size_;
 };
 
 // A Buffer is an arbitrary data blob, whose type need not be known
 // by the cache for storage and retrieval.
-using Buffer = std::vector<std::byte>;
+// using Buffer = std::vector<std::byte>;
+using Buffer = std::pair<void*, size_t>;
 
 // A CacheEntryItem may have several Buffers associated with it
 //   ex: one response may have multiple output buffers
@@ -78,12 +77,13 @@ class CacheEntryItem {
   std::vector<Buffer> Buffers();
   size_t BufferCount();
   void AddBuffer(boost::span<const std::byte> buffer);
+  void AddBuffer(const void* base, size_t byte_size);
+  void AddBuffer(std::pair<void*, size_t> buffer_pair);
 
  private:
   std::optional<Buffer> ToBytes(const InferenceResponse::Output& output);
   std::optional<CacheOutput> FromBytes(
       boost::span<const std::byte> packed_bytes);
-
 
   // NOTE: performance gain may be possible by removing this mutex and
   //   guaranteeing that no two threads will access/modify an item

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -56,6 +56,12 @@
 namespace triton { namespace core {
 
 struct CacheOutput {
+  ~CacheOutput()
+  {
+    if (buffer_) {
+      free(buffer_);
+    }
+  }
   std::string name_;
   inference::DataType dtype_;
   std::vector<int64_t> shape_;
@@ -72,6 +78,7 @@ using Buffer = std::pair<void*, size_t>;
 //   ex: one response may have multiple output buffers
 class CacheEntryItem {
  public:
+  ~CacheEntryItem();
   Status FromResponse(const InferenceResponse* response);
   Status ToResponse(InferenceResponse* response);
   std::vector<Buffer> Buffers();
@@ -79,6 +86,8 @@ class CacheEntryItem {
   void AddBuffer(boost::span<const std::byte> buffer);
   void AddBuffer(const void* base, size_t byte_size);
   void AddBuffer(std::pair<void*, size_t> buffer_pair);
+  void AddBuffer(std::pair<void*, size_t> buffer_pair, bool copy);
+  void AddBuffer(void* base, size_t byte_size, bool copy);
 
  private:
   std::optional<Buffer> ToBytes(const InferenceResponse::Output& output);

--- a/src/cache_entry.h
+++ b/src/cache_entry.h
@@ -1,4 +1,6 @@
+#pragma once
 #include <boost/core/span.hpp>
+#include <memory>
 #include <vector>
 #include "tritonserver_apis.h"
 
@@ -18,15 +20,27 @@ using Buffer = std::vector<std::byte>;
 //   using Item = std::vector<Buffer>;
 //   std::vector<Item> items_;
 
-class CacheEntry {
+class CacheEntryItem {
  public:
-  std::vector<Buffer> Items() { return items_; }
-  size_t Count() { return items_.size(); }
-  void AddItem(boost::span<const std::byte> buffer);
+  // TODO: immutable buffers?
+  std::vector<Buffer> Buffers();
+  size_t BufferCount();
+  void AddBuffer(boost::span<const std::byte> buffer);
 
  private:
   // TODO: Pointer to be more lightweight depending on usage?
-  std::vector<Buffer> items_;
+  std::vector<Buffer> buffers_;
+};
+
+class CacheEntry {
+ public:
+  std::vector<std::shared_ptr<CacheEntryItem>> Items();
+  size_t ItemCount();
+  void AddItem(const CacheEntryItem& item);
+
+ private:
+  // TODO: Pointer to be more lightweight depending on usage?
+  std::vector<std::shared_ptr<CacheEntryItem>> items_;
 };
 
 }}  // namespace triton::core

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -78,7 +78,7 @@ TritonCache::~TritonCache()
   LOG_VERBOSE(1) << "unloading cache '" << name_ << "'";
   if (fini_fn_) {
     if (cache_impl_) {
-      LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheDelete from: '" << libpath_
+      LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheFinalize from: '" << libpath_
                      << "'";
       LOG_TRITONSERVER_ERROR(fini_fn_(cache_impl_), "failed finalizing cache");
     } else {
@@ -120,10 +120,10 @@ TritonCache::LoadCacheLibrary()
 
     // Cache initialize and finalize functions, required
     RETURN_IF_ERROR(slib->GetEntrypoint(
-        dlhandle_, "TRITONCACHE_CacheNew", false /* optional */,
+        dlhandle_, "TRITONCACHE_CacheInitialize", false /* optional */,
         reinterpret_cast<void**>(&init_fn)));
     RETURN_IF_ERROR(slib->GetEntrypoint(
-        dlhandle_, "TRITONCACHE_CacheDelete", false /* optional */,
+        dlhandle_, "TRITONCACHE_CacheFinalize", false /* optional */,
         reinterpret_cast<void**>(&fini_fn)));
     RETURN_IF_ERROR(slib->GetEntrypoint(
         dlhandle_, "TRITONCACHE_CacheLookup", false /* optional */,

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -88,6 +88,12 @@ TritonCache::~TritonCache()
     LOG_ERROR << "cache finalize function is nullptr";
   }
 
+  if (dlhandle_) {
+    std::unique_ptr<SharedLibrary> slib;
+    LOG_STATUS_ERROR(SharedLibrary::Acquire(&slib), "~TritonCache");
+    LOG_STATUS_ERROR(slib->CloseLibraryHandle(dlhandle_), "~TritonCache");
+  }
+
   ClearHandles();
 }
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -139,13 +139,22 @@ TritonCache::TestCacheImpl()
   }
 
   std::cout << "=============== Insert Bytes ===============" << std::endl;
-  // TODO: Test multiple buffers
-  std::vector<int> buffer1{1, 2, 3};
-  auto buffer1_byte_size = sizeof(int) * buffer1.size();
-  auto base1 = reinterpret_cast<std::byte*>(buffer1.data());
+  // Setup byte buffers
+  std::vector<std::byte> buffer1{1, std::byte{0x01}};
+  std::vector<std::byte> buffer2{2, std::byte{0x02}};
+  std::vector<std::byte> buffer3{4, std::byte{0x03}};
+  std::vector<std::byte> buffer4{8, std::byte{0x04}};
+  std::vector<std::byte> buffer5{16, std::byte{0xFF}};
+  // Setup items
   std::vector<std::shared_ptr<CacheEntryItem>> items;
   items.emplace_back(new CacheEntryItem());
-  items[0]->AddBuffer({base1, buffer1_byte_size});
+  items.emplace_back(new CacheEntryItem());
+  // Add buffers to items
+  items[0]->AddBuffer(buffer1);
+  items[0]->AddBuffer(buffer2);
+  items[1]->AddBuffer(buffer3);
+  items[1]->AddBuffer(buffer4);
+  items[1]->AddBuffer(buffer5);
   status = Insert(items, "test_bytes_123_key");
 
   std::cout << "=============== Lookup ===============" << std::endl;
@@ -270,7 +279,8 @@ TritonCache::Lookup(const std::string& key)
   auto opaque_entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
   RETURN_NULLOPT_IF_TRITONSERVER_ERROR(
       lookup_fn_(cache_impl_, key.c_str(), opaque_entry));
-  LOG_VERBOSE(1) << "[LOOKUP] CacheEntry->ItemCount()" << entry->ItemCount();
+  std::cout << "[cache_manager.cc] [LOOKUP] CacheEntry->ItemCount(): "
+            << entry->ItemCount() << std::endl;
   return entry->Items();
 }
 

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -149,7 +149,7 @@ TritonCache::InitializeCacheImpl()
   // Initialize cache implementation
   LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheNew from: '" << libpath_ << "'";
   RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_, cache_config_.c_str()));
-  if (cache_impl_ == nullptr) {
+  if (!cache_impl_) {
     return Status(
         Status::Code::INTERNAL, "Failed to initialize cache implementation");
   }

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -35,6 +35,7 @@
 namespace triton { namespace core {
 
 
+// TODO: per-cache name
 std::string
 TritonCacheLibraryName()
 {
@@ -149,6 +150,7 @@ TritonCache::InitializeCacheImpl()
   // Initialize cache implementation
   LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheNew from: '" << libpath_ << "'";
   RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_, cache_config_.c_str()));
+
   if (!cache_impl_) {
     return Status(
         Status::Code::INTERNAL, "Failed to initialize cache implementation");
@@ -227,12 +229,12 @@ Status
 TritonCache::Insert(
     std::vector<std::shared_ptr<CacheEntryItem>> items, const std::string& key)
 {
-  LOG_VERBOSE(2) << "Inserting into cache";
+  LOG_VERBOSE(2) << "Inserting items at cache key: " << key;
   if (insert_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache insert function is nullptr");
   }
 
-  // TODO: If key exists, exit? Check with cache first.
+  // TODO Optimization: Check if key exists first before forming Cache Entry
 
   const auto entry = std::make_unique<CacheEntry>();
   for (const auto& item : items) {
@@ -249,13 +251,16 @@ Status
 TritonCache::Insert(
     boost::span<InferenceResponse*> responses, const std::string& key)
 {
-  LOG_VERBOSE(2) << "Inserting list of responses into cache";
+  LOG_VERBOSE(2) << "Inserting list of responses at cache key: " << key;
   if (insert_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache insert function is nullptr");
   }
 
   auto entry = CacheEntry();
   for (const auto& response : responses) {
+    if (!response) {
+      return Status(Status::Code::INVALID_ARG, "response is nullptr");
+    }
     auto item = std::make_shared<CacheEntryItem>();
     RETURN_IF_ERROR(item->FromResponse(response));
     entry.AddItem(item);
@@ -266,9 +271,9 @@ TritonCache::Insert(
 Status
 TritonCache::Insert(InferenceResponse* response, const std::string& key)
 {
-  LOG_VERBOSE(2) << "Inserting single response into cache";
-  if (insert_fn_ == nullptr) {
-    return Status(Status::Code::NOT_FOUND, "cache insert function is nullptr");
+  LOG_VERBOSE(2) << "Inserting single response at cache key: " << key;
+  if (!response) {
+    return Status(Status::Code::INVALID_ARG, "response is nullptr");
   }
 
   return Insert({&response, 1}, key);
@@ -278,7 +283,7 @@ TritonCache::Insert(InferenceResponse* response, const std::string& key)
 std::optional<std::vector<std::shared_ptr<CacheEntryItem>>>
 TritonCache::Lookup(const std::string& key)
 {
-  LOG_VERBOSE(2) << "Looking up bytes in cache";
+  LOG_VERBOSE(2) << "Looking up bytes at cache key: " << key;
   if (lookup_fn_ == nullptr) {
     LOG_ERROR << "cache lookup function is nullptr";
     return std::nullopt;
@@ -288,16 +293,15 @@ TritonCache::Lookup(const std::string& key)
   auto opaque_entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
   RETURN_NULLOPT_IF_TRITONSERVER_ERROR(
       lookup_fn_(cache_impl_, key.c_str(), opaque_entry));
-  LOG_VERBOSE(2) << "[LOOKUP] CacheEntry->ItemCount(): " << entry->ItemCount();
   return entry->Items();
 }
 
+// NOTE: Multiple responses won't be expected until supporting decoupled
+// or sequence models.
 Status
 TritonCache::Lookup(
     boost::span<InferenceResponse*> responses, const std::string& key)
 {
-  LOG_VERBOSE(2) << "Looking up multiple responses in cache";
-
   if (lookup_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache lookup function is nullptr");
   }

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -198,29 +198,6 @@ TritonCache::Hash(const InferenceRequest& request, uint64_t* key)
   return Status::Success;
 }
 
-/* TODO
-
-Status
-TritonCache::InsertBuffer(boost::span<std::byte> byte_span, const std::string&
-key)
-{
-  LOG_VERBOSE(1) << "Inserting into cache";
-  if (insert_fn_ == nullptr) {
-    return Status(Status::Code::NOT_FOUND, "cache insert function is nullptr");
-  }
-
-  // TODO: If key exists, exit? Check with cache first.
-
-  auto entry = std::make_unique<CacheEntry>();
-  entry->AddBuffer(byte_span);
-  auto opaque_entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
-  RETURN_IF_TRITONSERVER_ERROR(
-      insert_fn_(cache_impl_, key.c_str(), opaque_entry));
-  return Status::Success;
-}
-
-*/
-
 Status
 TritonCache::Insert(
     std::vector<std::shared_ptr<CacheEntryItem>> items, const std::string& key)
@@ -232,12 +209,12 @@ TritonCache::Insert(
 
   // TODO: If key exists, exit? Check with cache first.
 
-  auto entry = std::make_shared<CacheEntry>();
+  const auto entry = std::make_unique<CacheEntry>();
   for (const auto& item : items) {
-    // TODO
-    entry->AddItem(*item);
+    entry->AddItem(item);
   }
-  auto opaque_entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
+  const auto opaque_entry =
+      reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
   RETURN_IF_TRITONSERVER_ERROR(
       insert_fn_(cache_impl_, key.c_str(), opaque_entry));
   return Status::Success;

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -159,6 +159,32 @@ TritonCache::TestCacheImpl()
   if (!responses.has_value()) {
     return Status(Status::Code::INTERNAL, "Lookup failed");
   }
+  const auto lookup_items = responses.value();
+  if (lookup_items.size() != items.size()) {
+    return Status(
+        Status::Code::INTERNAL, "Expected " + std::to_string(items.size()) +
+                                    " got " +
+                                    std::to_string(lookup_items.size()));
+  }
+
+  for (size_t i = 0; i < items.size(); i++) {
+    auto expected_buffers = items[i]->Buffers();
+    auto lookup_buffers = lookup_items[i]->Buffers();
+    if (lookup_buffers.size() != expected_buffers.size()) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Expected " + std::to_string(expected_buffers.size()) + " got " +
+              std::to_string(lookup_buffers.size()));
+    }
+
+
+    for (size_t b = 0; b < expected_buffers.size(); b++) {
+      if (lookup_buffers[b] != expected_buffers[b]) {
+        return Status(
+            Status::Code::INTERNAL, "Buffer bytes didn't match for test input");
+      }
+    }
+  }
   std::cout << "======================================" << std::endl;
   std::cout << "============ Done Testing ============" << std::endl;
   std::cout << "======================================" << std::endl;

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -142,21 +142,9 @@ TritonCache::InitializeCacheImpl()
   if (init_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache init function is nullptr");
   }
-
-  // TODO: TRITONSERVER_Message doesn't seem to do any validation on the
-  //       string to assert valid JSON. Not sure why passing
-  //       'TritonServerMessage' would be better than just passing 'const char*'
-  // Convert JSON string config into TRITONSERVER_Message
-  TRITONSERVER_Message* config_msg = nullptr;
-  RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_MessageNewFromSerializedJson(
-      &config_msg, cache_config_.c_str(), cache_config_.size()));
-
   // Initialize cache implementation
   LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheNew from: '" << libpath_ << "'";
-  RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_, config_msg));
-  // TODO: Cache implementation will either have to copy config or they will
-  //       have to be responsible for deleting it if we don't delete here.
-  RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_MessageDelete(config_msg));
+  RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_, cache_config_.c_str()));
   if (cache_impl_ == nullptr) {
     return Status(
         Status::Code::INTERNAL, "Failed to initialize cache implementation");

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -128,16 +128,11 @@ TritonCache::TestCacheImpl()
   std::cout << "======================================" << std::endl;
   std::cout << "==== Testing Cache Implementation ====" << std::endl;
   std::cout << "======================================" << std::endl;
-  // TODO: Remove
   auto status = Status::Success;
-  InferenceResponse* response = nullptr;
-  std::cout << "=============== Insert Response ===============" << std::endl;
-  // TODO: need response implementation
-  status = Insert(response, "test_response_key");
-  if (!status.IsOk()) {
-    return status;
-  }
-
+  // TODO: can't test here without creating genuine request/responses or mocking
+  // InferenceResponse* response = nullptr;
+  // std::cout << "=============== Insert Response ===============" <<
+  // std::endl; RETURN_IF_ERROR(Insert(response, "test_response_key"));
   std::cout << "=============== Insert Bytes ===============" << std::endl;
   // Setup byte buffers
   std::vector<std::byte> buffer1{1, std::byte{0x01}};
@@ -157,12 +152,13 @@ TritonCache::TestCacheImpl()
   items[1]->AddBuffer(buffer5);
   status = Insert(items, "test_bytes_123_key");
 
-  std::cout << "=============== Lookup ===============" << std::endl;
-  status = Lookup(response, "test_bytes_123_key");
-  if (!status.IsOk()) {
-    return status;
+  // std::cout << "=============== Lookup Response ===============" <<
+  // std::endl; RETURN_IF_ERROR(Lookup(response, "test_response_key"));
+  std::cout << "=============== Lookup Bytes ===============" << std::endl;
+  const auto responses = Lookup("test_bytes_123_key");
+  if (!responses.has_value()) {
+    return Status(Status::Code::INTERNAL, "Lookup failed");
   }
-
   std::cout << "======================================" << std::endl;
   std::cout << "============ Done Testing ============" << std::endl;
   std::cout << "======================================" << std::endl;
@@ -172,8 +168,6 @@ TritonCache::TestCacheImpl()
 Status
 TritonCache::InitializeCacheImpl()
 {
-  // TODO: Shouldn't be needed since SharedLibrary should error
-  //       if non-optional function not found / nullptr
   if (init_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache init function is nullptr");
   }
@@ -190,11 +184,11 @@ TritonCache::InitializeCacheImpl()
 }
 
 Status
-TritonCache::Hash(const InferenceRequest& request, uint64_t* key)
+TritonCache::Hash(const InferenceRequest& request, std::string* key)
 {
   LOG_VERBOSE(1) << "Hashing into cache";
-  // TODO: call cache_hash_fn__
-  *key = 42;
+  // TODO: call hash function
+  *key = "test_bytes_123_key";
   return Status::Success;
 }
 
@@ -232,6 +226,11 @@ TritonCache::Insert(const InferenceResponse* response, const std::string& key)
   // TODO: If key exists, exit? Check with cache first.
 
   // TODO: Build byte buffer from response?
+  auto entry = CacheEntry();
+  // TODO: clean up, no need for smart ptrs here, etc.
+  auto item = std::make_shared<CacheEntryItem>();
+  RETURN_IF_ERROR(item->FromResponse(response));
+  entry.AddItem(item);
   // entry = CacheEntry();
   // auto status = entry.FromInferenceResponse(response);
   // if (!status.IsOk()) {

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -143,9 +143,20 @@ TritonCache::InitializeCacheImpl()
     return Status(Status::Code::NOT_FOUND, "cache init function is nullptr");
   }
 
+  // TODO: TRITONSERVER_Message doesn't seem to do any validation on the
+  //       string to assert valid JSON. Not sure why passing
+  //       'TritonServerMessage' would be better than just passing 'const char*'
+  // Convert JSON string config into TRITONSERVER_Message
+  TRITONSERVER_Message* config_msg = nullptr;
+  RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_MessageNewFromSerializedJson(
+      &config_msg, cache_config_.c_str(), cache_config_.size()));
+
   // Initialize cache implementation
   LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheNew from: '" << libpath_ << "'";
-  RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_));
+  RETURN_IF_TRITONSERVER_ERROR(init_fn_(&cache_impl_, config_msg));
+  // TODO: Cache implementation will either have to copy config or they will
+  //       have to be responsible for deleting it if we don't delete here.
+  RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_MessageDelete(config_msg));
   if (cache_impl_ == nullptr) {
     return Status(
         Status::Code::INTERNAL, "Failed to initialize cache implementation");

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -286,37 +286,29 @@ std::pair<Status, std::vector<std::shared_ptr<CacheEntryItem>>>
 TritonCache::Lookup(const std::string& key)
 {
   LOG_VERBOSE(2) << "Looking up bytes at cache key: " << key;
-  std::vector<std::shared_ptr<CacheEntryItem>> empty_items = {};
   if (lookup_fn_ == nullptr) {
-    return std::make_pair(
-        Status(Status::Code::INTERNAL, "cache lookup function is nullptr"),
-        empty_items);
+    auto fail = Status(Status::Code::INTERNAL, "lookup function is nullptr");
+    return {fail, {}};
   }
 
-  // TODO: Currently not using TRITONCACHE_CacheEntryNew/Delete APIs at all.
-  // Currently we create a new cache entry on Triton side, pass it to cache,
-  // and cache adds the items/buffers through C API. Not sure if New/Delete API
-  // is necessary.
   auto entry = std::make_unique<CacheEntry>();
   auto opaque_entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(entry.get());
   auto err = lookup_fn_(cache_impl_, key.c_str(), opaque_entry);
   if (err) {
-    return std::make_pair(
-        Status(
-            TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
-            TRITONSERVER_ErrorMessage(err)),
-        empty_items);
+    auto fail = Status(
+        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
+        TRITONSERVER_ErrorMessage(err));
+    return {fail, {}};
   }
 
   // NOTE: Copies entry's vector of item pointers, entry pointer will be
   // cleaned up.
-  // TODO: Item pointers are currently created on cache impl side by
+  // Item pointers are currently created on cache impl side by
   // TRITONCACHE_CacheEntryItemNew and we need to make sure the cache doesn't
   // call TRITONCACHE_CacheEntryItemDelete before Triton is done with them.
-  // Similarly, we are currently letting Triton clean up the CacheEntryItems
-  // when they go out of scope, so CacheEntryItemDelete API is not being used.
-  // TODO: could probably do better here.
-  return std::make_pair(Status::Success, entry->Items());
+  // Currently, we are letting Triton clean up the CacheEntryItems when they go
+  // out of scope, so CacheEntryItemDelete API is not needed in cache impl.
+  return {Status::Success, entry->Items()};
 }
 
 // NOTE: Multiple responses won't be expected until supporting decoupled

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -77,10 +77,14 @@ TritonCache::TritonCache(
 TritonCache::~TritonCache()
 {
   LOG_VERBOSE(1) << "unloading cache '" << name_ << "'";
-  if (fini_fn_ != nullptr) {
-    LOG_VERBOSE(2) << "Calling TRITONCACHE_CacheDelete from: '" << libpath_
-                   << "'";
-    LOG_TRITONSERVER_ERROR(fini_fn_(cache_impl_), "failed finalizing cache");
+  if (fini_fn_) {
+    if (cache_impl_) {
+      LOG_VERBOSE(1) << "Calling TRITONCACHE_CacheDelete from: '" << libpath_
+                     << "'";
+      LOG_TRITONSERVER_ERROR(fini_fn_(cache_impl_), "failed finalizing cache");
+    } else {
+      LOG_ERROR << "cache implementation handle is nullptr";
+    }
   } else {
     LOG_ERROR << "cache finalize function is nullptr";
   }

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -232,14 +232,13 @@ TritonCache::Insert(
   if (insert_fn_ == nullptr) {
     return Status(Status::Code::NOT_FOUND, "cache insert function is nullptr");
   }
+  // NOTE: Possible optimization - Check if key exists first before forming
+  // Cache Entry
 
-  // TODO: Optimization - Check if key exists first before forming Cache Entry
-
-  // TODO: Similar to Lookup, we are currently creating CacheEntry on Triton
-  // side, and letting cache retrieve the Items/Buffers via C APIs. So
-  // CacheEntryNew/Delete C APIs aren't being used at all.
-  // Cache impl will have to copy the buffers since Triton may invalidate them
-  // shortly after the insert_fn call.
+  // NOTE: Similar to Lookup, we are currently creating CacheEntry on Triton
+  // side, and letting cache retrieve the Items/Buffers via C APIs. The cache
+  // implementation will have to copy the buffers since Triton may invalidate
+  // them shortly after the insert_fn call.
   const auto entry = std::make_unique<CacheEntry>();
   for (const auto& item : items) {
     entry->AddItem(item);

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -63,7 +63,7 @@ class TritonCache {
   Status Lookup(
       boost::span<InferenceResponse*> responses, const std::string& key);
   Status Lookup(InferenceResponse* response, const std::string& key);
-  std::optional<std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
+  std::pair<Status, std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
       const std::string& key);
   // Hashes fields of request and stores it in "key"
   Status Hash(const InferenceRequest& request, std::string* key);

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -53,8 +53,8 @@ class TritonCache {
   const std::string& Name() const { return name_; }
   const std::string& Directory() const { return dir_; }
   const TritonServerMessage* CacheConfig() const { return cache_config_; }
-  // TODO
-  Status Insert(const InferenceResponse& response, uint64_t key);
+  // TODO: const ref?
+  Status Insert(const InferenceResponse* response, const std::string& key);
   Status Lookup(InferenceResponse* response, const std::string& key);
   Status Hash(const InferenceRequest& request, uint64_t* key);
   Status Evict();
@@ -98,10 +98,13 @@ class TritonCache {
   typedef TRITONSERVER_Error* (*TritonCacheFiniFn_t)(TRITONCACHE_Cache* cache);
   TritonCacheFiniFn_t fini_fn_;
   typedef TRITONSERVER_Error* (*TritonCacheLookupFn_t)(
-      TRITONCACHE_Cache* cache, const char* key, void** entries, size_t** sizes,
-      size_t* num_entries);
+      TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
   TritonCacheLookupFn_t lookup_fn_;
-  // TODO: Insert/Evict
+  typedef TRITONSERVER_Error* (*TritonCacheInsertFn_t)(
+      TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
+  TritonCacheInsertFn_t insert_fn_;
+
+  // TODO: Evict
 };
 
 //

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include "cache_entry.h"
 #include "constants.h"
 #include "infer_request.h"
 #include "infer_response.h"
@@ -68,9 +69,14 @@ class TritonCache {
   const TritonServerMessage* CacheConfig() const { return cache_config_; }
   // TODO: const ref?
   Status Insert(const InferenceResponse* response, const std::string& key);
-  Status Insert(boost::span<std::byte> byte_span, const std::string& key);
+  // Status InsertBuffer(boost::span<std::byte> byte_span, const std::string&
+  // key);
+  // TODO: unique vs shared
+  Status Insert(
+      std::vector<std::shared_ptr<CacheEntryItem>> items,
+      const std::string& key);
   Status Lookup(InferenceResponse* response, const std::string& key);
-  std::optional<std::vector<std::vector<std::byte>>> Lookup(
+  std::optional<std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
       const std::string& key);
   Status Hash(const InferenceRequest& request, uint64_t* key);
   Status Evict();

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -56,19 +56,18 @@ class TritonCache {
   const std::string& Name() const { return name_; }
   const std::string& Directory() const { return dir_; }
   const TritonServerMessage* CacheConfig() const { return cache_config_; }
-  // TODO: const ref?
-  Status Insert(const InferenceResponse* response, const std::string& key);
-  // Status InsertBuffer(boost::span<std::byte> byte_span, const std::string&
-  // key);
-  // TODO: unique vs shared
+  Status Insert(
+      boost::span<InferenceResponse*> responses, const std::string& key);
+  Status Insert(InferenceResponse* response, const std::string& key);
   Status Insert(
       std::vector<std::shared_ptr<CacheEntryItem>> items,
       const std::string& key);
+  Status Lookup(
+      boost::span<InferenceResponse*> responses, const std::string& key);
   Status Lookup(InferenceResponse* response, const std::string& key);
   std::optional<std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
       const std::string& key);
   Status Hash(const InferenceRequest& request, std::string* key);
-  Status Evict();
 
  private:
   TritonCache(
@@ -97,13 +96,11 @@ class TritonCache {
 
 
   // Cache Implementation
-  TRITONCACHE_Cache* cache_impl_;  // TODO: Smart pointer / custom deleter?
+  TRITONCACHE_Cache* cache_impl_;
 
   // dlopen / dlsym handles
   void* dlhandle_;
   // TODO: std::function doesn't work here?
-  // using TritonCacheInitFn_t =
-  // std::function<TRITONSERVER_Error*(TRITONCACHE_Cache**)>;
   typedef TRITONSERVER_Error* (*TritonCacheInitFn_t)(TRITONCACHE_Cache** cache);
   TritonCacheInitFn_t init_fn_;
   typedef TRITONSERVER_Error* (*TritonCacheFiniFn_t)(TRITONCACHE_Cache* cache);
@@ -114,8 +111,6 @@ class TritonCache {
   typedef TRITONSERVER_Error* (*TritonCacheInsertFn_t)(
       TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry);
   TritonCacheInsertFn_t insert_fn_;
-
-  // TODO: Evict
 };
 
 //

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -96,7 +96,7 @@ class TritonCache {
   // dlopen / dlsym handles
   void* dlhandle_;
   typedef TRITONSERVER_Error* (*TritonCacheInitFn_t)(
-      TRITONCACHE_Cache** cache, TRITONSERVER_Message* config);
+      TRITONCACHE_Cache** cache, const char* config);
   TritonCacheInitFn_t init_fn_;
   typedef TRITONSERVER_Error* (*TritonCacheFiniFn_t)(TRITONCACHE_Cache* cache);
   TritonCacheFiniFn_t fini_fn_;

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -58,7 +58,7 @@ class TritonCache {
       boost::span<InferenceResponse*> responses, const std::string& key);
   Status Insert(InferenceResponse* response, const std::string& key);
   Status Insert(
-      std::vector<std::shared_ptr<CacheEntryItem>> items,
+      const std::vector<std::shared_ptr<CacheEntryItem>>& items,
       const std::string& key);
   Status Lookup(
       boost::span<InferenceResponse*> responses, const std::string& key);

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -95,7 +95,8 @@ class TritonCache {
 
   // dlopen / dlsym handles
   void* dlhandle_;
-  typedef TRITONSERVER_Error* (*TritonCacheInitFn_t)(TRITONCACHE_Cache** cache);
+  typedef TRITONSERVER_Error* (*TritonCacheInitFn_t)(
+      TRITONCACHE_Cache** cache, TRITONSERVER_Message* config);
   TritonCacheInitFn_t init_fn_;
   typedef TRITONSERVER_Error* (*TritonCacheFiniFn_t)(TRITONCACHE_Cache* cache);
   TritonCacheFiniFn_t fini_fn_;

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -76,7 +76,6 @@ class TritonCache {
   void ClearHandles();
   Status LoadCacheLibrary();
   Status InitializeCacheImpl();
-  Status TestCacheImpl();  // TODO: Remove
   // Helper function to hash data buffers used by "input"
   Status HashInputBuffers(const InferenceRequest::Input* input, size_t* seed);
   // Helper function to hash each input in "request"

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -65,6 +65,7 @@ class TritonCache {
   Status Lookup(InferenceResponse* response, const std::string& key);
   std::optional<std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
       const std::string& key);
+  // Hashes fields of request and stores it in "key"
   Status Hash(const InferenceRequest& request, std::string* key);
 
  private:
@@ -76,6 +77,10 @@ class TritonCache {
   Status LoadCacheLibrary();
   Status InitializeCacheImpl();
   Status TestCacheImpl();  // TODO: Remove
+  // Helper function to hash data buffers used by "input"
+  Status HashInputBuffers(const InferenceRequest::Input* input, size_t* seed);
+  // Helper function to hash each input in "request"
+  Status HashInputs(const InferenceRequest& request, size_t* seed);
 
   // The name of the cache.
   const std::string name_;

--- a/src/cache_manager.h
+++ b/src/cache_manager.h
@@ -40,17 +40,6 @@
 #include "triton/common/model_config.h"
 #include "tritonserver_apis.h"
 
-// If TRITONSERVER error is non-OK, return std::nullopt for failed optional.
-#define RETURN_NULLOPT_IF_TRITONSERVER_ERROR(E)      \
-  do {                                               \
-    TRITONSERVER_Error* err__ = (E);                 \
-    if (err__ != nullptr) {                          \
-      LOG_ERROR << TRITONSERVER_ErrorMessage(err__); \
-      TRITONSERVER_ErrorDelete(err__);               \
-      return std::nullopt;                           \
-    }                                                \
-  } while (false)
-
 namespace triton { namespace core {
 
 //
@@ -78,7 +67,7 @@ class TritonCache {
   Status Lookup(InferenceResponse* response, const std::string& key);
   std::optional<std::vector<std::shared_ptr<CacheEntryItem>>> Lookup(
       const std::string& key);
-  Status Hash(const InferenceRequest& request, uint64_t* key);
+  Status Hash(const InferenceRequest& request, std::string* key);
   Status Evict();
 
  private:

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -80,10 +80,9 @@ DynamicBatchScheduler::DynamicBatchScheduler(
   // Both the server and model config should specify
   // caching enabled for model to utilize response cache.
   response_cache_enabled_ =
-      (response_cache_enable &&
-       model_->Server()->ResponseCacheEnabled() && 
-       model_->Server()->CacheManager() != nullptr &&
-       model_->Server()->CacheManager()->Cache() != nullptr);
+      (response_cache_enable && model_->Server()->ResponseCacheEnabled() &&
+       model_->Server()->CacheManager() &&
+       model_->Server()->CacheManager()->Cache());
 #ifdef TRITON_ENABLE_METRICS
   // Initialize metric reporter for cache statistics if cache enabled
   if (response_cache_enabled_) {
@@ -681,7 +680,6 @@ DynamicBatchScheduler::CacheLookUp(
 
   // Lookup and capture timestamps
   {
-    LOG_VERBOSE(1) << "Looking up in cache for key: " << key;
     request->CaptureCacheLookupStartNs();
     status = cache->Lookup(local_response.get(), key);
     request->CaptureCacheLookupEndNs();

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -663,6 +663,7 @@ DynamicBatchScheduler::CacheLookUp(
     request->SetCacheKey(key);
   }
   // TODO: cleanup key/hash logic
+  LOG_VERBOSE(1) << "Looking up in cache for key: " << key;
   status = cache->Lookup(local_response.get(), key);
   if (status.IsOk() && (local_response != nullptr)) {
     cached_response = std::move(local_response);

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -80,7 +80,10 @@ DynamicBatchScheduler::DynamicBatchScheduler(
   // Both the server and model config should specify
   // caching enabled for model to utilize response cache.
   response_cache_enabled_ =
-      (model_->Server()->ResponseCacheEnabled() && response_cache_enable);
+      (response_cache_enable &&
+       model_->Server()->ResponseCacheEnabled() && 
+       model_->Server()->CacheManager() != nullptr &&
+       model_->Server()->CacheManager()->Cache() != nullptr);
 #ifdef TRITON_ENABLE_METRICS
   // Initialize metric reporter for cache statistics if cache enabled
   if (response_cache_enabled_) {

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -611,7 +611,7 @@ DynamicBatchScheduler::DelegateResponse(
           // Cache insertion happens here because we need the backend to have
           // computed the inference response first in the case of cache miss
           auto cache = model_->Server()->CacheManager()->Cache();
-          auto status = cache->Insert(*response, key);
+          auto status = cache->Insert(response.get(), std::to_string(key));
           bool cache_miss =
               (status.StatusCode() != Status::Code::ALREADY_EXISTS);
           if (cache_miss) {

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -668,9 +668,9 @@ DynamicBatchScheduler::CacheLookUp(
   // Hash request into cache key
   std::string key = "";
   if (!request->CacheKeyIsSet()) {
-    status = cache->Hash(*request, &key);  // TODO: Check error
+    status = cache->Hash(*request, &key);
     if (!status.IsOk()) {
-      LOG_ERROR << "Failed to hash request";
+      LOG_ERROR << "Failed to hash request: " << status.Message();
       return;
     }
     request->SetCacheKey(key);

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1121,36 +1121,6 @@ InferenceRequest::ReportStatisticsCacheHit(MetricModelReporter* metric_reporter)
         request_end_ns, cache_lookup_duration_ns);
   }
 }
-
-void
-InferenceRequest::ReportStatisticsCacheMiss(
-    MetricModelReporter* metric_reporter)
-{
-  if (cache_lookup_start_ns_ >= cache_lookup_end_ns_) {
-    LOG_WARNING << LogRequest()
-                << "Cache lookup timestamps were not set correctly. Cache "
-                   "lookup duration stats may be incorrect.";
-  }
-  if (cache_insertion_start_ns_ >= cache_insertion_end_ns_) {
-    LOG_WARNING << LogRequest()
-                << "Cache insertion timestamps were not set correctly. Cache "
-                   "insertion duration stats may be incorrect.";
-  }
-
-  const uint64_t cache_lookup_duration_ns =
-      cache_lookup_end_ns_ - cache_lookup_start_ns_;
-
-  const uint64_t cache_insertion_duration_ns =
-      cache_insertion_end_ns_ - cache_insertion_start_ns_;
-
-  model_raw_->MutableStatsAggregator()->UpdateSuccessCacheMiss(
-      metric_reporter, cache_lookup_duration_ns, cache_insertion_duration_ns);
-  if (secondary_stats_aggregator_ != nullptr) {
-    secondary_stats_aggregator_->UpdateSuccessCacheMiss(
-        nullptr /* metric_reporter */, cache_lookup_duration_ns,
-        cache_insertion_duration_ns);
-  }
-}
 #endif  // TRITON_ENABLE_STATS
 
 //

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -311,10 +311,10 @@ class InferenceRequest {
   uint64_t TimeoutMicroseconds() const { return timeout_us_; }
   void SetTimeoutMicroseconds(uint64_t t) { timeout_us_ = t; }
 
-  uint64_t CacheKey() const { return cache_key_; }
+  std::string CacheKey() const { return cache_key_; }
   // It is up to the user to update the cache_key_ if modifying any hashable
   // fields of the request after cache_key_is_set_ has been set to true.
-  void SetCacheKey(uint64_t key)
+  void SetCacheKey(std::string key)
   {
     cache_key_ = key;
     cache_key_is_set_ = true;
@@ -707,7 +707,7 @@ class InferenceRequest {
   uint32_t batch_size_;
   uint32_t priority_;
   uint64_t timeout_us_;
-  uint64_t cache_key_ = 0;
+  std::string cache_key_;
   // Helper to determine if request was successfully hashed
   // and cache_key_ field is valid
   bool cache_key_is_set_ = false;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -311,10 +311,10 @@ class InferenceRequest {
   uint64_t TimeoutMicroseconds() const { return timeout_us_; }
   void SetTimeoutMicroseconds(uint64_t t) { timeout_us_ = t; }
 
-  std::string CacheKey() const { return cache_key_; }
+  const std::string& CacheKey() const { return cache_key_; }
   // It is up to the user to update the cache_key_ if modifying any hashable
   // fields of the request after cache_key_is_set_ has been set to true.
-  void SetCacheKey(std::string key)
+  void SetCacheKey(const std::string& key)
   {
     cache_key_ = key;
     cache_key_is_set_ = true;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -683,7 +683,7 @@ class InferenceRequest {
   uint32_t batch_size_;
   uint32_t priority_;
   uint64_t timeout_us_;
-  std::string cache_key_;
+  std::string cache_key_ = "";
   // Helper to determine if request was successfully hashed
   // and cache_key_ field is valid
   bool cache_key_is_set_ = false;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -598,26 +598,6 @@ class InferenceRequest {
     return cache_lookup_end_ns_;
   }
 
-  uint64_t CacheInsertionStartNs() const { return cache_insertion_start_ns_; }
-  uint64_t CaptureCacheInsertionStartNs()
-  {
-    cache_insertion_start_ns_ =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::steady_clock::now().time_since_epoch())
-            .count();
-    return cache_insertion_start_ns_;
-  }
-
-  uint64_t CacheInsertionEndNs() const { return cache_insertion_end_ns_; }
-  uint64_t CaptureCacheInsertionEndNs()
-  {
-    cache_insertion_end_ns_ =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            std::chrono::steady_clock::now().time_since_epoch())
-            .count();
-    return cache_insertion_end_ns_;
-  }
-
   uint64_t BatcherStartNs() const { return batcher_start_ns_; }
   uint64_t CaptureBatcherStartNs()
   {
@@ -653,13 +633,9 @@ class InferenceRequest {
       const uint64_t compute_output_duration_ns);
 
   // Report the statistics to stats collectors associated with the request on
-  // response cache hits.
+  // response cache hits. Cache miss stats will be updated through model object
+  // directly because the backend may release the request object.
   void ReportStatisticsCacheHit(MetricModelReporter* metric_reporter);
-
-  // Report the statistics to stats collectors associated with the request on
-  // response cache misses and update request duration to include cache
-  // insertion time.
-  void ReportStatisticsCacheMiss(MetricModelReporter* metric_reporter);
 
   // Statistics for each request are aggregated into the corresponding
   // model's statistics. Optionally this function may be used to

--- a/src/libtritonserver.ldscript
+++ b/src/libtritonserver.ldscript
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/libtritonserver.ldscript
+++ b/src/libtritonserver.ldscript
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,5 +28,6 @@
     TRITONSERVER_*;
     TRITONBACKEND_*;
     TRITONREPOAGENT_*;
+    TRITONCACHE_*;
   local: *;
 };

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -273,8 +273,7 @@ Metrics::EnableMetrics()
 }
 
 void
-Metrics::EnableCacheMetrics(
-    std::shared_ptr<TritonCache> response_cache)
+Metrics::EnableCacheMetrics(std::shared_ptr<TritonCache> response_cache)
 {
   auto singleton = GetSingleton();
   // Ensure thread-safe enabling of Cache Metrics
@@ -345,8 +344,7 @@ Metrics::StartPollingThreadSingleton(
 }
 
 bool
-Metrics::StartPollingThread(
-    std::shared_ptr<TritonCache> response_cache)
+Metrics::StartPollingThread(std::shared_ptr<TritonCache> response_cache)
 {
   // Nothing to poll if no polling metrics enabled, don't spawn a thread
   if (!cache_metrics_enabled_ && !gpu_metrics_enabled_ &&
@@ -705,8 +703,7 @@ Metrics::PollDcgmMetrics()
 }
 
 bool
-Metrics::InitializeCacheMetrics(
-    std::shared_ptr<TritonCache> response_cache)
+Metrics::InitializeCacheMetrics(std::shared_ptr<TritonCache> response_cache)
 {
   if (response_cache == nullptr) {
     LOG_WARNING

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -31,12 +31,12 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include "cache_manager.h"
 #include "prometheus/counter.h"
 #include "prometheus/gauge.h"
 #include "prometheus/registry.h"
 #include "prometheus/serializer.h"
 #include "prometheus/text_serializer.h"
-#include "cache_manager.h"
 
 #ifdef TRITON_ENABLE_METRICS_GPU
 #include <dcgm_agent.h>
@@ -118,8 +118,7 @@ class Metrics {
   static void EnableCpuMetrics();
 
   // Enable reporting of Cache metrics
-  static void EnableCacheMetrics(
-      std::shared_ptr<TritonCache> response_cache);
+  static void EnableCacheMetrics(std::shared_ptr<TritonCache> response_cache);
 
   // Start a thread for polling enabled metrics if any
   static void StartPollingThreadSingleton(
@@ -228,8 +227,7 @@ class Metrics {
   static Metrics* GetSingleton();
   bool InitializeDcgmMetrics();
   bool InitializeCpuMetrics();
-  bool InitializeCacheMetrics(
-      std::shared_ptr<TritonCache> response_cache);
+  bool InitializeCacheMetrics(std::shared_ptr<TritonCache> response_cache);
   bool StartPollingThread(std::shared_ptr<TritonCache> response_cache);
   bool PollCacheMetrics(std::shared_ptr<TritonCache> response_cache);
   bool PollDcgmMetrics();

--- a/src/server.cc
+++ b/src/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/server.cc
+++ b/src/server.cc
@@ -164,7 +164,6 @@ InferenceServer::Init()
     return status;
   }
 
-
   if (buffer_manager_thread_count_ > 0) {
     status = CommonErrorToStatus(triton::common::AsyncWorkQueue::Initialize(
         buffer_manager_thread_count_));

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/server.h
+++ b/src/server.h
@@ -196,6 +196,8 @@ class InferenceServer {
   // NOTE: Models still need caching enabled in individual model configs.
   bool ResponseCacheEnabled() const { return response_cache_enabled_; }
   void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
+  std::string CacheConfig() const { return cache_config_; }
+  void SetCacheConfig(std::string config_json) { cache_config_ = config_json; }
 
   // Get / set CUDA memory pool size
   const std::map<int, uint64_t>& CudaMemoryPoolByteSize() const
@@ -293,6 +295,7 @@ class InferenceServer {
   uint32_t model_load_thread_count_;
   uint64_t pinned_memory_pool_size_;
   bool response_cache_enabled_;
+  std::string cache_config_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_supported_compute_capability_;
   triton::common::BackendCmdlineConfigMap backend_cmdline_config_map_;

--- a/src/server.h
+++ b/src/server.h
@@ -273,14 +273,14 @@ class InferenceServer {
     return backend_manager_;
   }
 
+  // Return the pointer to RateLimiter object.
+  std::shared_ptr<RateLimiter> GetRateLimiter() { return rate_limiter_; }
+
   // Get the Cache Manager
   const std::shared_ptr<TritonCacheManager>& CacheManager()
   {
     return cache_manager_;
   }
-
-  // Return the pointer to RateLimiter object.
-  std::shared_ptr<RateLimiter> GetRateLimiter() { return rate_limiter_; }
 
  private:
   const std::string version_;

--- a/src/server.h
+++ b/src/server.h
@@ -198,6 +198,8 @@ class InferenceServer {
   void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
   std::string CacheConfig() const { return cache_config_; }
   void SetCacheConfig(std::string config_json) { cache_config_ = config_json; }
+  std::string CacheDir() const { return cache_dir_; }
+  void SetCacheDir(std::string dir) { cache_dir_ = dir; }
 
   // Get / set CUDA memory pool size
   const std::map<int, uint64_t>& CudaMemoryPoolByteSize() const
@@ -296,6 +298,7 @@ class InferenceServer {
   uint64_t pinned_memory_pool_size_;
   bool response_cache_enabled_;
   std::string cache_config_;
+  std::string cache_dir_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_supported_compute_capability_;
   triton::common::BackendCmdlineConfigMap backend_cmdline_config_map_;

--- a/src/server.h
+++ b/src/server.h
@@ -192,15 +192,10 @@ class InferenceServer {
     pinned_memory_pool_size_ = std::max((int64_t)0, s);
   }
 
-  // Get / set the response cache byte size.
-  uint64_t ResponseCacheByteSize() const { return response_cache_byte_size_; }
-  void SetResponseCacheByteSize(uint64_t s)
-  {
-    response_cache_byte_size_ = s;
-    response_cache_enabled_ = (s > 0) ? true : false;
-  }
-
+  // Get / set whether response cache will be enabled server-wide.
+  // NOTE: Models still need caching enabled in individual model configs.
   bool ResponseCacheEnabled() const { return response_cache_enabled_; }
+  void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
 
   // Get / set CUDA memory pool size
   const std::map<int, uint64_t>& CudaMemoryPoolByteSize() const
@@ -297,8 +292,6 @@ class InferenceServer {
   uint32_t buffer_manager_thread_count_;
   uint32_t model_load_thread_count_;
   uint64_t pinned_memory_pool_size_;
-  // TODO: remove or extract?
-  uint64_t response_cache_byte_size_;
   bool response_cache_enabled_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_supported_compute_capability_;
@@ -307,7 +300,6 @@ class InferenceServer {
   std::string repoagent_dir_;
   RateLimitMode rate_limit_mode_;
   RateLimiter::ResourceMap rate_limit_resource_map_;
-
 
   // Current state of the inference server.
   ServerReadyState ready_state_;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -82,9 +82,8 @@ set(
   ../memory.h
 )
 
-# FIXME: Compile cache test after reorganizing cache code
 #
-# Unit test for RequestResponseCache
+# Unit test for TritonCache
 #
 if(${TRITON_ENABLE_GPU})
   add_executable(

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -86,78 +86,86 @@ set(
 #
 # Unit test for RequestResponseCache
 #
-#if(${TRITON_ENABLE_GPU})
-#  add_executable(
-#    response_cache_test
-#    response_cache_test.cc
-#    ../response_cache.cc
-#    ../response_cache.h
-#    ../status.cc
-#    ../status.h
-#    ../constants.h
-#    ${MEMORY_SRCS}
-#    ${CUDA_MEMORY_MANAGER_SRCS}
-#    ${PINNED_MEMORY_MANAGER_SRCS}
-#    ${MEMORY_HDRS}
-#    ${CUDA_MEMORY_MANAGER_HDRS}
-#    ${PINNED_MEMORY_MANAGER_HDRS}
-#  )
-#
-#  set_target_properties(
-#    response_cache_test
-#    PROPERTIES
-#      SKIP_BUILD_RPATH TRUE
-#      BUILD_WITH_INSTALL_RPATH TRUE
-#      INSTALL_RPATH_USE_LINK_PATH FALSE
-#      INSTALL_RPATH ""
-#  )
-#
-#  target_include_directories(
-#    response_cache_test
-#    PRIVATE
-#      ${CMAKE_CURRENT_SOURCE_DIR}/..
-#      ${CMAKE_CURRENT_SOURCE_DIR}/../../include
-#      ${GTEST_INCLUDE_DIRS}
-#      ${CNMEM_PATH}/include
-#  )
-#
-#  target_compile_definitions(
-#    response_cache_test
-#    PRIVATE
-#      TRITON_ENABLE_LOGGING=1
-#      TRITON_ENABLE_GPU=1
-#      TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
-#  )
-#
-#  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
-#
-#  target_link_libraries(
-#    response_cache_test
-#    PRIVATE
-#      triton-common-error        # from repo-common
-#      triton-common-logging      # from repo-common
-#      proto-library              # from repo-common
-#      GTest::gtest
-#      GTest::gtest_main
-#      protobuf::libprotobuf
-#      ${CNMEM_LIBRARY}
-#      CUDA::cudart
-#  )
-#
-#  if (NOT WIN32)
-#    target_link_libraries(
-#      response_cache_test
-#      PRIVATE
-#        dl
-#        numa
-#    )
-#  endif()
-#
-#  install(
-#    TARGETS response_cache_test
-#    RUNTIME DESTINATION bin
-#  )
-#endif() # TRITON_ENABLE_GPU
+if(${TRITON_ENABLE_GPU})
+  add_executable(
+    response_cache_test
+    response_cache_test.cc
+    ../cache_manager.cc
+    ../cache_manager.h
+    ../cache_entry.cc
+    ../cache_entry.h
+    ../filesystem.cc
+    ../filesystem.h
+    ../shared_library.cc
+    ../shared_library.h
+    ../status.cc
+    ../status.h
+    ../constants.h
+    ${MEMORY_SRCS}
+    ${CUDA_MEMORY_MANAGER_SRCS}
+    ${PINNED_MEMORY_MANAGER_SRCS}
+    ${MEMORY_HDRS}
+    ${CUDA_MEMORY_MANAGER_HDRS}
+    ${PINNED_MEMORY_MANAGER_HDRS}
+  )
+
+  set_target_properties(
+    response_cache_test
+    PROPERTIES
+      SKIP_BUILD_RPATH TRUE
+      BUILD_WITH_INSTALL_RPATH TRUE
+      INSTALL_RPATH_USE_LINK_PATH FALSE
+      INSTALL_RPATH ""
+  )
+
+  target_include_directories(
+    response_cache_test
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/..
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+      ${GTEST_INCLUDE_DIRS}
+      ${CNMEM_PATH}/include
+  )
+
+  target_compile_definitions(
+    response_cache_test
+    PRIVATE
+      TRITON_ENABLE_LOGGING=1
+      TRITON_ENABLE_GPU=1
+      TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
+  )
+
+  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
+
+  target_link_libraries(
+    response_cache_test
+    PRIVATE
+      triton-common-error        # from repo-common
+      triton-common-logging      # from repo-common
+      triton-common-model-config # from repo-common
+      proto-library              # from repo-common
+      triton-core
+      GTest::gtest
+      GTest::gtest_main
+      protobuf::libprotobuf
+      ${CNMEM_LIBRARY}
+      CUDA::cudart
+  )
+
+  if (NOT WIN32)
+    target_link_libraries(
+      response_cache_test
+      PRIVATE
+        dl
+        numa
+    )
+  endif()
+
+  install(
+    TARGETS response_cache_test
+    RUNTIME DESTINATION bin
+  )
+endif() # TRITON_ENABLE_GPU
 
 #
 # Unit test for Query

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -660,7 +660,7 @@ TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryBytes)
   // Setup items
   std::shared_ptr<tc::CacheEntryItem> large_item(new tc::CacheEntryItem());
   // Add buffers to items
-  large_item->AddBuffer(large_data);
+  large_item->AddBufferCopy(large_data);
 
   std::cout << "Create large_response (larger than cache) of size: "
             << large_data.size() << std::endl;
@@ -738,11 +738,11 @@ TEST_F(RequestResponseCacheTest, TestCacheInsertLookupCompareBytes)
   std::shared_ptr<tc::CacheEntryItem> item1(new tc::CacheEntryItem());
   std::shared_ptr<tc::CacheEntryItem> item2(new tc::CacheEntryItem());
   // Add buffers to items
-  item1->AddBuffer(buffer1);
-  item1->AddBuffer(buffer2);
-  item2->AddBuffer(buffer3);
-  item2->AddBuffer(buffer4);
-  item2->AddBuffer(buffer5);
+  item1->AddBufferCopy(buffer1);
+  item1->AddBufferCopy(buffer2);
+  item2->AddBufferCopy(buffer3);
+  item2->AddBufferCopy(buffer4);
+  item2->AddBufferCopy(buffer5);
 
   helpers::check_status(
       helpers::InsertLookupCompare(cache, {item1}, "TestCacheSingleItemBytes"));

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -23,6 +23,7 @@
 // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "gtest/gtest-spi.h"
 #include "gtest/gtest.h"
 
 #include <thread>
@@ -306,76 +307,9 @@ InferenceRequest::SequenceId::SequenceId(uint64_t sequence_index)
 }}  // namespace triton::core
 
 
-namespace {
+namespace helpers {
 
 // Helpers
-tc::Status
-TestCacheImpl(std::shared_ptr<tc::TritonCache> cache)
-{
-  std::cout << "======================================" << std::endl;
-  std::cout << "==== Testing Cache Implementation ====" << std::endl;
-  std::cout << "======================================" << std::endl;
-  if (!cache) {
-    return tc::Status(tc::Status::Code::INTERNAL, "cache was nullptr");
-  }
-
-  auto status = tc::Status::Success;
-  std::cout << "=============== Insert Bytes ===============" << std::endl;
-  // Setup byte buffers
-  std::vector<std::byte> buffer1{1, std::byte{0x01}};
-  std::vector<std::byte> buffer2{2, std::byte{0x02}};
-  std::vector<std::byte> buffer3{4, std::byte{0x03}};
-  std::vector<std::byte> buffer4{8, std::byte{0x04}};
-  std::vector<std::byte> buffer5{16, std::byte{0xFF}};
-  // Setup items
-  std::vector<std::shared_ptr<tc::CacheEntryItem>> items;
-  items.emplace_back(new tc::CacheEntryItem());
-  items.emplace_back(new tc::CacheEntryItem());
-  // Add buffers to items
-  items[0]->AddBuffer(buffer1);
-  items[0]->AddBuffer(buffer2);
-  items[1]->AddBuffer(buffer3);
-  items[1]->AddBuffer(buffer4);
-  items[1]->AddBuffer(buffer5);
-  status = cache->Insert(items, "test_bytes_123_key");
-  std::cout << "=============== Lookup Bytes ===============" << std::endl;
-  const auto responses = cache->Lookup("test_bytes_123_key");
-  if (!responses.has_value()) {
-    return tc::Status(tc::Status::Code::INTERNAL, "Lookup failed");
-  }
-  const auto lookup_items = responses.value();
-  if (lookup_items.size() != items.size()) {
-    return tc::Status(
-        tc::Status::Code::INTERNAL, "Expected " + std::to_string(items.size()) +
-                                        " got " +
-                                        std::to_string(lookup_items.size()));
-  }
-
-  for (size_t i = 0; i < items.size(); i++) {
-    auto expected_buffers = items[i]->Buffers();
-    auto lookup_buffers = lookup_items[i]->Buffers();
-    if (lookup_buffers.size() != expected_buffers.size()) {
-      return tc::Status(
-          tc::Status::Code::INTERNAL,
-          "Expected " + std::to_string(expected_buffers.size()) + " got " +
-              std::to_string(lookup_buffers.size()));
-    }
-
-
-    for (size_t b = 0; b < expected_buffers.size(); b++) {
-      if (lookup_buffers[b] != expected_buffers[b]) {
-        return tc::Status(
-            tc::Status::Code::INTERNAL,
-            "Buffer bytes didn't match for test input");
-      }
-    }
-  }
-  std::cout << "======================================" << std::endl;
-  std::cout << "============ Done Testing ============" << std::endl;
-  std::cout << "======================================" << std::endl;
-  return tc::Status::Success;
-}
-
 void
 check_status(tc::Status status)
 {
@@ -383,11 +317,29 @@ check_status(tc::Status status)
 }
 
 void
+insert(
+    std::shared_ptr<tc::TritonCache> cache, tc::InferenceResponse* r,
+    std::string key)
+{
+  printf("Inserting key: %s\n", key.c_str());
+  check_status(cache->Insert(r, key));
+}
+
+void
+lookup(
+    std::shared_ptr<tc::TritonCache> cache, tc::InferenceResponse* r,
+    std::string key)
+{
+  printf("Looking up key: %s\n", key.c_str());
+  check_status(cache->Lookup(r, key));
+}
+
+void
 reset_response(
     std::unique_ptr<tc::InferenceResponse>* response,
     tc::InferenceRequest* request)
 {
-  check_status(request->ResponseFactory()->CreateResponse(response));
+  helpers::check_status(request->ResponseFactory()->CreateResponse(response));
 }
 
 // Only support 1-Dimensional data to keep it simple
@@ -401,11 +353,11 @@ std::unique_ptr<tc::InferenceResponse>
 GenerateResponse(
     const tc::InferenceRequest* request, inference::DataType dtype,
     TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
-    const std::vector<Tensor>& outputs)
+    const std::vector<helpers::Tensor>& outputs)
 {
   std::cout << "Create response object" << std::endl;
   std::unique_ptr<tc::InferenceResponse> response;
-  check_status(request->ResponseFactory()->CreateResponse(&response));
+  helpers::check_status(request->ResponseFactory()->CreateResponse(&response));
 
   std::cout << "Add output metadata to response object" << std::endl;
   for (const auto& tensor : outputs) {
@@ -420,12 +372,12 @@ GenerateResponse(
     shape[1] = tensor.data.size();
     uint64_t output_size = sizeof(tensor.data[0]) * tensor.data.size();
     std::cout << "Output size bytes: " << output_size << std::endl;
-    check_status(
+    helpers::check_status(
         response->AddOutput(tensor.name, dtype, shape, &response_output));
 
     std::cout << "Allocate output data buffer for response object" << std::endl;
     void* buffer;
-    check_status(response_output->AllocateDataBuffer(
+    helpers::check_status(response_output->AllocateDataBuffer(
         &buffer, output_size, &memory_type, &memory_type_id));
     if (buffer == nullptr) {
       std::cout << "[ERROR] buffer was nullptr;" << std::endl;
@@ -443,7 +395,7 @@ tc::InferenceRequest*
 GenerateRequest(
     tc::Model* model, uint64_t model_version, inference::DataType dtype,
     TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
-    const std::vector<Tensor>& inputs, const std::string& request_id)
+    const std::vector<helpers::Tensor>& inputs, const std::string& request_id)
 {
   auto request = new tc::InferenceRequest(model, model_version);
   for (const auto& tensor : inputs) {
@@ -467,10 +419,107 @@ GenerateRequest(
         tensor.data.data(), input_size, memory_type, memory_type_id);
   }
   // PrepareForInference for use of ImmutableInputs()
-  check_status(request->PrepareForInference());
+  helpers::check_status(request->PrepareForInference());
   request->SetId(request_id);  // for debugging purposes
   return request;
 }
+
+tc::Status
+InsertLookupCompare(
+    std::shared_ptr<tc::TritonCache> cache,
+    std::vector<std::shared_ptr<tc::CacheEntryItem>> items, std::string key)
+{
+  if (!cache) {
+    return tc::Status(tc::Status::Code::INTERNAL, "cache was nullptr");
+  }
+
+  std::cout << "=============== Insert ===============" << std::endl;
+  helpers::check_status(cache->Insert(items, key));
+  std::cout << "=============== Lookup ===============" << std::endl;
+  const auto responses = cache->Lookup(key);
+  if (!responses.has_value()) {
+    return tc::Status(tc::Status::Code::INTERNAL, "Lookup failed");
+  }
+  const auto lookup_items = responses.value();
+  // Compare cached items to inserted items
+  if (lookup_items.size() != items.size()) {
+    return tc::Status(
+        tc::Status::Code::INTERNAL, "Expected " + std::to_string(items.size()) +
+                                        " got " +
+                                        std::to_string(lookup_items.size()));
+  }
+
+  for (size_t i = 0; i < items.size(); i++) {
+    auto expected_buffers = items[i]->Buffers();
+    auto lookup_buffers = lookup_items[i]->Buffers();
+    if (lookup_buffers.size() != expected_buffers.size()) {
+      return tc::Status(
+          tc::Status::Code::INTERNAL,
+          "Expected " + std::to_string(expected_buffers.size()) + " got " +
+              std::to_string(lookup_buffers.size()));
+    }
+
+
+    for (size_t b = 0; b < expected_buffers.size(); b++) {
+      boost::span<std::byte> lookup = {
+          static_cast<std::byte*>(lookup_buffers[b].first),
+          lookup_buffers[b].second};
+      boost::span<std::byte> expected = {
+          static_cast<std::byte*>(expected_buffers[b].first),
+          expected_buffers[b].second};
+      // if (lookup_buffers[b] != expected_buffers[b]) {
+      if (!std::equal(
+              lookup.begin(), lookup.end(), expected.begin(), expected.end())) {
+        return tc::Status(
+            tc::Status::Code::INTERNAL,
+            "Buffer bytes didn't match for test input");
+      }
+    }
+  }
+  return tc::Status::Success;
+}
+
+std::shared_ptr<tc::TritonCache>
+CreateCache(uint64_t cache_size)
+{
+  // Create TritonCacheManager
+  std::shared_ptr<tc::TritonCacheManager> cache_manager;
+  auto cache_dir = "/opt/tritonserver/caches";
+  helpers::check_status(
+      tc::TritonCacheManager::Create(&cache_manager, cache_dir));
+
+  // Create TritonCache
+  std::shared_ptr<tc::TritonCache> cache;
+  auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
+  std::cout << "Creating cache with size: " << cache_size << std::endl;
+  helpers::check_status(cache_manager->CreateCache(
+      "response_cache" /* name */, cache_config, &cache));
+
+  return cache;
+}
+
+void
+CreateCacheExpectFail(std::string cache_config)
+{
+  // Create TritonCacheManager
+  std::shared_ptr<tc::TritonCacheManager> cache_manager;
+  auto cache_dir = "/opt/tritonserver/caches";
+  helpers::check_status(
+      tc::TritonCacheManager::Create(&cache_manager, cache_dir));
+
+  // Create TritonCache
+  std::shared_ptr<tc::TritonCache> cache;
+  auto status = cache_manager->CreateCache(
+      "response_cache" /* name */, cache_config, &cache);
+
+  ASSERT_FALSE(status.IsOk()) << "Creating cache with config: '" << cache_config
+                              << "' succeeded when it should fail.";
+  ASSERT_EQ(cache, nullptr);
+}
+
+}  // namespace helpers
+
+namespace {
 
 // Test Fixture
 class RequestResponseCacheTest : public ::testing::Test {
@@ -482,29 +531,31 @@ class RequestResponseCacheTest : public ::testing::Test {
     data1 = {5, 6, 7, 8};
 
     // Sample input vectors
-    inputs0 = std::vector<Tensor>{{"input", data0}};
-    inputs1 = std::vector<Tensor>{{"input", data1}};
-    inputs2 = std::vector<Tensor>{{"input", data1}};
-    inputs3 = std::vector<Tensor>{{"input0", data0}, {"input1", data1}};
-    inputs4 = std::vector<Tensor>{{"input1", data1}, {"input0", data0}};
+    inputs0 = std::vector<helpers::Tensor>{{"input", data0}};
+    inputs1 = std::vector<helpers::Tensor>{{"input", data1}};
+    inputs2 = std::vector<helpers::Tensor>{{"input", data1}};
+    inputs3 =
+        std::vector<helpers::Tensor>{{"input0", data0}, {"input1", data1}};
+    inputs4 =
+        std::vector<helpers::Tensor>{{"input1", data1}, {"input0", data0}};
 
     // Create three requests with same input name, two with same data, one with
     // different data
-    request0 = GenerateRequest(
+    request0 = helpers::GenerateRequest(
         model, model_version, dtype, memory_type, memory_type_id, inputs0,
         "request0");
-    request1 = GenerateRequest(
+    request1 = helpers::GenerateRequest(
         model, model_version, dtype, memory_type, memory_type_id, inputs1,
         "request1");
-    request2 = GenerateRequest(
+    request2 = helpers::GenerateRequest(
         model, model_version, dtype, memory_type, memory_type_id, inputs2,
         "request2");
     // Create two requests with the same two inputs but inserted in different
     // order
-    request3 = GenerateRequest(
+    request3 = helpers::GenerateRequest(
         model, model_version, dtype, memory_type, memory_type_id, inputs3,
         "request3");
-    request4 = GenerateRequest(
+    request4 = helpers::GenerateRequest(
         model, model_version, dtype, memory_type, memory_type_id, inputs4,
         "request4");
     // Verify requests were created correctly
@@ -517,11 +568,12 @@ class RequestResponseCacheTest : public ::testing::Test {
     // Generate a set of unique requests to use for parallelism tests
     for (size_t idx = 0; idx < thread_count; idx++) {
       std::vector<int> data(thread_count, static_cast<int>(idx));
-      std::vector<Tensor> inputs{Tensor{"input" + std::to_string(idx), data}};
+      std::vector<helpers::Tensor> inputs{
+          helpers::Tensor{"input" + std::to_string(idx), data}};
 
       std::string request_id = "unique" + std::to_string(idx);
       std::cout << "Generating request: " << request_id << std::endl;
-      auto request = GenerateRequest(
+      auto request = helpers::GenerateRequest(
           model, model_version, dtype, memory_type, memory_type_id, inputs,
           request_id);
       ASSERT_NE(request, nullptr);
@@ -530,19 +582,19 @@ class RequestResponseCacheTest : public ::testing::Test {
     ASSERT_EQ(unique_requests.size(), thread_count);
 
     // Sample outputs
-    Tensor output_tensor0 = {"output", data0};
+    helpers::Tensor output_tensor0 = {"output", data0};
     output0_size = sizeof(int) * data0.size();
-    outputs0 = std::vector<Tensor>{output_tensor0};
+    outputs0 = std::vector<helpers::Tensor>{output_tensor0};
     // Response of 100 ints, taking ~400 bytes at a time
     data100 = std::vector<int>(100, 0);
-    Tensor output_tensor100 = {"output", data100};
-    outputs100 = std::vector<Tensor>{output_tensor100};
+    helpers::Tensor output_tensor100 = {"output", data100};
+    outputs100 = std::vector<helpers::Tensor>{output_tensor100};
 
     // Sample responses
-    response0 = GenerateResponse(
+    response0 = helpers::GenerateResponse(
         request0, dtype, memory_type, memory_type_id, outputs0);
     ASSERT_NE(response0, nullptr);
-    response_400bytes = GenerateResponse(
+    response_400bytes = helpers::GenerateResponse(
         request0, dtype, memory_type, memory_type_id, outputs100);
     ASSERT_NE(response_400bytes, nullptr);
   }
@@ -569,35 +621,330 @@ class RequestResponseCacheTest : public ::testing::Test {
   uint64_t output0_size;
 
   std::vector<int> data0, data1, data100;
-  std::vector<Tensor> inputs0, inputs1, inputs2, inputs3, inputs4, inputs100;
-  std::vector<Tensor> outputs0, outputs100;
+  std::vector<helpers::Tensor> inputs0, inputs1, inputs2, inputs3, inputs4,
+      inputs100;
+  std::vector<helpers::Tensor> outputs0, outputs100;
   tc::InferenceRequest *request0, *request1, *request2, *request3, *request4;
   std::vector<tc::InferenceRequest*> unique_requests;
   std::unique_ptr<tc::InferenceResponse> response0, response_400bytes;
 };
 
-
-// Test end-to-end flow of cache
-TEST_F(RequestResponseCacheTest, TestEndToEnd)
+// Test cache size too small to initialize.
+TEST_F(RequestResponseCacheTest, TestCacheSizeTooSmall)
 {
-  std::cout << "Create cache" << std::endl;
+  // Pick intentionally small cache size, expecting failure
+  constexpr uint64_t cache_size = 1;
+  auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
+  std::cout << "Create cache of size: " << cache_size << std::endl;
+  helpers::CreateCacheExpectFail(cache_config);
+}
 
-  // Create CacheManager
-  std::shared_ptr<tc::TritonCacheManager> cache_manager;
-  auto cache_dir = "/opt/tritonserver/caches";
-  check_status(tc::TritonCacheManager::Create(&cache_manager, cache_dir));
+// Test cache size too large to initialize.
+TEST_F(RequestResponseCacheTest, TestCacheSizeTooLarge)
+{
+  // Pick intentionally large cache size, expecting failure
+  constexpr uint64_t cache_size = ULLONG_MAX;
+  auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
+  std::cout << "Create cache of size: " << cache_size << std::endl;
+  helpers::CreateCacheExpectFail(cache_config);
+}
 
-  // Create Cache
-  std::shared_ptr<tc::TritonCache> cache;
-  auto cache_config = R"({"size": 256})";
-  check_status(cache_manager->CreateCache(
-      "response_cache" /* name */, cache_config, &cache));
-  ASSERT_NE(cache, nullptr);
+TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryBytes)
+{
+  constexpr uint64_t cache_size = 4 * 1024 * 1024;  // 4 MB, arbitrary
+  auto cache = helpers::CreateCache(cache_size);
 
-  // TODO: Flesh out test more
-  check_status(TestCacheImpl(cache));
+  // Setup byte buffer larger than cache size
+  std::vector<std::byte> large_data(cache_size + 1);
+  // Setup items
+  std::shared_ptr<tc::CacheEntryItem> large_item(new tc::CacheEntryItem());
+  // Add buffers to items
+  large_item->AddBuffer(large_data);
+
+  std::cout << "Create large_response (larger than cache) of size: "
+            << large_data.size() << std::endl;
+  std::cout << "Insert large_response into cache" << std::endl;
+
+  auto status = cache->Insert({large_item}, "large_bytes");
+  // We expect insertion to fail here since cache is too small
+  std::cout << status.Message() << std::endl;
+  ASSERT_FALSE(status.IsOk())
+      << "Inserting item larger than cache succeeded when it should fail";
+}
+
+TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryResponse)
+{
+  constexpr uint64_t cache_size = 4 * 1024 * 1024;  // 4 MB, arbitrary
+  auto cache = helpers::CreateCache(cache_size);
+
+  // Set output data to be larger than cache size
+  // NOTE: This is not 1 byte larger than cache_size, the cache_size + 1 is to
+  // be clear it will always be larger than cache even if the dtype is changed.
+  std::vector<int> large_data(cache_size + 1, 0);
+  std::cout << "Create large_response (larger than cache) of size: "
+            << large_data.size() << std::endl;
+  std::vector<helpers::Tensor> large_outputs{
+      helpers::Tensor{"output", large_data}};
+  auto large_response = helpers::GenerateResponse(
+      request0, dtype, memory_type, memory_type_id, large_outputs);
+
+  std::cout << "Insert large_response into cache" << std::endl;
+  auto status = cache->Insert(large_response.get(), "large_response");
+  // We expect insertion to fail here since cache is too small
+  std::cout << status.Message() << std::endl;
+  ASSERT_FALSE(status.IsOk())
+      << "Inserting item larger than cache succeeded when it should fail";
+}
+
+TEST_F(RequestResponseCacheTest, TestEvictionLRU)
+{
+  // Set size 1200 to hold exactly 2x (400byte + metadata) responses, not 3x
+  auto cache = helpers::CreateCache(1200);
+  // Insert 2 responses, expecting both to fit in cache
+  helpers::check_status(cache->Insert(response_400bytes.get(), "request0"));
+  helpers::check_status(cache->Insert(response_400bytes.get(), "request1"));
+  // Validate both responses fit in cache by looking them up
+  ASSERT_TRUE(cache->Lookup("request0").has_value());
+  ASSERT_TRUE(cache->Lookup("request1").has_value());
+  // Insert a 3rd response, expecting the 1st response to be evicted
+  // in LRU order
+  helpers::check_status(cache->Insert(response_400bytes.get(), "request2"));
+  ASSERT_TRUE(cache->Lookup("request2").has_value());
+  ASSERT_FALSE(cache->Lookup("request0").has_value());
+  // Lookup 2nd request to bump its LRU order over 3rd
+  ASSERT_TRUE(cache->Lookup("request1").has_value());
+  // Insert a 4th response, expecting the 3rd to get evicted by LRU order
+  // after looking up the 2nd
+  helpers::check_status(cache->Insert(response_400bytes.get(), "request3"));
+  ASSERT_TRUE(cache->Lookup("request3").has_value());
+  ASSERT_TRUE(cache->Lookup("request1").has_value());
+  ASSERT_FALSE(cache->Lookup("request2").has_value());
+}
+
+TEST_F(RequestResponseCacheTest, TestCacheInsertLookupCompareBytes)
+{
+  auto cache = helpers::CreateCache(1024);
+  // Setup byte buffers
+  std::vector<std::byte> buffer1{1, std::byte{0x01}};
+  std::vector<std::byte> buffer2{2, std::byte{0x02}};
+  std::vector<std::byte> buffer3{4, std::byte{0x04}};
+  std::vector<std::byte> buffer4{8, std::byte{0x08}};
+  std::vector<std::byte> buffer5{16, std::byte{0xFF}};
+  // Setup items
+  std::shared_ptr<tc::CacheEntryItem> item1(new tc::CacheEntryItem());
+  std::shared_ptr<tc::CacheEntryItem> item2(new tc::CacheEntryItem());
+  // Add buffers to items
+  item1->AddBuffer(buffer1);
+  item1->AddBuffer(buffer2);
+  item2->AddBuffer(buffer3);
+  item2->AddBuffer(buffer4);
+  item2->AddBuffer(buffer5);
+
+  helpers::check_status(
+      helpers::InsertLookupCompare(cache, {item1}, "TestCacheSingleItemBytes"));
+  helpers::check_status(helpers::InsertLookupCompare(
+      cache, {item1, item2}, "TestCacheMultiItemBytes"));
 
   std::cout << "Done!" << std::endl;
+}
+
+TEST_F(RequestResponseCacheTest, TestHashingRequests)
+{
+  auto cache = helpers::CreateCache(1024);
+  std::string hash0, hash1, hash2, hash3, hash4;
+  helpers::check_status(cache->Hash(*request0, &hash0));
+  helpers::check_status(cache->Hash(*request1, &hash1));
+  helpers::check_status(cache->Hash(*request2, &hash2));
+  helpers::check_status(cache->Hash(*request3, &hash3));
+  helpers::check_status(cache->Hash(*request4, &hash4));
+  // Different input data should have different hashes
+  ASSERT_NE(hash0, hash1);
+  // Same input data should have same hashes
+  ASSERT_EQ(hash1, hash2);
+  // Two requests with same two inputs but added in different orders
+  ASSERT_EQ(hash3, hash4);
+}
+
+
+TEST_F(RequestResponseCacheTest, TestParallelInsert)
+{
+  // Set size 1200 to hold exactly 2x (400byte + metadata) responses, not 3x
+  auto cache = helpers::CreateCache(1200);
+  constexpr size_t expected_cache_hits = 2;
+
+  // Create threads
+  std::vector<std::thread> threads;
+  std::cout << "Insert responses into cache with [" << thread_count
+            << "] threads in parallel" << std::endl;
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    auto key = std::to_string(idx);
+    threads.emplace_back(
+        std::thread(&helpers::insert, cache, response_400bytes.get(), key));
+  }
+
+  // Join threads
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    std::cout << "Joining idx: " << idx << std::endl;
+    threads[idx].join();
+  }
+
+  // Lookup each inserted key to verify that expected number remain in cache
+  size_t cache_hits = 0;
+  size_t cache_misses = 0;
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    auto key = std::to_string(idx);
+    if (cache->Lookup(key).has_value()) {
+      cache_hits++;
+    } else {
+      cache_misses++;
+    }
+  }
+  ASSERT_EQ(cache_hits, expected_cache_hits);
+  ASSERT_EQ(cache_hits + cache_misses, thread_count);
+}
+
+TEST_F(RequestResponseCacheTest, TestParallelLookup)
+{
+  // Set size large enough to hold all responses
+  auto cache = helpers::CreateCache(1024);
+  const size_t expected_cache_hits = thread_count;
+  constexpr size_t expected_cache_misses = 0;
+
+  // Create threads
+  std::vector<std::thread> threads;
+  std::vector<std::unique_ptr<tc::InferenceResponse>> responses;
+
+  // Insert [thread_count] entries into cache sequentially
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    // Create response for each thread to fill from cache
+    std::unique_ptr<tc::InferenceResponse> response;
+    helpers::check_status(
+        unique_requests[idx]->ResponseFactory()->CreateResponse(&response));
+    responses.push_back(std::move(response));
+    // Insert response for each thread
+    auto key = std::to_string(idx);
+    cache->Insert(response0.get(), key);
+  }
+
+  // Assert all entries were put into cache and no evictions occurred yet
+  size_t cache_hits = 0;
+  size_t cache_misses = 0;
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    auto key = std::to_string(idx);
+    if (cache->Lookup(key).has_value()) {
+      cache_hits++;
+    } else {
+      cache_misses++;
+    }
+  }
+  ASSERT_EQ(cache_hits, expected_cache_hits);
+  ASSERT_EQ(cache_misses, expected_cache_misses);
+  ASSERT_EQ(cache_hits + cache_misses, thread_count);
+
+  // Lookup [thread_count] entries from cache in parallel
+  std::cout << "Lookup from cache with [" << thread_count
+            << "] threads in parallel" << std::endl;
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    auto key = std::to_string(idx);
+    threads.emplace_back(
+        std::thread(&helpers::lookup, cache, responses[idx].get(), key));
+  }
+
+  // Join threads
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    threads[idx].join();
+  }
+
+  // Grab output from sample response for comparison
+  const auto& response0_output = response0->Outputs()[0];
+
+  // Verify output results from cache
+  for (size_t idx = 0; idx < thread_count; idx++) {
+    // Fetch output buffer details
+    const void* response_buffer = nullptr;
+    size_t response_byte_size = 0;
+    TRITONSERVER_MemoryType response_memory_type;
+    int64_t response_memory_type_id;
+    void* userp;
+
+    // TODO: Handle multiple outputs more generically
+    const auto& response_test = responses[idx];
+    for (const auto& response_test_output : response_test->Outputs()) {
+      ASSERT_EQ(response_test_output.Name(), response0_output.Name());
+      ASSERT_EQ(response_test_output.DType(), response0_output.DType());
+      ASSERT_EQ(response_test_output.Shape(), response0_output.Shape());
+      helpers::check_status(response_test_output.DataBuffer(
+          &response_buffer, &response_byte_size, &response_memory_type,
+          &response_memory_type_id, &userp));
+
+      // TODO: Use Triton DType to cast buffer and compare outputs generically
+      const int* cache_output = static_cast<const int*>(response_buffer);
+      std::cout << "Check output buffer data from cache entry for thread ["
+                << idx << "]:" << std::endl;
+      for (size_t i = 0; i < response_byte_size / sizeof(int); i++) {
+        std::cout << cache_output[i] << " == " << data0[i] << std::endl;
+        ASSERT_EQ(cache_output[i], data0[i]);
+      }
+    }
+  }
+}
+
+TEST_F(RequestResponseCacheTest, TestResponseEndToEnd)
+{
+  auto cache = helpers::CreateCache(8 * 1024 * 1024);
+
+  std::string key = "";
+  helpers::check_status(cache->Hash(*request0, &key));
+  ASSERT_NE(key, "");
+
+  std::cout << "Lookup request0 in empty cache" << std::endl;
+  auto status = cache->Lookup(nullptr, key);
+  // This hash not in cache yet
+  ASSERT_FALSE(status.IsOk()) << "hash [" + key + "] should not be in cache";
+  std::cout << "Insert response into cache with request0" << std::endl;
+  // Insertion should succeed
+  helpers::check_status(cache->Insert(response0.get(), key));
+
+  // Duplicate insertion should fail since request0 already exists in cache
+  status = cache->Insert(response0.get(), key);
+  ASSERT_FALSE(status.IsOk())
+      << "Inserting duplicate item in cache should fail";
+
+  // Create response to test cache lookup
+  std::cout << "Create response object into fill from cache" << std::endl;
+  std::unique_ptr<tc::InferenceResponse> response_test;
+  helpers::check_status(
+      request0->ResponseFactory()->CreateResponse(&response_test));
+
+  // Lookup should now succeed
+  std::cout << "Lookup request0 in cache after insertion" << std::endl;
+  helpers::check_status(cache->Lookup(response_test.get(), key));
+  // Grab output from sample response for comparison
+  const auto& response0_output = response0->Outputs()[0];
+
+  // Fetch output buffer details
+  const void* response_buffer = nullptr;
+  size_t response_byte_size = 0;
+  TRITONSERVER_MemoryType response_memory_type;
+  int64_t response_memory_type_id;
+  void* userp;
+  // TODO: Handle multiple outputs and memory types more generically
+  for (const auto& response_test_output : response_test->Outputs()) {
+    ASSERT_EQ(response_test_output.Name(), response0_output.Name());
+    ASSERT_EQ(response_test_output.DType(), response0_output.DType());
+    ASSERT_EQ(response_test_output.Shape(), response0_output.Shape());
+    helpers::check_status(response_test_output.DataBuffer(
+        &response_buffer, &response_byte_size, &response_memory_type,
+        &response_memory_type_id, &userp));
+  }
+
+  // TODO: Use Triton DType to cast buffer and compare outputs generically
+  const int* cache_output = static_cast<const int*>(response_buffer);
+  std::cout << "Check output buffer data from cache entry:" << std::endl;
+  for (size_t i = 0; i < response_byte_size / sizeof(int); i++) {
+    std::cout << cache_output[i] << " == " << outputs0[0].data[i] << std::endl;
+    ASSERT_EQ(cache_output[i], outputs0[0].data[i]);
+  }
 }
 
 }  // namespace
@@ -606,7 +953,7 @@ int
 main(int argc, char** argv)
 {
 #ifdef TRITON_ENABLE_LOGGING
-  LOG_SET_VERBOSE(1);
+  LOG_SET_VERBOSE(2);
 #endif  // TRITON_ENABLE_LOGGING
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -653,6 +653,7 @@ TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryBytes)
 {
   constexpr uint64_t cache_size = 4 * 1024 * 1024;  // 4 MB, arbitrary
   auto cache = helpers::CreateCache(cache_size);
+  ASSERT_NE(cache, nullptr);
 
   // Setup byte buffer larger than cache size
   std::vector<std::byte> large_data(cache_size + 1);
@@ -676,6 +677,7 @@ TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryResponse)
 {
   constexpr uint64_t cache_size = 4 * 1024 * 1024;  // 4 MB, arbitrary
   auto cache = helpers::CreateCache(cache_size);
+  ASSERT_NE(cache, nullptr);
 
   // Set output data to be larger than cache size
   // NOTE: This is not 1 byte larger than cache_size, the cache_size + 1 is to
@@ -700,6 +702,7 @@ TEST_F(RequestResponseCacheTest, TestEvictionLRU)
 {
   // Set size 1200 to hold exactly 2x (400byte + metadata) responses, not 3x
   auto cache = helpers::CreateCache(1200);
+  ASSERT_NE(cache, nullptr);
   // Insert 2 responses, expecting both to fit in cache
   helpers::check_status(cache->Insert(response_400bytes.get(), "request0"));
   helpers::check_status(cache->Insert(response_400bytes.get(), "request1"));
@@ -724,6 +727,7 @@ TEST_F(RequestResponseCacheTest, TestEvictionLRU)
 TEST_F(RequestResponseCacheTest, TestCacheInsertLookupCompareBytes)
 {
   auto cache = helpers::CreateCache(1024);
+  ASSERT_NE(cache, nullptr);
   // Setup byte buffers
   std::vector<std::byte> buffer1{1, std::byte{0x01}};
   std::vector<std::byte> buffer2{2, std::byte{0x02}};
@@ -751,6 +755,7 @@ TEST_F(RequestResponseCacheTest, TestCacheInsertLookupCompareBytes)
 TEST_F(RequestResponseCacheTest, TestHashingRequests)
 {
   auto cache = helpers::CreateCache(1024);
+  ASSERT_NE(cache, nullptr);
   std::string hash0, hash1, hash2, hash3, hash4;
   helpers::check_status(cache->Hash(*request0, &hash0));
   helpers::check_status(cache->Hash(*request1, &hash1));
@@ -770,6 +775,7 @@ TEST_F(RequestResponseCacheTest, TestParallelInsert)
 {
   // Set size 1200 to hold exactly 2x (400byte + metadata) responses, not 3x
   auto cache = helpers::CreateCache(1200);
+  ASSERT_NE(cache, nullptr);
   constexpr size_t expected_cache_hits = 2;
 
   // Create threads
@@ -807,6 +813,7 @@ TEST_F(RequestResponseCacheTest, TestParallelLookup)
 {
   // Set size large enough to hold all responses
   auto cache = helpers::CreateCache(1024);
+  ASSERT_NE(cache, nullptr);
   const size_t expected_cache_hits = thread_count;
   constexpr size_t expected_cache_misses = 0;
 
@@ -892,6 +899,7 @@ TEST_F(RequestResponseCacheTest, TestParallelLookup)
 TEST_F(RequestResponseCacheTest, TestResponseEndToEnd)
 {
   auto cache = helpers::CreateCache(8 * 1024 * 1024);
+  ASSERT_NE(cache, nullptr);
 
   std::string key = "";
   helpers::check_status(cache->Hash(*request0, &key));

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -59,10 +59,8 @@ TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
   }
 
   const auto lentry = reinterpret_cast<CacheEntry*>(entry);
-  // TODO: lock?
-  const auto litems = lentry->Items();
-  *count = litems.size();
-  std::cout << "[DEBUG] [tritoncache.cc] entry->Items().size(): " << *count
+  *count = lentry->ItemCount();
+  std::cout << "[DEBUG] [tritoncache.cc] entry->ItemCount()" << *count
             << std::endl;
   return nullptr;  // success
 }
@@ -70,49 +68,151 @@ TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 // Adds item to entry
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryAddItem(
-    TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size)
+    TRITONCACHE_CacheEntry* entry, TRITONCACHE_CacheEntryItem* item)
 {
   if (entry == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
   }
 
-  const auto lentry = reinterpret_cast<CacheEntry*>(entry);
   // TODO: lock?
-  lentry->AddItem({reinterpret_cast<const std::byte*>(base), byte_size});
+  const auto lentry = reinterpret_cast<CacheEntry*>(entry);
+  const auto litem = reinterpret_cast<CacheEntryItem*>(item);
+  const auto item_copy = new CacheEntryItem(*litem);
+  // TODO: Maintain pointer instead of making another copy
+  lentry->AddItem(*item_copy);
   return nullptr;  // success
 }
 
 // Gets item at index from entry
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONCACHE_CacheEntryItem(
-    TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size)
+TRITONCACHE_CacheEntryGetItem(
+    TRITONCACHE_CacheEntry* entry, size_t index,
+    TRITONCACHE_CacheEntryItem** item)
 {
   if (entry == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
   }
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
 
   const auto lentry = reinterpret_cast<CacheEntry*>(entry);
-  // TODO: lock?
+  // TODO: lock? copy?
   const auto litems = lentry->Items();
   if (index >= litems.size()) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "index was greater than count");
   }
 
+  const auto litem = litems[index].get();
+  if (litem == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+  const auto item_copy = new CacheEntryItem(*litem);
+  *item = reinterpret_cast<TRITONCACHE_CacheEntryItem*>(item_copy);
+  return nullptr;  // success
+}
+
+/* CacheEntryItem Lifetime Management */
+
+// TODO: flesh out
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemNew(TRITONCACHE_CacheEntryItem** item)
+{
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+
+  // TODO: remove
+  std::cout << "[DEBUG] [tritoncache.cc] Creating new cache entry item"
+            << std::endl;
+  *item = reinterpret_cast<TRITONCACHE_CacheEntryItem*>(new CacheEntryItem());
+  return nullptr;
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemDelete(TRITONCACHE_CacheEntryItem* item)
+{
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+
+  // TODO: remove
+  std::cout << "[DEBUG] [tritoncache.cc] deleting cache entry item"
+            << std::endl;
+  delete reinterpret_cast<CacheEntryItem*>(item);
+  return nullptr;
+}
+
+/* CacheEntryItem Field Management */
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemBufferCount(
+    TRITONCACHE_CacheEntryItem* item, size_t* count)
+{
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+
+  const auto litem = reinterpret_cast<CacheEntryItem*>(item);
+  *count = litem->BufferCount();
+  std::cout << "[DEBUG] [tritoncache.cc] item->BufferCount()" << *count
+            << std::endl;
+  return nullptr;  // success
+}
+
+// Adds buffer to item
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemAddBuffer(
+    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size)
+{
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+
+  const auto litem = reinterpret_cast<CacheEntryItem*>(item);
+  litem->AddBuffer({reinterpret_cast<const std::byte*>(base), byte_size});
+  return nullptr;  // success
+}
+
+// Gets buffer at index from item
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemGetBuffer(
+    TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
+    size_t* byte_size)
+{
+  if (item == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+  }
+
+  const auto litem = reinterpret_cast<CacheEntryItem*>(item);
+  const auto lbuffers = litem->Buffers();
+  if (index >= lbuffers.size()) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "index was greater than count");
+  }
+
   // Make a copy for Triton to own
-  const std::vector<std::byte> buffer = litems[index];
+  const std::vector<std::byte> buffer = lbuffers[index];
   auto byte_base = reinterpret_cast<std::byte*>(malloc(buffer.size()));
   std::copy(buffer.begin(), buffer.end(), byte_base);
 
   *base = byte_base;
   *byte_size = buffer.size();
-  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItem addr: " << byte_base
-            << std::endl;
-  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItem size: "
+  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItemBuffer addr: "
+            << byte_base << std::endl;
+  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItemBuffer size: "
             << buffer.size() << std::endl;
-  return nullptr;
+  return nullptr;  // success
 }
 
 }  // extern C

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -17,8 +17,9 @@ namespace triton { namespace core {
 
 extern "C" {
 
-/* CacheEntry Lifetime Management */
-
+//
+// CacheEntry Lifetime Management
+//
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryNew(TRITONCACHE_CacheEntry** entry)
 {
@@ -27,8 +28,6 @@ TRITONCACHE_CacheEntryNew(TRITONCACHE_CacheEntry** entry)
         TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
   }
 
-  // TODO: remove
-  std::cout << "[DEBUG] [tritoncache.cc] Creating new cache entry" << std::endl;
   *entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(new CacheEntry());
   return nullptr;
 }
@@ -41,14 +40,13 @@ TRITONCACHE_CacheEntryDelete(TRITONCACHE_CacheEntry* entry)
         TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
   }
 
-  // TODO: remove
-  std::cout << "[DEBUG] [tritoncache.cc] deleting cache entry" << std::endl;
   delete reinterpret_cast<CacheEntry*>(entry);
   return nullptr;
 }
 
-/* CacheEntry Field Management */
-
+//
+// CacheEntry Field Management
+//
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 {
@@ -59,8 +57,6 @@ TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 
   const auto lentry = reinterpret_cast<CacheEntry*>(entry);
   *count = lentry->ItemCount();
-  std::cout << "[DEBUG] [tritoncache.cc] entry->ItemCount(): " << *count
-            << std::endl;
   return nullptr;  // success
 }
 
@@ -116,8 +112,9 @@ TRITONCACHE_CacheEntryGetItem(
   return nullptr;  // success
 }
 
-/* CacheEntryItem Lifetime Management */
-
+//
+// CacheEntryItem Lifetime Management
+//
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemNew(TRITONCACHE_CacheEntryItem** item)
 {
@@ -126,9 +123,6 @@ TRITONCACHE_CacheEntryItemNew(TRITONCACHE_CacheEntryItem** item)
         TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
   }
 
-  // TODO: remove
-  std::cout << "[DEBUG] [tritoncache.cc] Creating new cache entry item"
-            << std::endl;
   *item = reinterpret_cast<TRITONCACHE_CacheEntryItem*>(new CacheEntryItem());
   return nullptr;
 }
@@ -141,15 +135,13 @@ TRITONCACHE_CacheEntryItemDelete(TRITONCACHE_CacheEntryItem* item)
         TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
   }
 
-  // TODO: remove
-  std::cout << "[DEBUG] [tritoncache.cc] deleting cache entry item"
-            << std::endl;
   delete reinterpret_cast<CacheEntryItem*>(item);
   return nullptr;
 }
 
-/* CacheEntryItem Field Management */
-
+//
+// CacheEntryItem Field Management
+//
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemBufferCount(
     TRITONCACHE_CacheEntryItem* item, size_t* count)
@@ -161,8 +153,6 @@ TRITONCACHE_CacheEntryItemBufferCount(
 
   const auto litem = reinterpret_cast<CacheEntryItem*>(item);
   *count = litem->BufferCount();
-  std::cout << "[DEBUG] [tritoncache.cc] item->BufferCount()" << *count
-            << std::endl;
   return nullptr;  // success
 }
 
@@ -206,10 +196,6 @@ TRITONCACHE_CacheEntryItemGetBuffer(
 
   *base = byte_base;
   *byte_size = buffer.size();
-  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItemBuffer addr: "
-            << byte_base << std::endl;
-  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItemBuffer size: "
-            << buffer.size() << std::endl;
   return nullptr;  // success
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -112,7 +112,6 @@ TRITONCACHE_CacheEntryAddItem(
 
   // Triton CacheEntry will take ownership of item, caller should not
   // invalidate it.
-  // TODO: Copy, signal/callback, cleanup?
   std::shared_ptr<CacheEntryItem> sitem(litem);
   lentry->AddItem(sitem);
   return nullptr;  // success
@@ -224,6 +223,7 @@ TRITONCACHE_CacheEntryItemAddBuffer(
         "Only buffers in CPU memory are allowed in cache currently");
   }
   const auto litem = reinterpret_cast<CacheEntryItem*>(item);
+  // COPY: This will add a copy of the buffer to the item.
   litem->AddBuffer(base, byte_size);
   return nullptr;  // success
 }

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -7,9 +7,8 @@ extern "C" {
 
 /* CacheEntry Field Management */
 
-TRITONSERVER_Error*
-TRITONCACHE_CacheEntryItemCount(
-    TRITONCACHE_CacheEntry* entry, size_t* count)
+TRITONCACHE_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 {
   if (entry == nullptr) {
     return TRITONSERVER_ErrorNew(
@@ -24,7 +23,7 @@ TRITONCACHE_CacheEntryItemCount(
 }
 
 // Adds item to entry
-TRITONSERVER_Error*
+TRITONCACHE_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size)
 {
@@ -40,7 +39,7 @@ TRITONCACHE_CacheEntryAddItem(
 }
 
 // Gets item at index from entry
-TRITONSERVER_Error*
+TRITONCACHE_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItem(
     TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size)
 {
@@ -58,9 +57,11 @@ TRITONCACHE_CacheEntryItem(
   }
 
   // Make a copy for Triton to own
-  const std::vector<std::byte>& buffer = litems[index];
-  auto byte_base = reinterpret_cast<std::byte*>(*base);
+  const std::vector<std::byte> buffer = litems[index];
+  auto byte_base = reinterpret_cast<std::byte*>(malloc(buffer.size()));
   std::copy(buffer.begin(), buffer.end(), byte_base);
+
+  *base = byte_base;
   *byte_size = buffer.size();
   return nullptr;
 }

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -1,0 +1,70 @@
+#include "cache_entry.h"
+#include "tritonserver_apis.h"
+
+namespace triton { namespace core {
+
+extern "C" {
+
+/* CacheEntry Field Management */
+
+TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItemCount(
+    TRITONCACHE_CacheEntry* entry, size_t* count)
+{
+  if (entry == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
+  }
+
+  const auto lentry = reinterpret_cast<CacheEntry*>(entry);
+  // TODO: lock?
+  const auto litems = lentry->Items();
+  *count = litems.size();
+  return nullptr;  // success
+}
+
+// Adds item to entry
+TRITONSERVER_Error*
+TRITONCACHE_CacheEntryAddItem(
+    TRITONCACHE_CacheEntry* entry, void* base, size_t byte_size)
+{
+  if (entry == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
+  }
+
+  const auto lentry = reinterpret_cast<CacheEntry*>(entry);
+  // TODO: lock?
+  lentry->AddItem({reinterpret_cast<std::byte*>(base), byte_size});
+  return nullptr;  // success
+}
+
+// Gets item at index from entry
+TRITONSERVER_Error*
+TRITONCACHE_CacheEntryItem(
+    TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size)
+{
+  if (entry == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
+  }
+
+  const auto lentry = reinterpret_cast<CacheEntry*>(entry);
+  // TODO: lock?
+  const auto litems = lentry->Items();
+  if (index >= litems.size()) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "index was greater than count");
+  }
+
+  // Make a copy for Triton to own
+  const std::vector<std::byte>& buffer = litems[index];
+  auto byte_base = reinterpret_cast<std::byte*>(*base);
+  std::copy(buffer.begin(), buffer.end(), byte_base);
+  *byte_size = buffer.size();
+  return nullptr;
+}
+
+}  // extern C
+
+}}  // namespace triton::core

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -26,7 +26,7 @@ TRITONCACHE_CacheEntryItemCount(
 // Adds item to entry
 TRITONSERVER_Error*
 TRITONCACHE_CacheEntryAddItem(
-    TRITONCACHE_CacheEntry* entry, void* base, size_t byte_size)
+    TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size)
 {
   if (entry == nullptr) {
     return TRITONSERVER_ErrorNew(
@@ -35,7 +35,7 @@ TRITONCACHE_CacheEntryAddItem(
 
   const auto lentry = reinterpret_cast<CacheEntry*>(entry);
   // TODO: lock?
-  lentry->AddItem({reinterpret_cast<std::byte*>(base), byte_size});
+  lentry->AddItem({reinterpret_cast<const std::byte*>(base), byte_size});
   return nullptr;  // success
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -1,3 +1,4 @@
+#include <iostream>  // debug
 #include "cache_entry.h"
 
 // For unknown reason, windows will not export the TRITONCACHE_*
@@ -16,6 +17,37 @@ namespace triton { namespace core {
 
 extern "C" {
 
+/* CacheEntry Lifetime Management */
+
+// TODO: flesh out
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryNew(TRITONCACHE_CacheEntry** entry)
+{
+  if (entry == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
+  }
+
+  // TODO: remove
+  std::cout << "[DEBUG] [tritoncache.cc] Creating new cache entry" << std::endl;
+  *entry = reinterpret_cast<TRITONCACHE_CacheEntry*>(new CacheEntry());
+  return nullptr;
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_CacheEntryDelete(TRITONCACHE_CacheEntry* entry)
+{
+  if (entry == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "entry was nullptr");
+  }
+
+  // TODO: remove
+  std::cout << "[DEBUG] [tritoncache.cc] deleting cache entry" << std::endl;
+  delete reinterpret_cast<CacheEntry*>(entry);
+  return nullptr;
+}
+
 /* CacheEntry Field Management */
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
@@ -30,6 +62,8 @@ TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
   // TODO: lock?
   const auto litems = lentry->Items();
   *count = litems.size();
+  std::cout << "[DEBUG] [tritoncache.cc] entry->Items().size(): " << *count
+            << std::endl;
   return nullptr;  // success
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -110,8 +110,9 @@ TRITONCACHE_CacheEntryAddItem(
   const auto lentry = reinterpret_cast<CacheEntry*>(entry);
   const auto litem = reinterpret_cast<CacheEntryItem*>(item);
 
-  // Triton CacheEntry will explicitly take ownership of item
-  // TODO: Copy, cleanup?
+  // Triton CacheEntry will take ownership of item, caller should not
+  // invalidate it.
+  // TODO: Copy, signal/callback, cleanup?
   std::shared_ptr<CacheEntryItem> sitem(litem);
   lentry->AddItem(sitem);
   return nullptr;  // success

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -1,5 +1,16 @@
 #include "cache_entry.h"
-#include "tritonserver_apis.h"
+
+// For unknown reason, windows will not export the TRITONCACHE_*
+// functions declared with dllexport in tritoncache.h. To get
+// those functions exported it is (also?) necessary to mark the
+// definitions in this file with dllexport as well.
+#if defined(_MSC_VER)
+#define TRITONAPI_DECLSPEC __declspec(dllexport)
+#elif defined(__GNUC__)
+#define TRITONAPI_DECLSPEC __attribute__((__visibility__("default")))
+#else
+#define TRITONAPI_DECLSPEC
+#endif
 
 namespace triton { namespace core {
 
@@ -7,7 +18,7 @@ extern "C" {
 
 /* CacheEntry Field Management */
 
-TRITONCACHE_DECLSPEC TRITONSERVER_Error*
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 {
   if (entry == nullptr) {
@@ -23,7 +34,7 @@ TRITONCACHE_CacheEntryItemCount(TRITONCACHE_CacheEntry* entry, size_t* count)
 }
 
 // Adds item to entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error*
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryAddItem(
     TRITONCACHE_CacheEntry* entry, const void* base, size_t byte_size)
 {
@@ -39,7 +50,7 @@ TRITONCACHE_CacheEntryAddItem(
 }
 
 // Gets item at index from entry
-TRITONCACHE_DECLSPEC TRITONSERVER_Error*
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItem(
     TRITONCACHE_CacheEntry* entry, size_t index, void** base, size_t* byte_size)
 {

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -108,6 +108,10 @@ TRITONCACHE_CacheEntryItem(
 
   *base = byte_base;
   *byte_size = buffer.size();
+  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItem addr: " << byte_base
+            << std::endl;
+  std::cout << "[DEBUG] [tritoncache.cc] CacheEntryGetItem size: "
+            << buffer.size() << std::endl;
   return nullptr;
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -224,7 +224,7 @@ TRITONCACHE_CacheEntryItemAddBuffer(
   }
   const auto litem = reinterpret_cast<CacheEntryItem*>(item);
   // COPY: This will add a copy of the buffer to the item.
-  litem->AddBuffer(base, byte_size);
+  litem->AddBufferCopy(base, byte_size);
   return nullptr;  // success
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -197,14 +197,25 @@ TRITONCACHE_CacheEntryItemBufferCount(
 // Adds buffer to item
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemAddBuffer(
-    TRITONCACHE_CacheEntryItem* item, const void* base, size_t byte_size,
-    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id)
+    TRITONCACHE_CacheEntryItem* item, const void* base,
+    TRITONSERVER_BufferAttributes* buffer_attributes)
 {
-  if (item == nullptr) {
+  if (!item || !base || !buffer_attributes) {
     return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "item, base, or buffer_attributes was nullptr");
   }
 
+  // Get buffer attributes set by caller
+  size_t byte_size = 0;
+  TRITONSERVER_BufferAttributesByteSize(buffer_attributes, &byte_size);
+  if (!byte_size) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "Buffer byte size was zero");
+  }
+
+  TRITONSERVER_MemoryType memory_type;
+  TRITONSERVER_BufferAttributesMemoryType(buffer_attributes, &memory_type);
   // DLIS-2673: Add better memory_type support
   if (memory_type != TRITONSERVER_MEMORY_CPU &&
       memory_type != TRITONSERVER_MEMORY_CPU_PINNED) {
@@ -221,12 +232,12 @@ TRITONCACHE_CacheEntryItemAddBuffer(
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONCACHE_CacheEntryItemGetBuffer(
     TRITONCACHE_CacheEntryItem* item, size_t index, void** base,
-    size_t* byte_size, TRITONSERVER_MemoryType* memory_type,
-    int64_t* memory_type_id)
+    TRITONSERVER_BufferAttributes* buffer_attributes)
 {
-  if (item == nullptr) {
+  if (!item || !base || !buffer_attributes) {
     return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "item was nullptr");
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "item, base, or buffer_attributes was nullptr");
   }
 
   const auto litem = reinterpret_cast<CacheEntryItem*>(item);
@@ -239,10 +250,12 @@ TRITONCACHE_CacheEntryItemGetBuffer(
   const auto [buffer, buffer_size] = lbuffers[index];
   // No copy
   *base = buffer;
-  *byte_size = buffer_size;
-  // DLIS-2673: Add better memory_type support
-  *memory_type = TRITONSERVER_MEMORY_CPU;
-  *memory_type_id = 0;
+  // Set buffer attributes
+  TRITONSERVER_BufferAttributesSetByteSize(buffer_attributes, buffer_size);
+  // DLIS-2673: Add better memory_type support, default to CPU memory for now
+  TRITONSERVER_BufferAttributesSetMemoryType(
+      buffer_attributes, TRITONSERVER_MEMORY_CPU);
+  TRITONSERVER_BufferAttributesSetMemoryTypeId(buffer_attributes, 0);
   return nullptr;  // success
 }
 

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -18,6 +18,17 @@ namespace triton { namespace core {
 extern "C" {
 
 //
+// TRITONCACHE API Version
+//
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONCACHE_ApiVersion(uint32_t* major, uint32_t* minor)
+{
+  *major = TRITONCACHE_API_VERSION_MAJOR;
+  *minor = TRITONCACHE_API_VERSION_MINOR;
+  return nullptr;  // success
+}
+
+//
 // CacheEntry Lifetime Management
 //
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
@@ -189,11 +200,10 @@ TRITONCACHE_CacheEntryItemGetBuffer(
         TRITONSERVER_ERROR_INVALID_ARG, "index was greater than count");
   }
 
-  // Make a copy for Triton to own
-  const std::vector<std::byte> buffer = lbuffers[index];
+  const auto buffer = lbuffers[index];
+  // TODO: Probably shouldn't copy here. Caller should copy if needed.
   auto byte_base = reinterpret_cast<std::byte*>(malloc(buffer.size()));
   std::copy(buffer.begin(), buffer.end(), byte_base);
-
   *base = byte_base;
   *byte_size = buffer.size();
   return nullptr;  // success

--- a/src/tritoncache.cc
+++ b/src/tritoncache.cc
@@ -1,4 +1,29 @@
-#include <iostream>  // debug
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "cache_entry.h"
 
 // For unknown reason, windows will not export the TRITONCACHE_*
@@ -201,7 +226,7 @@ TRITONCACHE_CacheEntryItemGetBuffer(
   }
 
   const auto buffer = lbuffers[index];
-  // TODO: Probably shouldn't copy here. Caller should copy if needed.
+  // TODO: Probably shouldn't copy here.
   auto byte_base = reinterpret_cast<std::byte*>(malloc(buffer.size()));
   std::copy(buffer.begin(), buffer.end(), byte_base);
   *base = byte_base;

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -330,7 +330,6 @@ class TritonServerOptions {
   uint64_t metrics_interval_;
   unsigned int exit_timeout_;
   uint64_t pinned_memory_pool_size_;
-  bool response_cache_enabled_;
   unsigned int buffer_manager_thread_count_;
   unsigned int model_load_thread_count_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
@@ -351,7 +350,7 @@ TritonServerOptions::TritonServerOptions()
       rate_limit_mode_(tc::RateLimitMode::RL_OFF), metrics_(true),
       gpu_metrics_(true), cpu_metrics_(true), metrics_interval_(2000),
       exit_timeout_(30), pinned_memory_pool_size_(1 << 28),
-      response_cache_enabled_(true), buffer_manager_thread_count_(0),
+      buffer_manager_thread_count_(0),
       model_load_thread_count_(
           std::max(2u, 2 * std::thread::hardware_concurrency())),
 #ifdef TRITON_ENABLE_GPU
@@ -1176,12 +1175,10 @@ TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size)
 {
-  // TODO: For easier dev, replace with error after
-  return nullptr;  // success
-  // return TRITONSERVER_ErrorNew(
-  //    TRITONSERVER_ERROR_UNSUPPORTED,
-  //    "This API has been deprecated. See TRITONCACHE_CacheNew to specify cache
-  //    " "specific fields through 'config'.");
+  return TRITONSERVER_ErrorNew(
+      TRITONSERVER_ERROR_UNSUPPORTED,
+      "This API has been deprecated. See TRITONCACHE_CacheNew to specify cache "
+      "specific fields through 'config'.");
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1175,10 +1175,10 @@ TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size)
 {
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "This API has been deprecated. See TRITONCACHE_CacheNew to specify cache "
-      "specific fields through 'config'.");
+  // For backwards compatibility, forward this API call to new CacheConfig API.
+  std::string config_json = R"({"size": )" + std::to_string(size) + "}";
+  return TRITONSERVER_ServerOptionsSetCacheConfig(
+      options, "", config_json.c_str());
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1168,10 +1168,12 @@ TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
     TRITONSERVER_ServerOptions* options, uint64_t size)
 {
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNSUPPORTED,
-      "This API has been deprecated. See TRITONCACHE_CacheNew to specify cache "
-      "specific fields through 'config'.");
+  // TODO: For easier dev, replace with error after
+  return nullptr;  // success
+  // return TRITONSERVER_ErrorNew(
+  //    TRITONSERVER_ERROR_UNSUPPORTED,
+  //    "This API has been deprecated. See TRITONCACHE_CacheNew to specify cache
+  //    " "specific fields through 'config'.");
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2293,8 +2293,6 @@ TRITONSERVER_ServerNew(
       "exit_timeout", std::to_string(lserver->ExitTimeoutSeconds())});
   options_table.InsertRow(std::vector<std::string>{
       "cache_enabled", std::to_string(lserver->ResponseCacheEnabled())});
-  options_table.InsertRow(
-      std::vector<std::string>{"cache_config", lserver->CacheConfig()});
 
   std::string options_table_string = options_table.PrintTable();
   LOG_INFO << options_table_string;

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1178,7 +1178,7 @@ TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
   // For backwards compatibility, forward this API call to new CacheConfig API.
   std::string config_json = R"({"size": )" + std::to_string(size) + "}";
   return TRITONSERVER_ServerOptionsSetCacheConfig(
-      options, "", config_json.c_str());
+      options, "" /* cache_name */, config_json.c_str());
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*

--- a/src/tritonserver_apis.h
+++ b/src/tritonserver_apis.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -357,6 +357,8 @@ TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetCudaMemoryPoolByteSize()
 {
 }
+// Deprecated. Use "config" field in TRITONCACHE_CacheNew to configure cache
+// implementation specific fields.
 TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize()
 {

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -357,10 +357,13 @@ TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetCudaMemoryPoolByteSize()
 {
 }
-// Deprecated. Use "config" field in TRITONCACHE_CacheNew to configure cache
-// implementation specific fields.
+// Deprecated. See TRITONSERVER_ServerOptionsSetCacheConfig instead.
 TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetResponseCacheByteSize()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetCacheConfig()
 {
 }
 TRITONAPI_DECLSPEC void

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -958,6 +958,36 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup()
 }
 
 TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheNew()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheDelete()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheInsert()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheLookup()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEvict()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryNew()
+{
+}
+
+TRITONAPI_DECLSPEC void
 TRITONCACHE_CacheEntryItemCount()
 {
 }

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -367,6 +367,10 @@ TRITONSERVER_ServerOptionsSetCacheConfig()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetCacheDirectory()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetMinSupportedComputeCapability()
 {
 }

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -957,4 +957,19 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup()
 {
 }
 
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemCount()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItem()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryAddItem()
+{
+}
+
 } /* extern "C" */

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -967,12 +967,57 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup()
 }
 
 TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheNew()
+TRITONCACHE_ApiVersion()
 {
 }
 
 TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheDelete()
+TRITONCACHE_CacheEntryItemCount()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryAddItem()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryGetItem()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemNew()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemDelete()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemBufferCount()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemAddBuffer()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheEntryItemGetBuffer()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheInitialize()
+{
+}
+
+TRITONAPI_DECLSPEC void
+TRITONCACHE_CacheFinalize()
 {
 }
 
@@ -983,31 +1028,6 @@ TRITONCACHE_CacheInsert()
 
 TRITONAPI_DECLSPEC void
 TRITONCACHE_CacheLookup()
-{
-}
-
-TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheEvict()
-{
-}
-
-TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheEntryNew()
-{
-}
-
-TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheEntryItemCount()
-{
-}
-
-TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheEntryItem()
-{
-}
-
-TRITONAPI_DECLSPEC void
-TRITONCACHE_CacheEntryAddItem()
 {
 }
 


### PR DESCRIPTION
Main Changes:
- General structure of new TRITONCACHE APIs and scaffolding from CLI to Core has added
    - `tritoncache.cc` was added with core-side TRITONCACHE API implementations
    - `cache_manager.*` and `cache_entry.*` have been added to encapsulate shared library communication
    - Some optimizations can definitely be made in the number of copies being done and lifetimes/ownership, open to a lot of feedback here
- `--response-cache-byte-size` and corresponding C API has been deprecated in favor of `--cache-config` and `--cache-dir`. SetResponseCacheByteSize API will now call SetCacheConfig with specified size for now.
- Some "band-aid" fixes have been made on the metrics/stats related to caching, but will be fixed more thoroughly in a follow-up PR
- Response Cache unit test has been updated to use new Cache API via TritonCacheManager 

Some (potential) follow-up PRs:
- [ ] docs updates (response_cache.md, metrics.md, etc.)
- [ ] (?) per-model caches, cache config specified in model `config.pbtxt` as suggested by Iman
- [ ] remove copy from cache impl side by instead adding some callback/signal to hold onto a buffer until Triton has copied it to response output
    - may profile with nsys to see the specific impact here
 
<details>
<summary>TODO Items</summary>

- [x] serialize/deserialize responses
- [x] simple test that responses are cached correctly with example client
- [x] Remove or update `--response-cache-byte-size > 0` logic for enabling cache
    - this can be controlled by cache/cache_config
- [x] pass cache_config to TritonCache
- [x] pass cache_dir to TritonCache
- [x] re-enable minimal unit test
- [x] minimally fix cache stats for perf analyzer (follow up PR for thorough fixes)
- [x] Check memory leaks
- [x] check copyrights
- [x] Update cache unit test (follow up test PR: #144)
- [ ] Add API descriptions/docs (TBD on some copy/ownership changes)
---
- [ ] Performance benchmarking
    - [ ] Optimize copies / remove unnecessary copies
    - [ ] Consider Exists API, may be tricky concurrency wise (exists when checking but not when looking up), or hurt performance (add concurrency around Exists + Insert/Lookup)
    - [ ] Nsight compare
    - [ ] Verify no C++17 related bottlenecks
- [ ] Check stats/metrics (follow up metric PR)
    - [ ] Check L0_perf_analyzer_report
    - [x] Update cache miss stats through model rather than request due to request lifetime issues (released by backend before callback)
 - [ ] Update response_cache.md doc (follow up doc PR)

</details>

Corresponding server changes: https://github.com/triton-inference-server/server/pull/5119