### PR TITLE
Map cache name to library and config

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1708,14 +1708,23 @@ TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
 /// Set the cache config that will be used to initialize the cache
 /// implementation for "cache_name".
 ///
-/// Examples:
+/// It is expected that the "cache_name" provided matches a directory inside
+/// the "cache_dir" used for TRITONSERVER_ServerOptionsSetCacheDirectory. The
+/// default "cache_dir" is "/opt/tritonserver/caches", so for a "cache_name" of
+/// "local", Triton would expect to find the "local" cache implementation at
+/// "/opt/tritonserver/caches/local/libtritoncache_local.so"
+///
+/// Altogether an example for the "local" cache implementation would look like:
+///   std::string cache_name = "local";
 ///   std::string config_json = R"({"size": 1048576})"
-///   std::string config_json = "{\"size\": 1048576}"
+///   auto err = TRITONSERVER_ServerOptionsSetCacheConfig(
+///     options, cache_name, config_json);
 ///
 /// \param options The server options object.
-/// FIXME: cache_name included for future extensibility, but not currently used.
-/// \param cache_name The name of the cache.
-/// \param config_json The string representation of config JSON.
+/// \param cache_name The name of the cache. Example names would be
+/// "local", "redis", or the name of a custom cache implementation.
+/// \param config_json The string representation of config JSON that is
+/// used to initialize the cache implementation.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetCacheConfig(
@@ -1724,8 +1733,6 @@ TRITONSERVER_ServerOptionsSetCacheConfig(
 
 /// Set the directory containing cache shared libraries. This
 /// directory is searched when looking for cache implementations.
-/// Currently, it is expected that this directory contains a file
-/// specifically named "libtritoncache.so"/"tritoncache.dll".
 ///
 /// \param options The server options object.
 /// \param cache_dir The full path of the cache directory.

--- a/src/cache_manager.cc
+++ b/src/cache_manager.cc
@@ -35,12 +35,12 @@
 namespace triton { namespace core {
 
 std::string
-TritonCacheLibraryName()
+TritonCacheLibraryName(const std::string& cache_name)
 {
 #ifdef _WIN32
-  return std::string("tritoncache.dll");
+  return std::string("tritoncache_") + cache_name + ".dll";
 #else
-  return std::string("libtritoncache.so");
+  return std::string("libtritoncache_") + cache_name + ".so";
 #endif
 }
 
@@ -399,10 +399,11 @@ TritonCacheManager::CreateCache(
 
   // Get the path to the cache shared library. Search path is global
   // cache directory.
-  const std::vector<std::string> search_paths = {cache_dir_};
+  const std::vector<std::string> search_paths = {JoinPath({cache_dir_, name})};
+
   // Triton will only use a single cache library path for now,
   // regardless of implementation.
-  std::string cache_libname = TritonCacheLibraryName();
+  std::string cache_libname = TritonCacheLibraryName(name);
   std::string libpath = "";
   for (const auto& path : search_paths) {
     const auto full_path = JoinPath({path, cache_libname});

--- a/src/server.h
+++ b/src/server.h
@@ -44,6 +44,9 @@
 
 namespace triton { namespace core {
 
+// Maps cache name -> json config string
+using CacheConfigMap = std::unordered_map<std::string, std::string>;
+
 class Model;
 class InferenceRequest;
 
@@ -196,8 +199,7 @@ class InferenceServer {
   // NOTE: Models still need caching enabled in individual model configs.
   bool ResponseCacheEnabled() const { return response_cache_enabled_; }
   void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
-  std::string CacheConfig() const { return cache_config_; }
-  void SetCacheConfig(std::string config_json) { cache_config_ = config_json; }
+  void SetCacheConfig(CacheConfigMap cfg) { cache_config_map_ = cfg; }
   std::string CacheDir() const { return cache_dir_; }
   void SetCacheDir(std::string dir) { cache_dir_ = dir; }
 
@@ -297,7 +299,7 @@ class InferenceServer {
   uint32_t model_load_thread_count_;
   uint64_t pinned_memory_pool_size_;
   bool response_cache_enabled_;
-  std::string cache_config_;
+  CacheConfigMap cache_config_map_;
   std::string cache_dir_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_supported_compute_capability_;

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -492,14 +492,16 @@ CreateCache(uint64_t cache_size)
   std::shared_ptr<tc::TritonCache> cache;
   auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
   std::cout << "Creating cache with size: " << cache_size << std::endl;
-  helpers::check_status(cache_manager->CreateCache(
-      "response_cache" /* name */, cache_config, &cache));
+  auto cache_name = "local";
+  helpers::check_status(
+      cache_manager->CreateCache(cache_name, cache_config, &cache));
 
   return cache;
 }
 
 void
-CreateCacheExpectFail(std::string cache_config)
+CreateCacheExpectFail(
+    const std::string& cache_name, const std::string& cache_config)
 {
   // Create TritonCacheManager
   std::shared_ptr<tc::TritonCacheManager> cache_manager;
@@ -509,8 +511,7 @@ CreateCacheExpectFail(std::string cache_config)
 
   // Create TritonCache
   std::shared_ptr<tc::TritonCache> cache;
-  auto status = cache_manager->CreateCache(
-      "response_cache" /* name */, cache_config, &cache);
+  auto status = cache_manager->CreateCache(cache_name, cache_config, &cache);
 
   ASSERT_FALSE(status.IsOk()) << "Creating cache with config: '" << cache_config
                               << "' succeeded when it should fail.";
@@ -636,7 +637,7 @@ TEST_F(RequestResponseCacheTest, TestCacheSizeTooSmall)
   constexpr uint64_t cache_size = 1;
   auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
   std::cout << "Create cache of size: " << cache_size << std::endl;
-  helpers::CreateCacheExpectFail(cache_config);
+  helpers::CreateCacheExpectFail("local", cache_config);
 }
 
 // Test cache size too large to initialize.
@@ -646,7 +647,7 @@ TEST_F(RequestResponseCacheTest, TestCacheSizeTooLarge)
   constexpr uint64_t cache_size = ULLONG_MAX;
   auto cache_config = R"({"size": )" + std::to_string(cache_size) + "}";
   std::cout << "Create cache of size: " << cache_size << std::endl;
-  helpers::CreateCacheExpectFail(cache_config);
+  helpers::CreateCacheExpectFail("local", cache_config);
 }
 
 TEST_F(RequestResponseCacheTest, TestCacheSizeSmallerThanEntryBytes)

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -308,9 +308,9 @@ class TritonServerOptions {
     return host_policy_map_;
   }
 
-  const std::string& CacheConfig() const { return cache_config_; }
-  void SetCacheConfig(const std::string& cfg) { cache_config_ = cfg; }
-
+  tc::CacheConfigMap CacheConfig() { return cache_config_map_; }
+  TRITONSERVER_Error* AddCacheConfig(
+      const std::string& cache_name, const std::string& config_json);
   const std::string& CacheDir() const { return cache_dir_; }
   void SetCacheDir(const std::string& dir) { cache_dir_ = dir; }
 
@@ -337,8 +337,7 @@ class TritonServerOptions {
   std::string backend_dir_;
   std::string repoagent_dir_;
   std::string cache_dir_;
-  // String representation of JSON cache config
-  std::string cache_config_;
+  tc::CacheConfigMap cache_config_map_;
   triton::common::BackendCmdlineConfigMap backend_cmdline_config_map_;
   triton::common::HostPolicyCmdlineConfigMap host_policy_map_;
 };
@@ -360,7 +359,7 @@ TritonServerOptions::TritonServerOptions()
 #endif  // TRITON_ENABLE_GPU
       backend_dir_("/opt/tritonserver/backends"),
       repoagent_dir_("/opt/tritonserver/repoagents"),
-      cache_dir_("/opt/tritonserver/caches"), cache_config_("{}")
+      cache_dir_("/opt/tritonserver/caches")
 {
 #ifndef TRITON_ENABLE_METRICS
   metrics_ = false;
@@ -409,6 +408,14 @@ TritonServerOptions::AddBackendConfig(
       backend_cmdline_config_map_[backend_name];
   cc.push_back(std::make_pair(setting, value));
 
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TritonServerOptions::AddCacheConfig(
+    const std::string& cache_name, const std::string& config_json)
+{
+  cache_config_map_[cache_name] = config_json;
   return nullptr;  // success
 }
 
@@ -1177,8 +1184,9 @@ TRITONSERVER_ServerOptionsSetResponseCacheByteSize(
 {
   // For backwards compatibility, forward this API call to new CacheConfig API.
   std::string config_json = R"({"size": )" + std::to_string(size) + "}";
+  std::string default_cache = "local";
   return TRITONSERVER_ServerOptionsSetCacheConfig(
-      options, "" /* cache_name */, config_json.c_str());
+      options, default_cache.c_str(), config_json.c_str());
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
@@ -1189,8 +1197,7 @@ TRITONSERVER_ServerOptionsSetCacheConfig(
   TritonServerOptions* loptions =
       reinterpret_cast<TritonServerOptions*>(options);
   // NOTE: cache_name included for future extensibility, but not currently used.
-  loptions->SetCacheConfig(config_json);
-  return nullptr;  // success
+  return loptions->AddCacheConfig(cache_name, config_json);
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
@@ -2136,8 +2143,8 @@ TRITONSERVER_ServerNew(
   lserver->SetRateLimiterResources(loptions->RateLimiterResources());
   lserver->SetPinnedMemoryPoolByteSize(loptions->PinnedMemoryPoolByteSize());
   lserver->SetCudaMemoryPoolByteSize(loptions->CudaMemoryPoolByteSize());
-  // TODO: expose server option for this?
-  lserver->SetResponseCacheEnabled(true);
+  bool cache_enabled = !loptions->CacheConfig().empty();
+  lserver->SetResponseCacheEnabled(cache_enabled);
   lserver->SetCacheConfig(loptions->CacheConfig());
   lserver->SetCacheDir(loptions->CacheDir());
   double min_compute_capability = loptions->MinSupportedComputeCapability();

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -308,7 +308,7 @@ class TritonServerOptions {
     return host_policy_map_;
   }
 
-  tc::CacheConfigMap CacheConfig() { return cache_config_map_; }
+  const tc::CacheConfigMap& CacheConfig() { return cache_config_map_; }
   TRITONSERVER_Error* AddCacheConfig(
       const std::string& cache_name, const std::string& config_json);
   const std::string& CacheDir() const { return cache_dir_; }


### PR DESCRIPTION
This enables user to specify which cache implementation they want to use, for example `local` or `redis`, and specify them on the CLI in the related server PR: https://github.com/triton-inference-server/server/pull/5119.

The `cache_name` must match a folder in the CACHE_DIR (ex: `/opt/tritonserver/caches/`) similar to how backends and repoagents are loaded and configured today.

> **NOTE**:
> There may only be one cache configured (and therefore instantiated) at this time. In the future, there may be support for multiple global caches such as a `local` and a `redis` cache co-existing with no API changes, only minor changes to `TritonCacheManager` and how it's interacted with.