### PR TITLE
Added cache to custom batching functions

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1441,10 +1441,10 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
 /// model loading. The batcher will point to a user-defined data structure that
 /// holds read-only data used for custom batching.
 ///
-/// \param model The backend model for which Triton is forming a batch.
 /// \param batcher User-defined placeholder for backend to store and
 /// retrieve information about the batching strategy for this model.
 /// return a TRITONSERVER_Error indicating success or failure.
+/// \param model The backend model for which Triton is forming a batch.
 TRITONSERVER_Error* TRITONBACKEND_BatcherInitialize(
     TRITONBACKEND_Batcher** batcher, TRITONBACKEND_Model* model);
 

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1416,12 +1416,14 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(
 /// \param userp The placeholder for backend to store and retrieve information
 /// about this pending batch. When the callback returns, this should reflect
 /// the latest batch information.
+/// \param cache_userp The read-only placeholder for backend to retrieve
+// information about the batching strategy for this model.
 /// \param should_include The pointer to be updated on whether the request
 /// should be included in the batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchIncludeRequest(
     TRITONBACKEND_Model* model, TRITONBACKEND_Request* request, void* userp,
-    bool* should_include);
+    const void* cache_userp, bool* should_include);
 
 /// Callback to be invoked when Triton has begun forming a batch.
 /// \param model The backend model for which Triton is forming a batch.
@@ -1436,6 +1438,21 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchInitialize(
 /// about this pending batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
+
+/// Callback to be invoked when Triton loads model.
+/// This will hold a cached user pointer that can be read during custom
+/// batching. \param model The backend model for which Triton is forming a
+/// batch. \param cache_userp The placeholder for backend to store and retrieve
+/// information about the batching strategy for this model. \return a
+/// TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheInitialize(
+    TRITONBACKEND_Model* model, void** cache_userp);
+
+/// Callback to be invoked when Triton unloads model.
+/// \param cache_userp The placeholder for backend to store and retrieve
+/// information about the batching strategy for this model. \return a
+/// TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheFinalize(void* cache_userp);
 
 #ifdef __cplusplus
 }

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1445,6 +1445,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
 /// retrieve information about the batching strategy for this model.
 /// return a TRITONSERVER_Error indicating success or failure.
 /// \param model The backend model for which Triton is forming a batch.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_BatcherInitialize(
     TRITONBACKEND_Batcher** batcher, TRITONBACKEND_Model* model);
 

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1431,7 +1431,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchIncludeRequest(
 // information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchInitialize(
-    TRITONBACKEND_Model* model, void** userp, const void** cache_userp);
+    TRITONBACKEND_Model* model, void** userp, const void* cache_userp);
 
 /// Callback to be invoked when Triton has finishing forming a batch.
 /// \param userp The placeholder for backend to store and retrieve information

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1446,7 +1446,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
 /// return a TRITONSERVER_Error indicating success or failure.
 /// \param model The backend model for which Triton is forming a batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_Error* TRITONBACKEND_BatcherInitialize(
+TRITONSERVER_Error* TRITONBACKEND_ModelBatcherInitialize(
     TRITONBACKEND_Batcher** batcher, TRITONBACKEND_Model* model);
 
 /// Free memory associated with batcher. This is called during model unloading.
@@ -1454,7 +1454,7 @@ TRITONSERVER_Error* TRITONBACKEND_BatcherInitialize(
 /// \param batcher User-defined placeholder for backend to store and
 /// retrieve information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_Error* TRITONBACKEND_BatcherFinalize(
+TRITONSERVER_Error* TRITONBACKEND_ModelBatcherFinalize(
     TRITONBACKEND_Batcher* batcher);
 
 #ifdef __cplusplus

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -65,6 +65,7 @@ struct TRITONBACKEND_Backend;
 struct TRITONBACKEND_Model;
 struct TRITONBACKEND_ModelInstance;
 struct TRITONBACKEND_BackendAttribute;
+struct TRITONBACKEND_Batcher;
 
 ///
 /// TRITONBACKEND API Version
@@ -1411,7 +1412,6 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(
 ///
 
 /// Check whether a request should be added to the pending model batch.
-/// \param model The backend model for which Triton is forming a batch.
 /// \param request The request to be added to the pending batch.
 /// \param userp The placeholder for backend to store and retrieve information
 /// about this pending batch. When the callback returns, this should reflect
@@ -1420,18 +1420,16 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(
 /// should be included in the batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchIncludeRequest(
-    TRITONBACKEND_Model* model, TRITONBACKEND_Request* request, void* userp,
-    bool* should_include);
+    TRITONBACKEND_Request* request, void* userp, bool* should_include);
 
 /// Callback to be invoked when Triton has begun forming a batch.
-/// \param model The backend model for which Triton is forming a batch.
+/// \param batcher The read-only placeholder for backend to retrieve
+// information about the batching strategy for this model.
 /// \param userp The placeholder for backend to store and retrieve information
 /// about this pending batch.
-/// \param cache_userp The read-only placeholder for backend to retrieve
-// information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchInitialize(
-    TRITONBACKEND_Model* model, void** userp, const void* cache_userp);
+    const TRITONBACKEND_Batcher* batcher, void** userp);
 
 /// Callback to be invoked when Triton has finishing forming a batch.
 /// \param userp The placeholder for backend to store and retrieve information
@@ -1439,21 +1437,24 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchInitialize(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
 
-/// Callback to be invoked when Triton loads model.
-/// This will hold a cached user pointer that can be read during custom
-/// batching.
+/// Create a new batcher for use with custom batching. This is called during
+/// model loading. The batcher will point to a user-defined data structure that
+/// holds read-only data used for custom batching.
+///
 /// \param model The backend model for which Triton is forming a batch.
-/// \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model.
+/// \param batcher User-defined placeholder for backend to store and
+/// retrieve information about the batching strategy for this model.
 /// return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheInitialize(
-    TRITONBACKEND_Model* model, void** cache_userp);
+TRITONSERVER_Error* TRITONBACKEND_BatcherInitialize(
+    TRITONBACKEND_Batcher** batcher, TRITONBACKEND_Model* model);
 
-/// Callback to be invoked when Triton unloads model.
-/// \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model.
+/// Free memory associated with batcher. This is called during model unloading.
+///
+/// \param batcher User-defined placeholder for backend to store and
+/// retrieve information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheFinalize(void* cache_userp);
+TRITONSERVER_Error* TRITONBACKEND_BatcherFinalize(
+    TRITONBACKEND_Batcher* batcher);
 
 #ifdef __cplusplus
 }

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1416,22 +1416,22 @@ TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(
 /// \param userp The placeholder for backend to store and retrieve information
 /// about this pending batch. When the callback returns, this should reflect
 /// the latest batch information.
-/// \param cache_userp The read-only placeholder for backend to retrieve
-// information about the batching strategy for this model.
 /// \param should_include The pointer to be updated on whether the request
 /// should be included in the batch.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchIncludeRequest(
     TRITONBACKEND_Model* model, TRITONBACKEND_Request* request, void* userp,
-    const void* cache_userp, bool* should_include);
+    bool* should_include);
 
 /// Callback to be invoked when Triton has begun forming a batch.
 /// \param model The backend model for which Triton is forming a batch.
 /// \param userp The placeholder for backend to store and retrieve information
 /// about this pending batch.
+/// \param cache_userp The read-only placeholder for backend to retrieve
+// information about the batching strategy for this model.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchInitialize(
-    TRITONBACKEND_Model* model, void** userp);
+    TRITONBACKEND_Model* model, void** userp, const void** cache_userp);
 
 /// Callback to be invoked when Triton has finishing forming a batch.
 /// \param userp The placeholder for backend to store and retrieve information
@@ -1441,17 +1441,18 @@ TRITONSERVER_Error* TRITONBACKEND_ModelBatchFinalize(void* userp);
 
 /// Callback to be invoked when Triton loads model.
 /// This will hold a cached user pointer that can be read during custom
-/// batching. \param model The backend model for which Triton is forming a
-/// batch. \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model. \return a
-/// TRITONSERVER_Error indicating success or failure.
+/// batching.
+/// \param model The backend model for which Triton is forming a batch.
+/// \param cache_userp The placeholder for backend to store and retrieve
+/// information about the batching strategy for this model.
+/// return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheInitialize(
     TRITONBACKEND_Model* model, void** cache_userp);
 
 /// Callback to be invoked when Triton unloads model.
 /// \param cache_userp The placeholder for backend to store and retrieve
-/// information about the batching strategy for this model. \return a
-/// TRITONSERVER_Error indicating success or failure.
+/// information about the batching strategy for this model.
+/// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_Error* TRITONBACKEND_ModelBatchCacheFinalize(void* cache_userp);
 
 #ifdef __cplusplus

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -50,7 +50,7 @@ class TritonModel : public Model {
       TRITONBACKEND_Model* model, TRITONBACKEND_Request* request, void* userp,
       bool* should_include);
   typedef TRITONSERVER_Error* (*TritonModelBatchInitFn_t)(
-      TRITONBACKEND_Model* model, void** userp);
+      TRITONBACKEND_Model* model, void** userp, void* cache_userp);
   typedef TRITONSERVER_Error* (*TritonModelBatchFiniFn_t)(void* userp);
   typedef TRITONSERVER_Error* (*TritonModelBatchCacheInitFn_t)(
       TRITONBACKEND_Model* model, void** cache_userp);

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -151,7 +151,7 @@ class TritonModel : public Model {
   // Opaque state associated with this model.
   void* state_;
 
-  // Custom batching shared object handle, function pointers, and user pointer.
+  // Custom batching shared object handle, function pointers, and batcher pointer.
   void* batch_dlhandle_;
   TritonModelBatchInclFn_t batch_incl_fn_;
   TritonModelBatchInitFn_t batch_init_fn_;

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -52,6 +52,10 @@ class TritonModel : public Model {
   typedef TRITONSERVER_Error* (*TritonModelBatchInitFn_t)(
       TRITONBACKEND_Model* model, void** userp);
   typedef TRITONSERVER_Error* (*TritonModelBatchFiniFn_t)(void* userp);
+  typedef TRITONSERVER_Error* (*TritonModelBatchCacheInitFn_t)(
+      TRITONBACKEND_Model* model, void** cache_userp);
+  typedef TRITONSERVER_Error* (*TritonModelBatchCacheFiniFn_t)(
+      void* cache_userp);
 
   static Status Create(
       InferenceServer* server, const std::string& model_path,
@@ -84,6 +88,7 @@ class TritonModel : public Model {
   TritonModelBatchInclFn_t ModelBatchInclFn() const { return batch_incl_fn_; }
   TritonModelBatchInitFn_t ModelBatchInitFn() const { return batch_init_fn_; }
   TritonModelBatchFiniFn_t ModelBatchFiniFn() const { return batch_fini_fn_; }
+  void** CacheUserPointerAddr() { return &cache_user_pointer_; }
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonModel);
@@ -147,11 +152,13 @@ class TritonModel : public Model {
   // Opaque state associated with this model.
   void* state_;
 
-  // Custom batching shared object handle and function pointers.
+  // Custom batching shared object handle, function pointers, and user pointer.
   void* batch_dlhandle_;
   TritonModelBatchInclFn_t batch_incl_fn_;
   TritonModelBatchInitFn_t batch_init_fn_;
   TritonModelBatchFiniFn_t batch_fini_fn_;
+  TritonModelBatchCacheFiniFn_t batch_cache_fini_fn_;
+  void* cache_user_pointer_ = nullptr;
 };
 
 }}  // namespace triton::core

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -47,15 +47,14 @@ class TritonModelInstance;
 class TritonModel : public Model {
  public:
   typedef TRITONSERVER_Error* (*TritonModelBatchInclFn_t)(
-      TRITONBACKEND_Model* model, TRITONBACKEND_Request* request, void* userp,
-      bool* should_include);
+      TRITONBACKEND_Request* request, void* userp, bool* should_include);
   typedef TRITONSERVER_Error* (*TritonModelBatchInitFn_t)(
-      TRITONBACKEND_Model* model, void** userp, void* cache_userp);
+      TRITONBACKEND_Batcher* batcher, void** userp);
   typedef TRITONSERVER_Error* (*TritonModelBatchFiniFn_t)(void* userp);
-  typedef TRITONSERVER_Error* (*TritonModelBatchCacheInitFn_t)(
-      TRITONBACKEND_Model* model, void** cache_userp);
-  typedef TRITONSERVER_Error* (*TritonModelBatchCacheFiniFn_t)(
-      void* cache_userp);
+  typedef TRITONSERVER_Error* (*TritonModelBatcherInitFn_t)(
+      TRITONBACKEND_Batcher** batcher, TRITONBACKEND_Model* model);
+  typedef TRITONSERVER_Error* (*TritonModelBatcherFiniFn_t)(
+      TRITONBACKEND_Batcher* batcher);
 
   static Status Create(
       InferenceServer* server, const std::string& model_path,
@@ -88,7 +87,7 @@ class TritonModel : public Model {
   TritonModelBatchInclFn_t ModelBatchInclFn() const { return batch_incl_fn_; }
   TritonModelBatchInitFn_t ModelBatchInitFn() const { return batch_init_fn_; }
   TritonModelBatchFiniFn_t ModelBatchFiniFn() const { return batch_fini_fn_; }
-  void** CacheUserPointerAddr() { return &cache_user_pointer_; }
+  TRITONBACKEND_Batcher** Batcher() { return &batcher_; }
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonModel);
@@ -157,8 +156,8 @@ class TritonModel : public Model {
   TritonModelBatchInclFn_t batch_incl_fn_;
   TritonModelBatchInitFn_t batch_init_fn_;
   TritonModelBatchFiniFn_t batch_fini_fn_;
-  TritonModelBatchCacheFiniFn_t batch_cache_fini_fn_;
-  void* cache_user_pointer_ = nullptr;
+  TritonModelBatcherFiniFn_t batcher_fini_fn_;
+  TRITONBACKEND_Batcher* batcher_ = nullptr;
 };
 
 }}  // namespace triton::core

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -748,7 +748,7 @@ DynamicBatchScheduler::CustomBatchInit()
     return;
   TRITONSERVER_Error* err = model_->ModelBatchInitFn()(
       reinterpret_cast<TRITONBACKEND_Model*>(model_),
-      curr_payload_.get()->UserPointerAddr());
+      curr_payload_.get()->UserPointerAddr(), *model_->CacheUserPointerAddr());
   if (err != nullptr) {
     LOG_ERROR << "Custom batching initialization function failed for model "
               << model_->Name() << ": " << TRITONSERVER_ErrorMessage(err);

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -731,7 +731,6 @@ DynamicBatchScheduler::CustomBatchIncl(
   if (!CustomBatchEnabled())
     return;
   TRITONSERVER_Error* err = model_->ModelBatchInclFn()(
-      reinterpret_cast<TRITONBACKEND_Model*>(model_),
       reinterpret_cast<TRITONBACKEND_Request*>(request),
       *curr_payload_.get()->UserPointerAddr(), should_include);
   if (err) {
@@ -747,8 +746,7 @@ DynamicBatchScheduler::CustomBatchInit()
   if (!CustomBatchEnabled())
     return;
   TRITONSERVER_Error* err = model_->ModelBatchInitFn()(
-      reinterpret_cast<TRITONBACKEND_Model*>(model_),
-      curr_payload_.get()->UserPointerAddr(), *model_->CacheUserPointerAddr());
+      *model_->Batcher(), curr_payload_.get()->UserPointerAddr());
   if (err != nullptr) {
     LOG_ERROR << "Custom batching initialization function failed for model "
               << model_->Name() << ": " << TRITONSERVER_ErrorMessage(err);


### PR DESCRIPTION
This PR builds on #143. For custom batching where the user defines additional constraints for the dynamic batcher, this PR allows the user to call two new optional functions that initialize and finalize once. This allows them to create a cached object that can be read for every batch without needing to be re-initialized.

An example use case is where the user needs to read a value from the model config for batching, so they would only want to read it from the config once and save it to use with their custom batch-handling logic. See volume_batching.cc in this PR as an example.

The core PR adds the loading of shared library functions, saving of the cached user pointer, and initialization/finalization calls as needed.

Backend: https://github.com/triton-inference-server/backend/pull/76
Server: https://github.com/triton-inference-server/server/pull/5204