### PR TITLE
Fix GCS public bucket access

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -544,6 +544,8 @@ GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
       gs_cred.path_);
   if (creds) {
     client_ = gcs::Client(gcs::ClientOptions(*creds));
+  } else {
+    client_ = gcs::Client::CreateDefaultClient();
   }
 }
 

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -545,7 +545,8 @@ GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
   if (creds) {
     client_ = gcs::Client(gcs::ClientOptions(*creds));
   } else {
-    client_ = gcs::Client::CreateDefaultClient();
+    client_ = gcs::Client(
+        gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials()));
   }
 }
 


### PR DESCRIPTION
This is a placeholder PR for reviewing the change that enables accessing GCS public buckets anonymously (without credentials). After approval, #148 should be merged instead.