### PR TITLE
Enable GCS compute engine credentials

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -535,7 +535,7 @@ class GCSFileSystem : public FileSystem {
       const std::string path, bool* exists,
       google::cloud::StatusOr<gcs::ObjectMetadata>* metadata);
 
-  google::cloud::StatusOr<gcs::Client> client_;
+  std::unique_ptr<gcs::Client> client_;
 };
 
 GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
@@ -555,7 +555,7 @@ GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
           gcs::oauth2::CreateAnonymousCredentials());  // no credential
     }
   }
-  client_ = gcs::Client(options);
+  client_ = std::make_unique<gcs::Client>(options);
 }
 
 Status

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -546,10 +546,14 @@ GCSFileSystem::GCSFileSystem(const GCSCredential& gs_cred)
   if (creds) {
     options.set<gcs::Oauth2CredentialsOption>(*creds);  // json credential
   } else {
-    options.set<google::cloud::UnifiedCredentialsOption>(
-        google::cloud::MakeGoogleDefaultCredentials());  // metadata service
-    options.set<google::cloud::UnifiedCredentialsOption>(
-        google::cloud::MakeInsecureCredentials());  // public bucket
+    auto creds = gcs::oauth2::CreateComputeEngineCredentials();
+    if (creds->AuthorizationHeader()) {
+      options.set<gcs::Oauth2CredentialsOption>(creds);  // metadata service
+    }
+    else {
+      options.set<gcs::Oauth2CredentialsOption>(
+          gcs::oauth2::CreateAnonymousCredentials());  // no credential
+    }
   }
   client_ = gcs::Client(options);
 }


### PR DESCRIPTION
GCS supports a range of different authentication method for connecting to the service, specifically we want to support [JSON file](https://googleapis.dev/cpp/google-cloud-storage/1.42.0/namespacegoogle_1_1cloud_1_1storage_1_1oauth2.html#a8e14b8e892425fcc5c9cdad80120eead), [Compute Engine](https://googleapis.dev/cpp/google-cloud-storage/1.42.0/namespacegoogle_1_1cloud_1_1storage_1_1oauth2.html#ad47cf9331fa6c0999407b1da378368d0) and [Anonymous](https://googleapis.dev/cpp/google-cloud-storage/1.42.0/namespacegoogle_1_1cloud_1_1storage_1_1oauth2.html#a086aa0ad3dad05d6a500252ba144dff7) credentials. This PR adds the Compute Engine credential which automatically connects to the metadata server and fetch an access token for accessing GCS (a.k.a. identity mechanism), when inside Kubernetes or Compute Engine if properly setup.

If the JSON credential is not supplied (either via [env var](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md#google-cloud-storage) or [credential file](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md#cloud-storage-with-credential-file-beta)), then the Compute Engine credential is tried next. If the Compute Engine credential is unable to fetch [AuthorizationHeader](https://googleapis.dev/cpp/google-cloud-storage/1.42.0/classgoogle_1_1cloud_1_1storage_1_1oauth2_1_1ComputeEngineCredentials.html#a8c3a5d405366523e2f4df06554f0a676), then Anonymous credential is used.

Related PR: https://github.com/triton-inference-server/server/pull/5355
Closes https://github.com/triton-inference-server/server/issues/5039