### PR TITLE
Initialize custom batching handle and functions

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -609,7 +609,7 @@ TritonModel::~TritonModel()
 void
 TritonModel::ClearHandles()
 {
-  {
+  if (batch_dlhandle_ != nullptr) {
     std::unique_ptr<SharedLibrary> slib;
     LOG_STATUS_ERROR(
         SharedLibrary::Acquire(&slib), "~TritonModel::ClearHandles");

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -567,7 +567,6 @@ TritonModel::TritonModel(
       localized_model_dir_(localized_model_dir), backend_(backend),
       state_(nullptr)
 {
-  ClearHandles();
 }
 
 TritonModel::~TritonModel()

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -609,14 +609,17 @@ TritonModel::~TritonModel()
 void
 TritonModel::ClearHandles()
 {
-  if (batch_dlhandle_ != nullptr) {
+  if (batch_dlhandle_ == nullptr) {
+    return;
+  }
+
+  {
     std::unique_ptr<SharedLibrary> slib;
     LOG_STATUS_ERROR(
         SharedLibrary::Acquire(&slib), "~TritonModel::ClearHandles");
     LOG_STATUS_ERROR(
         slib->CloseLibraryHandle(batch_dlhandle_), "TritonModel::ClearHandles");
   }
-
   batch_dlhandle_ = nullptr;
   batch_incl_fn_ = nullptr;
   batch_init_fn_ = nullptr;

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -75,7 +75,8 @@ class TritonModel : public Model {
       const uint32_t config_version,
       TRITONSERVER_Message* updated_config_message);
   const std::shared_ptr<TritonBackend>& Backend() const { return backend_; }
-  const std::unordered_map<std::string, TritonInstanceGroup>& InstanceGroups() const
+  const std::unordered_map<std::string, TritonInstanceGroup>& InstanceGroups()
+      const
   {
     return instance_group_map_;
   }
@@ -150,14 +151,15 @@ class TritonModel : public Model {
   // Passive instance groups are those instances which are
   // loaded but not added to the scheduler.
   std::unordered_map<std::string, TritonInstanceGroup> instance_group_map_;
-  std::unordered_map<std::string, TritonInstanceGroup> passive_instance_group_map_;
+  std::unordered_map<std::string, TritonInstanceGroup>
+      passive_instance_group_map_;
 
   // Opaque state associated with this model.
   void* state_;
 
   // Custom batching shared object handle, function pointers, and batcher
   // pointer.
-  void* batch_dlhandle_;
+  void* batch_dlhandle_ = nullptr;
   TritonModelBatchInclFn_t batch_incl_fn_;
   TritonModelBatchInitFn_t batch_init_fn_;
   TritonModelBatchFiniFn_t batch_fini_fn_;

--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -160,11 +160,11 @@ class TritonModel : public Model {
   // Custom batching shared object handle, function pointers, and batcher
   // pointer.
   void* batch_dlhandle_ = nullptr;
-  TritonModelBatchInclFn_t batch_incl_fn_;
-  TritonModelBatchInitFn_t batch_init_fn_;
-  TritonModelBatchFiniFn_t batch_fini_fn_;
-  TritonModelBatcherInitFn_t batcher_init_fn_;
-  TritonModelBatcherFiniFn_t batcher_fini_fn_;
+  TritonModelBatchInclFn_t batch_incl_fn_ = nullptr;
+  TritonModelBatchInitFn_t batch_init_fn_ = nullptr;
+  TritonModelBatchFiniFn_t batch_fini_fn_ = nullptr;
+  TritonModelBatcherInitFn_t batcher_init_fn_ = nullptr;
+  TritonModelBatcherFiniFn_t batcher_fini_fn_ = nullptr;
   TRITONBACKEND_Batcher* batcher_ = nullptr;
 };
 


### PR DESCRIPTION
The custom batcher handle and functions needs to be initialized.

If the handle is not initialized to a null pointer, it's possible that models that do not use the custom batcher will have dlclose called on random memory, leading to unexpected behavior. For simplicity, I also made the function pointers be initialized to null pointer without ClearHandles() needing to be called during model construction. This enforces good default behavior and prevents them from registering as non-null and being called on random memory.

I also added a check in ClearHandles that the pointer is null. This is already checked in dlclose, but I moved it earlier to avoid running the later code when not necessary.