### PR TITLE
fallback to default GCS client if json credentials file were not found

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -544,6 +544,8 @@ GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
       gs_cred.path_);
   if (creds) {
     client_ = gcs::Client(gcs::ClientOptions(*creds));
+  } else {
+    client_ = gcs::Client::CreateDefaultClient();
   }
 }
 


### PR DESCRIPTION
We store our model repository in GCS.

We upgraded from triton 22.07 to 22.11.

In 22.07 it worked correctly, but in 22.11 it stopped working.

We run our triton server on GKE, and use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to connect to GCS. Unfortunately, there's no json file credentials created in this auth method.