### PR TITLE
Order max_resources_mtx_ avoid deadlock reloading

### DIFF
--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -736,8 +736,8 @@ RateLimiter::ResourceManager::RemoveModelInstance(
 Status
 RateLimiter::ResourceManager::UpdateResourceLimits()
 {
-  std::lock_guard<std::mutex> lk1(max_resources_mtx_);
-  std::lock_guard<std::mutex> lk2(model_resources_mtx_);
+  std::lock_guard<std::mutex> lk1(model_resources_mtx_);
+  std::lock_guard<std::mutex> lk2(max_resources_mtx_);
   max_resources_.clear();
   // Obtain the maximum resource across all the instances
   // and use it as the default available.


### PR DESCRIPTION
On heavy load and reloading models server stuck.

Best practices of cpp https://wiki.sei.cmu.edu/confluence/display/cplusplus/CON53-CPP.+Avoid+deadlock+by+locking+in+a+predefined+order

test scenario:
use c api triton inference server lib r 22.11
use 2 simple bool fp32 models from example, 
run constantly reload
run model inference and metadata requests in multiple threads.
not resources limits set for models.

stack
```sh
TID 7113:
#0  0x0000ffff9fdae2bc __lll_lock_wait
#1  0x0000ffff9fda5cd8 __pthread_mutex_lock
#2  0x0000ffff9ff40fa4 triton::core::RateLimiter::ResourceManager::UpdateResourceLimits()
#3  0x0000ffff9ff42590 triton::core::RateLimiter::RegisterModelInstance(triton::core::TritonModelInstance*, inference::ModelRateLimiter const&)
#4  0x0000ffff9fe85e98 triton::core::TritonModelInstance::CreateInstance(triton::core::TritonModel*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, TRITONSERVER_instancegroupkind_enum, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, inference::ModelRateLimiter const&, bool, std::map<unsigned int, std::shared_ptr<triton::core::TritonModelInstance::TritonBackendThread>, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::shared_ptr<triton::core::TritonModelInstance::TritonBackendThread> > > >*, std::vector<triton::core::TritonModelInstance::SecondaryDevice, std::allocator<triton::core::TritonModelInstance::SecondaryDevice> > const&)
#5  0x0000ffff9fe86cec triton::core::TritonModelInstance::CreateInstances(triton::core::TritonModel*, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > > > const&, inference::ModelConfig const&, bool)
#6  0x0000ffff9fe7c248 triton::core::TritonModel::Create(triton::core::InferenceServer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > > > const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, inference::ModelConfig, bool, std::unique_ptr<triton::core::TritonModel, std::default_delete<triton::core::TritonModel> >*)
#7  0x0000ffff9ff0ab48 triton::core::ModelLifeCycle::CreateModel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, triton::core::ModelLifeCycle::ModelInfo*, bool)
#8  0x0000ffff9ff10234 std::_Function_handler<void (), triton::core::ModelLifeCycle::AsyncLoad(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, inference::ModelConfig const&, bool, std::shared_ptr<triton::core::TritonRepoAgentModelList> const&, std::function<void (triton::core::Status)>&&)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
#9  0x0000ffffa003c260 std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run()
#10 0x0000ffff9f745fac
#11 0x0000ffff9fda3624 start_thread
#12 0x0000ffff9fcfa49c


#0  0x0000ffff9fdae2bc __lll_lock_wait
#1  0x0000ffff9fda5cd8 __pthread_mutex_lock
#2  0x0000ffff9ff3e78c triton::core::RateLimiter::ResourceManager::AllocateResources(triton::core::RateLimiter::ModelInstanceContext const*)
#3  0x0000ffff9ff3ef74 triton::core::RateLimiter::AttemptAllocation()
#4  0x0000ffff9ff3f144 triton::core::RateLimiter::OnStage(triton::core::RateLimiter::ModelInstanceContext*)
#5  0x0000ffff9ff3aedc triton::core::RateLimiter::ModelInstanceContext::Stage(std::function<void (triton::core::RateLimiter::ModelInstanceContext*)>)
#6  0x0000ffff9ff3f8c0 triton::core::RateLimiter::ModelContext::StageInstanceIfAvailable(triton::core::TritonModelInstance*)
#7  0x0000ffff9ff406b0 triton::core::RateLimiter::OnRelease(triton::core::RateLimiter::ModelInstanceContext*)
#8  0x0000ffff9ff3ab68 triton::core::RateLimiter::ModelInstanceContext::Release()
#9  0x0000ffff9ff29954 triton::core::Payload::OnRelease()
#10 0x0000ffff9ff3b344 triton::core::RateLimiter::PayloadRelease(std::shared_ptr<triton::core::Payload>&)
#11 0x0000ffff9fe8301c triton::core::TritonModelInstance::TritonBackendThread::BackendThread(int, int)
#12 0x0000ffff9f745fac
#13 0x0000ffff9fda3624 start_thread
#14 0x0000ffff9fcfa49c
```