### PR TITLE
Add namespace as model identifier to relax ensemble specification

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 17
+#define TRITONSERVER_API_VERSION_MINOR 18
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the
@@ -1760,6 +1760,16 @@ TRITONSERVER_ServerOptionsSetBufferManagerThreadCount(
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetModelLoadThreadCount(
     TRITONSERVER_ServerOptions* options, unsigned int thread_count);
+
+/// Enable model namespacing to allow serving models with the same name if
+/// they are in different namespaces.
+///
+/// \param options The server options object.
+/// \param enable_namespace Whether to enable model namespacing or not.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetModelNamespacing(
+    TRITONSERVER_ServerOptions* options, bool enable_namespace);
 
 /// Provide a log output file.
 ///

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -327,7 +327,7 @@ class EnsembleContext {
   std::unordered_map<std::string, TensorData> tensor_data_;
 
   // Handle to all models that may be used in the ensemble
-  std::unordered_map<std::string, VersionMap> handles_;
+  std::unordered_map<ModelIdentifier, VersionMap> handles_;
 
   // Request specific information that obtained from ensemble request and
   // should be applied to all internal requests
@@ -368,16 +368,16 @@ EnsembleContext::EnsembleContext(
   // they have the same lifetime as the ensemble request to avoid unloading
   // while the ensemble is executing.
   for (const auto& step_info : info_->steps_) {
-    auto it = handles_.find(step_info.model_name_);
+    auto it = handles_.find(step_info.model_id_);
     if (it == handles_.end()) {
-      it = handles_.emplace(std::make_pair(step_info.model_name_, VersionMap()))
+      it = handles_.emplace(std::make_pair(step_info.model_id_, VersionMap()))
                .first;
     }
     auto ver_it = it->second.find(step_info.model_version_);
     if (ver_it == it->second.end()) {
       std::shared_ptr<Model> model = nullptr;
       ensemble_status_ = is_->GetModel(
-          step_info.model_name_, step_info.model_version_, &model);
+          step_info.model_id_, step_info.model_version_, &model);
       if (!ensemble_status_.IsOk()) {
         break;
       }
@@ -860,7 +860,7 @@ EnsembleContext::InitStep(
     std::unique_ptr<Step>* step)
 {
   const auto& istep = info_->steps_[step_idx];
-  auto& version_map = handles_[istep.model_name_];
+  auto& version_map = handles_[istep.model_id_];
   auto& model = version_map[istep.model_version_];
 
   const bool allow_batching = (model->Config().max_batch_size() > 0);
@@ -912,7 +912,7 @@ EnsembleContext::InitStep(
                             (flags != tensor.flags_))) {
         LOG_ERROR << irequest->LogRequest()
                   << "Different set of response parameters are set for '"
-                  << istep.model_name_ << "'. Parameter correlation ID "
+                  << istep.model_id_ << "'. Parameter correlation ID "
                   << correlation_id << ", flags " << flags << " is used.";
         continue;
       }
@@ -1347,7 +1347,7 @@ EnsembleScheduler::EnsembleScheduler(
 
   for (const auto& element : config.ensemble_scheduling().step()) {
     size_t step_idx = info_->steps_.size();
-    info_->steps_.emplace_back(element.model_name(), element.model_version());
+    info_->steps_.emplace_back(ModelIdentifier(element.model_namespace(), element.model_name()), element.model_version());
     for (const auto& pair : element.input_map()) {
       auto it = info_->tensor_to_step_.find(pair.second);
       if (it == info_->tensor_to_step_.end()) {

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -376,8 +376,8 @@ EnsembleContext::EnsembleContext(
     auto ver_it = it->second.find(step_info.model_version_);
     if (ver_it == it->second.end()) {
       std::shared_ptr<Model> model = nullptr;
-      ensemble_status_ = is_->GetModel(
-          step_info.model_id_, step_info.model_version_, &model);
+      ensemble_status_ =
+          is_->GetModel(step_info.model_id_, step_info.model_version_, &model);
       if (!ensemble_status_.IsOk()) {
         break;
       }
@@ -1347,7 +1347,9 @@ EnsembleScheduler::EnsembleScheduler(
 
   for (const auto& element : config.ensemble_scheduling().step()) {
     size_t step_idx = info_->steps_.size();
-    info_->steps_.emplace_back(ModelIdentifier(element.model_namespace(), element.model_name()), element.model_version());
+    info_->steps_.emplace_back(
+        ModelIdentifier(element.model_namespace(), element.model_name()),
+        element.model_version());
     for (const auto& pair : element.input_map()) {
       auto it = info_->tensor_to_step_.find(pair.second);
       if (it == info_->tensor_to_step_.end()) {

--- a/src/ensemble_scheduler.h
+++ b/src/ensemble_scheduler.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/ensemble_scheduler.h
+++ b/src/ensemble_scheduler.h
@@ -29,6 +29,7 @@
 
 #include <memory>
 #include "metric_model_reporter.h"
+#include "model.h"
 #include "model_config.pb.h"
 #include "model_config_utils.h"
 #include "scheduler.h"
@@ -48,12 +49,12 @@ class InferenceServer;
 
 struct EnsembleInfo {
   struct StepInfo {
-    StepInfo(const std::string& model_name, const int64_t model_version)
-        : model_name_(model_name), model_version_(model_version)
+    StepInfo(const ModelIdentifier& model_id, const int64_t model_version)
+        : model_id_(model_id), model_version_(model_version)
     {
     }
 
-    std::string model_name_;
+    ModelIdentifier model_id_;
     int64_t model_version_;
     std::unordered_map<std::string, std::string> input_to_tensor_;
     std::unordered_map<std::string, std::string> output_to_tensor_;

--- a/src/ensemble_utils.cc
+++ b/src/ensemble_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -90,10 +90,11 @@ ValidateTensorConsistency(
   if (lhs.type_ != rhs.type_) {
     return Status(
         Status::Code::INVALID_ARG,
-        message + "inconsistent data type: " +
-            inference::DataType_Name(lhs.type_) + " is inferred from model " +
-            lhs.model_id_.str() + " while " + inference::DataType_Name(rhs.type_) +
-            " is inferred from model " + rhs.model_id_.str());
+        message +
+            "inconsistent data type: " + inference::DataType_Name(lhs.type_) +
+            " is inferred from model " + lhs.model_id_.str() + " while " +
+            inference::DataType_Name(rhs.type_) + " is inferred from model " +
+            rhs.model_id_.str());
   }
 
   // Shapes must match or either one uses variable size shape, if one uses
@@ -119,7 +120,8 @@ ValidateTensorConsistency(
 
 Status
 ValidateTensorMapping(
-    const ModelIdentifier& ensemble_id, const inference::ModelEnsembling::Step& step,
+    const ModelIdentifier& ensemble_id,
+    const inference::ModelEnsembling::Step& step,
     const inference::ModelConfig& model_config,
     std::unordered_map<std::string, TensorNode>* ensemble_tensors)
 {
@@ -134,9 +136,9 @@ ValidateTensorMapping(
     if (input_names.find(input_map.first) == input_names.end()) {
       return Status(
           Status::Code::INVALID_ARG,
-          "in ensemble " + ensemble_id.str() + ", ensemble tensor " + input_map.second +
-              " is mapping to non-existing input " + input_map.first +
-              " in model " + step_id.str());
+          "in ensemble " + ensemble_id.str() + ", ensemble tensor " +
+              input_map.second + " is mapping to non-existing input " +
+              input_map.first + " in model " + step_id.str());
     }
   }
   for (const auto& model_input : model_config.input()) {
@@ -144,8 +146,7 @@ ValidateTensorMapping(
     for (const auto& input_map : step.input_map()) {
       if (model_input.name() == input_map.first) {
         TensorNode model_tensor(
-            step_id, batching, model_input.data_type(),
-            model_input.dims());
+            step_id, batching, model_input.data_type(), model_input.dims());
         auto it = ensemble_tensors->find(input_map.second);
         if (it != ensemble_tensors->end()) {
           RETURN_IF_ERROR(ValidateTensorConsistency(
@@ -188,9 +189,9 @@ ValidateTensorMapping(
     if (output_names.find(output_map.first) == output_names.end()) {
       return Status(
           Status::Code::INVALID_ARG,
-          "in ensemble " + ensemble_id.str() + ", ensemble tensor " + output_map.second +
-              " is mapped from non-existing output " + output_map.first +
-              " in model " + step.model_name());
+          "in ensemble " + ensemble_id.str() + ", ensemble tensor " +
+              output_map.second + " is mapped from non-existing output " +
+              output_map.first + " in model " + step.model_name());
     }
   }
   std::shared_ptr<TensorNode> sibling_node(new TensorNode(step_id));
@@ -199,8 +200,7 @@ ValidateTensorMapping(
     for (const auto& model_output : model_config.output()) {
       if (model_output.name() == output_map.first) {
         TensorNode model_tensor(
-            step_id, batching, model_output.data_type(),
-            model_output.dims());
+            step_id, batching, model_output.data_type(), model_output.dims());
         auto it = ensemble_tensors->find(output_map.second);
         if (it != ensemble_tensors->end()) {
           RETURN_IF_ERROR(ValidateTensorConsistency(

--- a/src/model.h
+++ b/src/model.h
@@ -52,7 +52,7 @@ struct ModelIdentifier {
 
   bool operator!=(const ModelIdentifier& rhs) const
   {
-    return (!(namespace_ != rhs.namespace_) || !(name_ != rhs.name_));
+    return ((namespace_ != rhs.namespace_) || (name_ != rhs.name_));
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)

--- a/src/model.h
+++ b/src/model.h
@@ -55,9 +55,9 @@ struct ModelIdentifier {
     return (!(namespace_ != rhs.namespace_) || !(name_ != rhs.name_));
   }
 
-  // [WIP] remove special handling to hide log differences
   friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)
   {
+    // Avoid log differences if namespace is disabled
     if (rhs.namespace_.empty()) {
       os << rhs.name_;
       return os;
@@ -68,18 +68,18 @@ struct ModelIdentifier {
 
   std::string str() const
   {
+    // Avoid log differences if namespace is disabled
     if (namespace_.empty()) {
       return name_;
     }
     return (namespace_ + "::" + name_);
   }
 
-  // [WIP] note for myself, should clean up
   // namespace is not a reflection of the model repository althought it is
   // currently implmented to be the same as the repository of the model.
   std::string namespace_;
   // name is the name registered to Triton, it is the model directory name
-  // by default and can be overwritten.
+  // by default and may be overwritten.
   std::string name_;
 };
 }}  // namespace triton::core

--- a/src/model.h
+++ b/src/model.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -34,7 +34,9 @@
 namespace triton { namespace core {
 struct ModelIdentifier {
   ModelIdentifier(const std::string& model_namespace, const std::string& name)
-   : namespace_(model_namespace), name_(name) {}
+      : namespace_(model_namespace), name_(name)
+  {
+  }
 
   bool operator<(const ModelIdentifier& rhs) const
   {
@@ -93,8 +95,9 @@ class hash<triton::core::ModelIdentifier> {
   {
     // trival hash for multiple entries
     // https://en.cppreference.com/w/cpp/utility/hash
-    return (hash<std::string>()(model_id.namespace_)
-               ^ (hash<std::string>()(model_id.name_) << 1));
+    return (
+        hash<std::string>()(model_id.namespace_) ^
+        (hash<std::string>()(model_id.name_) << 1));
   }
 };
 }  // namespace std

--- a/src/model.h
+++ b/src/model.h
@@ -32,6 +32,73 @@
 #include "status.h"
 
 namespace triton { namespace core {
+struct ModelIdentifier {
+  ModelIdentifier(const std::string& model_namespace, const std::string& name)
+   : namespace_(model_namespace), name_(name) {}
+
+  bool operator<(const ModelIdentifier& rhs) const
+  {
+    if (namespace_ == rhs.namespace_) {
+      return (name_ < rhs.name_);
+    } else {
+      return (namespace_ < rhs.namespace_);
+    }
+  }
+
+  bool operator==(const ModelIdentifier& rhs) const
+  {
+    return ((namespace_ == rhs.namespace_) && (name_ == rhs.name_));
+  }
+
+  bool operator!=(const ModelIdentifier& rhs) const
+  {
+    return (!(namespace_ != rhs.namespace_) || !(name_ != rhs.name_));
+  }
+
+  // [WIP] remove special handling to hide log differences
+  friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)
+  {
+    if (rhs.namespace_.empty()) {
+      os << rhs.name_;
+      return os;
+    }
+    os << rhs.namespace_ << "::" << rhs.name_;
+    return os;
+  }
+
+  std::string str() const
+  {
+    if (namespace_.empty()) {
+      return name_;
+    }
+    return (namespace_ + "::" + name_);
+  }
+
+  // [WIP] note for myself, should clean up
+  // namespace is not a reflection of the model repository althought it is
+  // currently implmented to be the same as the repository of the model.
+  std::string namespace_;
+  // name is the name registered to Triton, it is the model directory name
+  // by default and can be overwritten.
+  std::string name_;
+};
+}}  // namespace triton::core
+
+// define hash function for struct to be used as unordered_map key
+namespace std {
+template <>
+class hash<triton::core::ModelIdentifier> {
+ public:
+  size_t operator()(const triton::core::ModelIdentifier& model_id) const
+  {
+    // trival hash for multiple entries
+    // https://en.cppreference.com/w/cpp/utility/hash
+    return (hash<std::string>()(model_id.namespace_)
+               ^ (hash<std::string>()(model_id.name_) << 1));
+  }
+};
+}  // namespace std
+namespace triton { namespace core {
 
 class InferenceRequest;
 

--- a/src/model_lifecycle.cc
+++ b/src/model_lifecycle.cc
@@ -546,7 +546,7 @@ ModelLifeCycle::CreateModel(
               std::shared_ptr<Model> model;
               // Safe to obtain model because the ensemble can't be loaded
               // until the involved models are ready
-              GetModel(element.model_name(), element.model_version(), &model);
+              GetModel({element.model_namespace(), element.model_name()}, element.model_version(), &model);
               label_provider->AddLabels(
                   pair.second,
                   model->GetLabelProvider()->GetLabels(pair.first));

--- a/src/model_lifecycle.cc
+++ b/src/model_lifecycle.cc
@@ -81,7 +81,7 @@ namespace {
 
 Status
 VersionsToLoad(
-    const std::string model_path, const std::string& name,
+    const std::string model_path, const ModelIdentifier& model_id,
     const inference::ModelConfig& model_config, std::set<int64_t>* versions)
 {
   versions->clear();
@@ -116,7 +116,7 @@ VersionsToLoad(
       if (!version_not_exist) {
         versions->emplace(v);
       } else {
-        LOG_ERROR << "version " << v << " is specified for model '" << name
+        LOG_ERROR << "version " << v << " is specified for model '" << model_id
                   << "', but the version directory is not present";
       }
     }
@@ -234,12 +234,12 @@ ModelLifeCycle::StopAllModels()
   return Status::Success;
 }
 
-const std::set<std::tuple<std::string, int64_t, size_t>>
+const std::set<std::tuple<ModelIdentifier, int64_t, size_t>>
 ModelLifeCycle::InflightStatus()
 {
   LOG_VERBOSE(2) << "InflightStatus()";
   std::lock_guard<std::mutex> map_lock(map_mtx_);
-  std::set<std::tuple<std::string, int64_t, size_t>> inflight_status;
+  std::set<std::tuple<ModelIdentifier, int64_t, size_t>> inflight_status;
   for (auto& model_version : map_) {
     for (auto& version_model : model_version.second) {
       if (version_model.second != nullptr) {
@@ -280,12 +280,12 @@ ModelLifeCycle::ModelStates()
 }
 
 const VersionStateMap
-ModelLifeCycle::VersionStates(const std::string& model_name)
+ModelLifeCycle::VersionStates(const ModelIdentifier& model_id)
 {
-  LOG_VERBOSE(2) << "VersionStates() '" << model_name << "'";
+  LOG_VERBOSE(2) << "VersionStates() '" << model_id << "'";
   std::lock_guard<std::mutex> map_lock(map_mtx_);
   VersionStateMap version_map;
-  auto mit = map_.find(model_name);
+  auto mit = map_.find(model_id);
   if (mit != map_.end()) {
     for (auto& version_model : mit->second) {
       std::lock_guard<std::mutex> lock(version_model.second->mtx_);
@@ -299,11 +299,11 @@ ModelLifeCycle::VersionStates(const std::string& model_name)
 
 Status
 ModelLifeCycle::ModelState(
-    const std::string& model_name, const int64_t model_version,
+    const ModelIdentifier& model_id, const int64_t model_version,
     ModelReadyState* state)
 {
   std::lock_guard<std::mutex> map_lock(map_mtx_);
-  auto mit = map_.find(model_name);
+  auto mit = map_.find(model_id);
   if (mit != map_.end()) {
     auto vit = mit->second.find(model_version);
     if (vit != mit->second.end()) {
@@ -314,28 +314,28 @@ ModelLifeCycle::ModelState(
   }
 
   return Status(
-      Status::Code::NOT_FOUND, "model '" + model_name + "', version " +
+      Status::Code::NOT_FOUND, "model '" + model_id.str() + "', version " +
                                    std::to_string(model_version) +
                                    " is not found");
 }
 
 Status
 ModelLifeCycle::GetModel(
-    const std::string& model_name, const int64_t version,
+    const ModelIdentifier& model_id, const int64_t version,
     std::shared_ptr<Model>* model)
 {
-  LOG_VERBOSE(2) << "GetModel() '" << model_name << "' version " << version;
+  LOG_VERBOSE(2) << "GetModel() '" << model_id << "' version " << version;
   std::lock_guard<std::mutex> map_lock(map_mtx_);
-  auto mit = map_.find(model_name);
+  auto mit = map_.find(model_id);
   if (mit == map_.end()) {
-    return Status(Status::Code::NOT_FOUND, "'" + model_name + "' is not found");
+    return Status(Status::Code::NOT_FOUND, "'" + model_id.str() + "' is not found");
   }
 
   auto vit = mit->second.find(version);
   if (vit == mit->second.end()) {
     if (version != -1) {
       return Status(
-          Status::Code::NOT_FOUND, "'" + model_name + "' version " +
+          Status::Code::NOT_FOUND, "'" + model_id.str() + "' version " +
                                        std::to_string(version) +
                                        " is not found");
     }
@@ -359,7 +359,7 @@ ModelLifeCycle::GetModel(
     if (latest == -1) {
       return Status(
           Status::Code::NOT_FOUND,
-          "'" + model_name + "' has no available versions");
+          "'" + model_id.str() + "' has no available versions");
     }
   } else {
     std::lock_guard<std::mutex> lock(vit->second->mtx_);
@@ -367,7 +367,7 @@ ModelLifeCycle::GetModel(
       *model = vit->second->model_;
     } else {
       return Status(
-          Status::Code::UNAVAILABLE, "'" + model_name + "' version " +
+          Status::Code::UNAVAILABLE, "'" + model_id.str() + "' version " +
                                          std::to_string(version) +
                                          " is not at ready state");
     }
@@ -376,11 +376,11 @@ ModelLifeCycle::GetModel(
 }
 
 Status
-ModelLifeCycle::AsyncUnload(const std::string& model_name)
+ModelLifeCycle::AsyncUnload(const ModelIdentifier& model_id)
 {
-  LOG_VERBOSE(2) << "AsyncUnload() '" << model_name << "'";
+  LOG_VERBOSE(2) << "AsyncUnload() '" << model_id << "'";
   std::lock_guard<std::mutex> map_lock(map_mtx_);
-  auto it = map_.find(model_name);
+  auto it = map_.find(model_id);
   if (it == map_.end()) {
     return Status(
         Status::Code::INVALID_ARG, "Model to be unloaded has not been served");
@@ -420,28 +420,28 @@ ModelLifeCycle::AsyncUnload(const std::string& model_name)
 
 Status
 ModelLifeCycle::AsyncLoad(
-    const std::string& model_name, const std::string& model_path,
+    const ModelIdentifier& model_id, const std::string& model_path,
     const inference::ModelConfig& model_config, const bool is_config_provided,
     const std::shared_ptr<TritonRepoAgentModelList>& agent_model_list,
     std::function<void(Status)>&& OnComplete)
 {
-  LOG_VERBOSE(2) << "AsyncLoad() '" << model_name << "'";
+  LOG_VERBOSE(2) << "AsyncLoad() '" << model_id << "'";
 
   std::lock_guard<std::mutex> map_lock(map_mtx_);
-  auto it = map_.find(model_name);
+  auto it = map_.find(model_id);
   if (it == map_.end()) {
-    it = map_.emplace(std::make_pair(model_name, VersionMap())).first;
+    it = map_.emplace(std::make_pair(model_id, VersionMap())).first;
   }
 
   std::set<int64_t> versions;
   RETURN_IF_ERROR(
-      VersionsToLoad(model_path, model_name, model_config, &versions));
+      VersionsToLoad(model_path, model_id, model_config, &versions));
   if (versions.empty()) {
     return Status(
         Status::Code::INVALID_ARG,
         "at least one version must be available under the version policy of "
         "model '" +
-            model_name + "'");
+            model_id.str() + "'");
   }
 
 
@@ -456,7 +456,7 @@ ModelLifeCycle::AsyncLoad(
         new ModelInfo(model_path, model_config, now_ns));
     ModelInfo* model_info = linfo.get();
 
-    LOG_INFO << "loading: " << model_name << ":" << version;
+    LOG_INFO << "loading: " << model_id << ":" << version;
     model_info->state_ = ModelReadyState::LOADING;
     model_info->state_reason_.clear();
     model_info->agent_model_list_ = agent_model_list;
@@ -491,10 +491,10 @@ ModelLifeCycle::AsyncLoad(
     }
 
     // Load model asynchronously via thread pool
-    load_pool_->Enqueue([this, model_name, version, model_info, OnComplete,
+    load_pool_->Enqueue([this, model_id, version, model_info, OnComplete,
                          load_tracker, is_config_provided]() {
-      CreateModel(model_name, version, model_info, is_config_provided);
-      OnLoadComplete(model_name, version, model_info, OnComplete, load_tracker);
+      CreateModel(model_id, version, model_info, is_config_provided);
+      OnLoadComplete(model_id, version, model_info, OnComplete, load_tracker);
     });
   }
 
@@ -503,10 +503,10 @@ ModelLifeCycle::AsyncLoad(
 
 void
 ModelLifeCycle::CreateModel(
-    const std::string& model_name, const int64_t version, ModelInfo* model_info,
+    const ModelIdentifier& model_id, const int64_t version, ModelInfo* model_info,
     const bool is_config_provided)
 {
-  LOG_VERBOSE(2) << "CreateModel() '" << model_name << "' version " << version;
+  LOG_VERBOSE(2) << "CreateModel() '" << model_id << "' version " << version;
   const auto& model_config = model_info->model_config_;
 
   // Create model
@@ -572,11 +572,11 @@ ModelLifeCycle::CreateModel(
     // UNLOAD_COMPLETE signal (see ~TritonRepoAgentModelList for detail)
     auto agent_model_list = model_info->agent_model_list_;
     model_info->model_.reset(
-        is.release(), ModelDeleter([this, model_name, version, model_info,
+        is.release(), ModelDeleter([this, model_id, version, model_info,
                                     agent_model_list]() mutable {
-          LOG_VERBOSE(2) << "OnDestroy callback() '" << model_name
+          LOG_VERBOSE(2) << "OnDestroy callback() '" << model_id
                          << "' version " << version;
-          LOG_INFO << "successfully unloaded '" << model_name << "' version "
+          LOG_INFO << "successfully unloaded '" << model_id << "' version "
                    << version;
           // Update model state as it is fully unloaded
           {
@@ -594,7 +594,7 @@ ModelLifeCycle::CreateModel(
           }
         }));
   } else {
-    LOG_ERROR << "failed to load '" << model_name << "' version " << version
+    LOG_ERROR << "failed to load '" << model_id << "' version " << version
               << ": " << status.AsString();
     model_info->state_ = ModelReadyState::UNAVAILABLE;
     model_info->state_reason_ = status.AsString();
@@ -603,7 +603,7 @@ ModelLifeCycle::CreateModel(
 
 void
 ModelLifeCycle::OnLoadComplete(
-    const std::string& model_name, const int64_t version, ModelInfo* model_info,
+    const ModelIdentifier& model_id, const int64_t version, ModelInfo* model_info,
     std::function<void(Status)> OnComplete,
     std::shared_ptr<LoadTracker> load_tracker)
 {
@@ -625,7 +625,7 @@ ModelLifeCycle::OnLoadComplete(
       load_tracker->affected_version_cnt_) {
     // hold 'map_mtx_' as there will be change onto the model info map
     std::lock_guard<std::mutex> map_lock(map_mtx_);
-    auto it = map_.find(model_name);
+    auto it = map_.find(model_id);
     // Check if the load is the latest frontground action on the model
     for (const auto& version_info : it->second) {
       if (version_info.second->last_update_ns_ >
@@ -691,7 +691,7 @@ ModelLifeCycle::OnLoadComplete(
         std::lock_guard<std::mutex> curr_info_lk(loaded.second->mtx_);
         loaded.second->state_ = ModelReadyState::READY;
         model_info->state_reason_.clear();
-        LOG_INFO << "successfully loaded '" << model_name << "' version "
+        LOG_INFO << "successfully loaded '" << model_id << "' version "
                  << version;
 
         auto bit = background_models_.find((uintptr_t)loaded.second);

--- a/src/model_lifecycle.h
+++ b/src/model_lifecycle.h
@@ -56,6 +56,11 @@ struct ModelIdentifier {
     return ((namespace_ == rhs.namespace_) && (name_ == rhs.name_));
   }
 
+  bool operator!=(const ModelIdentifier& rhs) const
+  {
+    return (!(namespace_ != rhs.namespace_) || !(name_ != rhs.name_));
+  }
+
   friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)
   {
     os << rhs.namespace_ << "::" << rhs.name_;

--- a/src/model_lifecycle.h
+++ b/src/model_lifecycle.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -178,8 +178,7 @@ class ModelLifeCycle {
   // All versions that are being served will be unloaded only after
   // the load is finished sucessfully.
   Status AsyncLoad(
-      const ModelIdentifier& model_id,
-      const std::string& model_path,
+      const ModelIdentifier& model_id, const std::string& model_path,
       const inference::ModelConfig& model_config, const bool is_config_provided,
       const std::shared_ptr<TritonRepoAgentModelList>& agent_model_list,
       std::function<void(Status)>&& OnComplete);

--- a/src/model_lifecycle.h
+++ b/src/model_lifecycle.h
@@ -31,71 +31,12 @@
 #include <map>
 #include <mutex>
 #include "infer_parameter.h"
+#include "model.h"
 #include "model_config.pb.h"
 #include "repo_agent.h"
 #include "status.h"
 #include "triton/common/model_config.h"
 #include "triton/common/thread_pool.h"
-
-namespace triton { namespace core {
-struct ModelIdentifier {
-  ModelIdentifier(const std::string& model_namespace, const std::string& name)
-   : namespace_(model_namespace), name_(name) {}
-
-  bool operator<(const ModelIdentifier& rhs) const
-  {
-    if (namespace_ == rhs.namespace_) {
-      return (name_ < rhs.name_);
-    } else {
-      return (namespace_ < rhs.namespace_);
-    }
-  }
-
-  bool operator==(const ModelIdentifier& rhs) const
-  {
-    return ((namespace_ == rhs.namespace_) && (name_ == rhs.name_));
-  }
-
-  bool operator!=(const ModelIdentifier& rhs) const
-  {
-    return (!(namespace_ != rhs.namespace_) || !(name_ != rhs.name_));
-  }
-
-  friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)
-  {
-    os << rhs.namespace_ << "::" << rhs.name_;
-    return os;
-  }
-
-  std::string str() const
-  {
-    return (namespace_ + "::" + name_);
-  }
-
-  // [WIP] note for myself, should clean up
-  // namespace is not a reflection of the model repository althought it is
-  // currently implmented to be the same as the repository of the model.
-  std::string namespace_;
-  // name is the name registered to Triton, it is the model directory name
-  // by default and can be overwritten.
-  std::string name_;
-};
-}}  // namespace triton::core
-
-// define hash function for struct to be used as unordered_map key
-namespace std {
-template <>
-class hash<triton::core::ModelIdentifier> {
- public:
-  size_t operator()(const triton::core::ModelIdentifier& model_id) const
-  {
-    // trival hash for multiple entries
-    // https://en.cppreference.com/w/cpp/utility/hash
-    return (hash<std::string>()(model_id.namespace_)
-               ^ (hash<std::string>()(model_id.name_) << 1));
-  }
-};
-}  // namespace std
 
 namespace triton { namespace core {
 struct ModelLifeCycleOptions {
@@ -218,7 +159,6 @@ class TritonRepoAgentModelList {
 };
 
 class InferenceServer;
-class Model;
 
 class ModelLifeCycle {
  public:

--- a/src/model_lifecycle.h
+++ b/src/model_lifecycle.h
@@ -38,8 +38,10 @@
 #include "triton/common/thread_pool.h"
 
 namespace triton { namespace core {
-
 struct ModelIdentifier {
+  ModelIdentifier(const std::string& model_namespace, const std::string& name)
+   : namespace_(model_namespace), name_(name) {}
+
   bool operator<(const ModelIdentifier& rhs) const
   {
     if (namespace_ == rhs.namespace_) {
@@ -49,7 +51,12 @@ struct ModelIdentifier {
     }
   }
 
-  friend ostream& operator<<(ostream& os, const ModelIdentifier& rhs)
+  bool operator==(const ModelIdentifier& rhs) const
+  {
+    return ((namespace_ == rhs.namespace_) && (name_ == rhs.name_));
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const ModelIdentifier& rhs)
   {
     os << rhs.namespace_ << "::" << rhs.name_;
     return os;
@@ -60,10 +67,32 @@ struct ModelIdentifier {
     return (namespace_ + "::" + name_);
   }
 
+  // [WIP] note for myself, should clean up
+  // namespace is not a reflection of the model repository althought it is
+  // currently implmented to be the same as the repository of the model.
   std::string namespace_;
+  // name is the name registered to Triton, it is the model directory name
+  // by default and can be overwritten.
   std::string name_;
 };
+}}  // namespace triton::core
 
+// define hash function for struct to be used as unordered_map key
+namespace std {
+template <>
+class hash<triton::core::ModelIdentifier> {
+ public:
+  size_t operator()(const triton::core::ModelIdentifier& model_id) const
+  {
+    // trival hash for multiple entries
+    // https://en.cppreference.com/w/cpp/utility/hash
+    return (hash<std::string>()(model_id.namespace_)
+               ^ (hash<std::string>()(model_id.name_) << 1));
+  }
+};
+}  // namespace std
+
+namespace triton { namespace core {
 struct ModelLifeCycleOptions {
   explicit ModelLifeCycleOptions(
       const double min_compute_capability,

--- a/src/model_lifecycle.h
+++ b/src/model_lifecycle.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <functional>
+#include <iostream>
 #include <map>
 #include <mutex>
 #include "infer_parameter.h"
@@ -37,6 +38,31 @@
 #include "triton/common/thread_pool.h"
 
 namespace triton { namespace core {
+
+struct ModelIdentifier {
+  bool operator<(const ModelIdentifier& rhs) const
+  {
+    if (namespace_ == rhs.namespace_) {
+      return (name_ < rhs.name_);
+    } else {
+      return (namespace_ < rhs.namespace_);
+    }
+  }
+
+  friend ostream& operator<<(ostream& os, const ModelIdentifier& rhs)
+  {
+    os << rhs.namespace_ << "::" << rhs.name_;
+    return os;
+  }
+
+  std::string str() const
+  {
+    return (namespace_ + "::" + name_);
+  }
+
+  std::string namespace_;
+  std::string name_;
+};
 
 struct ModelLifeCycleOptions {
   explicit ModelLifeCycleOptions(
@@ -89,7 +115,7 @@ const std::string& ModelReadyStateString(ModelReadyState state);
 
 using VersionStateMap =
     std::map<int64_t, std::pair<ModelReadyState, std::string>>;
-using ModelStateMap = std::map<std::string, VersionStateMap>;
+using ModelStateMap = std::map<ModelIdentifier, VersionStateMap>;
 
 // Helper class to manage the lifecycle of a list of associated agent models
 class TritonRepoAgentModelList {
@@ -178,19 +204,20 @@ class ModelLifeCycle {
   // All versions that are being served will be unloaded only after
   // the load is finished sucessfully.
   Status AsyncLoad(
-      const std::string& model_name, const std::string& model_path,
+      const ModelIdentifier& model_id,
+      const std::string& model_path,
       const inference::ModelConfig& model_config, const bool is_config_provided,
       const std::shared_ptr<TritonRepoAgentModelList>& agent_model_list,
       std::function<void(Status)>&& OnComplete);
 
   // Unload model asynchronously.
-  Status AsyncUnload(const std::string& model_name);
+  Status AsyncUnload(const ModelIdentifier& model_id);
 
   // Get specified version of the model. Latest ready version will
   // be retrieved if 'version' is -1. Return error if the version specified is
   // not found or it is not ready.
   Status GetModel(
-      const std::string& model_name, const int64_t version,
+      const ModelIdentifier& model_id, const int64_t version,
       std::shared_ptr<Model>* model);
 
   // Get the ModelStateMap representation of the live models. A model is
@@ -203,11 +230,11 @@ class ModelLifeCycle {
   const ModelStateMap ModelStates();
 
   // Get the VersionStateMap representation of the specified model.
-  const VersionStateMap VersionStates(const std::string& model_name);
+  const VersionStateMap VersionStates(const ModelIdentifier& model_id);
 
   // Get the state of a specific model version.
   Status ModelState(
-      const std::string& model_name, const int64_t model_version,
+      const ModelIdentifier& model_id, const int64_t model_version,
       ModelReadyState* state);
 
   // Instruct the model to stop accepting new inference requests.
@@ -215,7 +242,7 @@ class ModelLifeCycle {
 
   // Return the number of in-flight inference if any, model versions
   // that don't have in-flight inferences will not be included.
-  const std::set<std::tuple<std::string, int64_t, size_t>> InflightStatus();
+  const std::set<std::tuple<ModelIdentifier, int64_t, size_t>> InflightStatus();
 
  private:
   struct ModelInfo {
@@ -291,14 +318,14 @@ class ModelLifeCycle {
   }
 
   void CreateModel(
-      const std::string& model_name, const int64_t version,
+      const ModelIdentifier& model_id, const int64_t version,
       ModelInfo* model_info, const bool is_config_provided);
   // Callback function template for model load.
   // 'OnComplete' needs to be passed by value for now as there can be
   // multiple versions to be loaded and each holds a copy of
   // the 'OnComplete' callback.
   void OnLoadComplete(
-      const std::string& model_name, const int64_t version,
+      const ModelIdentifier& model_id, const int64_t version,
       ModelInfo* model_info, std::function<void(Status)> OnComplete,
       std::shared_ptr<LoadTracker> load_tracker);
 
@@ -307,7 +334,7 @@ class ModelLifeCycle {
   std::mutex map_mtx_;
 
   using VersionMap = std::map<int64_t, std::unique_ptr<ModelInfo>>;
-  using ModelMap = std::map<std::string, VersionMap>;
+  using ModelMap = std::map<ModelIdentifier, VersionMap>;
   ModelMap map_;
   // Models that are being loaded / unloaded in background
   std::map<uintptr_t, std::unique_ptr<ModelInfo>> background_models_;

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -99,7 +99,10 @@ class ModelRepositoryManager {
     inference::ModelConfig model_config_;
 
     // Graph info
+    // Whether the node has been checked for performing lifecycle change
+    // (load / unload)
     bool checked_;
+    // Whether the node has connected: all required upstreams are found
     bool connected_;
     // store only the model names for missing upstreams, and remove from it
     // only if the upstream is exactly matched. This variable works with

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -53,14 +53,15 @@ class ModelRepositoryManager {
   // Index information for a model.
   struct ModelIndex {
     ModelIndex(const ModelIdentifier& n)
-        : name_only_(true), namespace_(n.namespace_), name_(n.name_), version_(-1),
-          state_(ModelReadyState::UNKNOWN)
+        : name_only_(true), namespace_(n.namespace_), name_(n.name_),
+          version_(-1), state_(ModelReadyState::UNKNOWN)
     {
     }
     ModelIndex(
         const ModelIdentifier& n, const int64_t v, const ModelReadyState s,
         const std::string& r)
-        : name_only_(false), namespace_(n.namespace_), name_(n.name_), version_(v), state_(s), reason_(r)
+        : name_only_(false), namespace_(n.namespace_), name_(n.name_),
+          version_(v), state_(s), reason_(r)
     {
     }
     const bool name_only_;
@@ -80,8 +81,14 @@ class ModelRepositoryManager {
     {
     }
 
-    void DisconnectUpstream(DependencyNode* upstream) { upstreams_.erase(upstream); }
-    void DisconnectDownstream(DependencyNode* downstream) { downstreams_.erase(downstream); }
+    void DisconnectUpstream(DependencyNode* upstream)
+    {
+      upstreams_.erase(upstream);
+    }
+    void DisconnectDownstream(DependencyNode* downstream)
+    {
+      downstreams_.erase(downstream);
+    }
 
     // Overall status
     Status status_;
@@ -99,7 +106,8 @@ class ModelRepositoryManager {
     // 'missing_nodes_' in DependencyGraph to provide bi-directional lookup for
     // dependency resolution (exact / fuzzy match).
     // i.e. the node will look for upstream node that has matching identifier,
-    // but upstream node with different namspace can still be used if not found.
+    // but upstream node with different namespace can still be used if not
+    // found.
     std::set<std::string> missing_upstreams_;
     std::unordered_map<DependencyNode*, std::set<int64_t>> upstreams_;
     std::set<DependencyNode*> downstreams_;
@@ -117,25 +125,43 @@ class ModelRepositoryManager {
     // There is coupling between the dependency graph and global map: global map
     // will be used to resolve dependency (node connectivity), and global map
     // will be updated to reflect node changes.
-    DependencyGraph(std::unordered_map<std::string, std::set<ModelIdentifier>>& global_map)
-     : global_map_ref_(global_map) {}
+    DependencyGraph(
+        std::unordered_map<std::string, std::set<ModelIdentifier>>& global_map)
+        : global_map_ref_(global_map)
+    {
+    }
 
     std::unordered_map<ModelIdentifier, std::unique_ptr<DependencyNode>>*
-    MutableNodes() {return &nodes_; }
+    MutableNodes()
+    {
+      return &nodes_;
+    }
 
     // Remove the given set of nodes, return two sets of nodes: The first set
     // contains existing nodes to be re-evaluated, because they depend on
     // the nodes removed; the second set contains all the nodes removed in this
     // operation.
-    std::pair<std::set<ModelIdentifier>, std::set<ModelIdentifier>> RemoveNodes(const std::set<ModelIdentifier>& nodes, const bool cascading_removal);
+    // 'cascading_removal' control whether other nodes will be removed. If true,
+    // it will also remove the nodes that were added to dependency graph only
+    // because they were needed by the node in 'nodes'. In other words, they
+    // will no longer be needed once the 'nodes' are removed and can be removed
+    // from the dependency graph as well. Such an operation will be recursively
+    // applied and thus called "cascading".
+    std::pair<std::set<ModelIdentifier>, std::set<ModelIdentifier>> RemoveNodes(
+        const std::set<ModelIdentifier>& nodes, const bool cascading_removal);
 
-    // Update the given set of nodes to reflect the latest model information polled,
-    // returns existing nodes to be re-evaluated, including the modified node.
-    std::set<ModelIdentifier> UpdateNodes(const std::set<ModelIdentifier>& nodes, const ModelRepositoryManager* model_manager);
+    // Update the given set of nodes to reflect the latest model information
+    // polled, returns existing nodes to be re-evaluated, including the modified
+    // node.
+    std::set<ModelIdentifier> UpdateNodes(
+        const std::set<ModelIdentifier>& nodes,
+        const ModelRepositoryManager* model_manager);
 
     // Add the given set of nodes to the dependency graph,
     // returns existing nodes to be re-evaluated, including the added node.
-    std::set<ModelIdentifier> AddNodes(const std::set<ModelIdentifier>& nodes, const ModelRepositoryManager* model_manager);
+    std::set<ModelIdentifier> AddNodes(
+        const std::set<ModelIdentifier>& nodes,
+        const ModelRepositoryManager* model_manager);
 
     // Helper function on the 'node_id' to construct the edges between nodes
     // in the dependency graph. The node status will be updated if the node
@@ -143,10 +169,11 @@ class ModelRepositoryManager {
     // are made to the dependency graph.
     void ConnectDependencyGraph(const ModelIdentifier& node_id);
 
-    // Look up node in dependency graph with matching model identifier. If not found and fuzzy match
-    // is allowed, a node in different namespace will be returned if it is the only node with the same
-    // name
-    DependencyNode* FindNode(const ModelIdentifier& model_id, const bool allow_fuzzy_matching);
+    // Look up node in dependency graph with matching model identifier. If not
+    // found and fuzzy match is allowed, a node in different namespace will be
+    // returned if it is the only node with the same name
+    DependencyNode* FindNode(
+        const ModelIdentifier& model_id, const bool allow_fuzzy_matching);
 
     // Check if there is circular dependency on the given node, the node
     // status will be updated if the node has circular dependency.
@@ -164,10 +191,12 @@ class ModelRepositoryManager {
     // "upstreams" of the node (i.e. composing models of the ensemble), the
     // second set is the "downstreams" of the node (i.e. the model is required
     // by other ensembles)
-    std::pair<std::set<ModelIdentifier>, std::set<ModelIdentifier>> RemoveNode(const ModelIdentifier& model_id);
+    std::pair<std::set<ModelIdentifier>, std::set<ModelIdentifier>> RemoveNode(
+        const ModelIdentifier& model_id);
 
     // Recursive version for internal use.
-    Status CircularDependencyCheck(DependencyNode* current_node, const DependencyNode* start_node);
+    Status CircularDependencyCheck(
+        DependencyNode* current_node, const DependencyNode* start_node);
 
     std::unordered_map<std::string, std::set<ModelIdentifier>>& global_map_ref_;
     std::unordered_map<ModelIdentifier, std::unique_ptr<DependencyNode>> nodes_;
@@ -275,7 +304,8 @@ class ModelRepositoryManager {
       const ModelIdentifier& model_id, const int64_t model_version,
       std::shared_ptr<Model>* model);
 
-  Status FindModelIdentifier(const std::string& model_name, ModelIdentifier* model_id);
+  Status FindModelIdentifier(
+      const std::string& model_name, ModelIdentifier* model_id);
 
   /// Get the index of all models in all repositories.
   /// \param ready_only If true return only index of models that are ready.
@@ -310,8 +340,7 @@ class ModelRepositoryManager {
   ModelRepositoryManager(
       const std::set<std::string>& repository_paths, const bool autofill,
       const bool polling_enabled, const bool model_control_enabled,
-      const double min_compute_capability,
-      const bool enable_model_namespacing,
+      const double min_compute_capability, const bool enable_model_namespacing,
       std::unique_ptr<ModelLifeCycle> life_cycle);
 
   /// The internal function that are called in Create() and PollAndUpdate().
@@ -346,8 +375,9 @@ class ModelRepositoryManager {
       const std::unordered_map<
           std::string, std::vector<const InferenceParameter*>>& models,
       std::set<ModelIdentifier>* added, std::set<ModelIdentifier>* deleted,
-      std::set<ModelIdentifier>* modified, std::set<ModelIdentifier>* unmodified,
-      ModelInfoMap* updated_infos, bool* all_models_polled);
+      std::set<ModelIdentifier>* modified,
+      std::set<ModelIdentifier>* unmodified, ModelInfoMap* updated_infos,
+      bool* all_models_polled);
 
   /// Helper function for Poll() to initialize ModelInfo for the model.
   /// \param model_id The identifier of the model.
@@ -377,7 +407,8 @@ class ModelRepositoryManager {
   /// from the repository.
   /// \return The error status.
   Status UpdateDependencyGraph(
-      const std::set<ModelIdentifier>& added, const std::set<ModelIdentifier>& deleted,
+      const std::set<ModelIdentifier>& added,
+      const std::set<ModelIdentifier>& deleted,
       const std::set<ModelIdentifier>& modified,
       std::set<ModelIdentifier>* deleted_dependents = nullptr);
 
@@ -385,7 +416,8 @@ class ModelRepositoryManager {
   /// \param name The model name.
   /// \param model_info Returns the model information.
   /// \return OK if found, NOT_FOUND otherwise.
-  Status GetModelInfo(const ModelIdentifier& model_id, ModelInfo** model_info) const;
+  Status GetModelInfo(
+      const ModelIdentifier& model_id, ModelInfo** model_info) const;
 
   /// Get the models to be loaded / unloaded based on the model loaded in
   /// previous iteration.
@@ -419,8 +451,10 @@ class ModelRepositoryManager {
   // Dependency graph
 
   // WAR to avoid change in behavior (mainly error reporting) if model namespace
-  // is not enable.
-  std::function<Status(const std::string& model_name, ModelIdentifier* model_id)> find_identifier_fn_;
+  // is not enabled.
+  std::function<Status(
+      const std::string& model_name, ModelIdentifier* model_id)>
+      find_identifier_fn_;
   // A map from model name to model identifiers that share the same model name
   std::unordered_map<std::string, std::set<ModelIdentifier>> global_map_;
   DependencyGraph dependency_graph_;
@@ -428,12 +462,12 @@ class ModelRepositoryManager {
   // Repository specific..
 
   const bool enable_model_namespacing_;
-  
+
   // [FIXME] Better document below: 'infos_' is the in memory representation of
   // repo polling results. It is a intermediate layer between the set of models
   // in storage and the models being served, and it doesn't directly reflect the
   // state of the two above.
-  // 
+  //
   // There are three stages in terms of changing model:
   //   - poll model
   //   - resolve dependency
@@ -453,8 +487,8 @@ class ModelRepositoryManager {
   std::set<std::string> repository_paths_;
   // Mappings from (overridden) model names to a pair of their repository and
   // absolute path
-  // [FIXME] key should be updated to contain namespace as well, need to work with
-  // enable namespace. Need to revisit with repository side of things
+  // [DLIS-4596] key should be updated to contain namespace to work with enabled
+  // namespace. Also need to revisit with repository side of things.
   std::unordered_map<std::string, std::pair<std::string, std::string>>
       model_mappings_;
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -428,6 +428,27 @@ class ModelRepositoryManager {
   // Repository specific..
 
   const bool enable_model_namespacing_;
+  
+  // [FIXME] Better document below: 'infos_' is the in memory representation of
+  // repo polling results. It is a intermediate layer between the set of models
+  // in storage and the models being served, and it doesn't directly reflect the
+  // state of the two above.
+  // 
+  // There are three stages in terms of changing model:
+  //   - poll model
+  //   - resolve dependency
+  //   - load model
+  //
+  // 'infos_' is a long living object across model changes to serve as
+  // differentiator between polls (i.e. is the model newly added? modified?),
+  // so it is a subset of storage models at the time of polling. Note that
+  // it can be marked "dirty" to handle "fallback / revert" in model lifecycle:
+  // if the model is currently being served and re-load action is required, the
+  // lifecycle will keep the "older" model if the newer storage model is
+  // malformed => re-load failure. Marking info "dirty" in this case to ensure
+  // the model to be polled again even though the storage model hasn't been
+  // changed, for operation idempotence.
+  // (https://github.com/triton-inference-server/server/issues/3802)
   ModelInfoMap infos_;
   std::set<std::string> repository_paths_;
   // Mappings from (overridden) model names to a pair of their repository and

--- a/src/server.cc
+++ b/src/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/server.cc
+++ b/src/server.cc
@@ -229,7 +229,8 @@ InferenceServer::Init()
   status = ModelRepositoryManager::Create(
       this, version_, model_repository_paths_, startup_models_,
       strict_model_config_, polling_enabled, model_control_enabled,
-      life_cycle_options, &model_repository_manager_);
+      life_cycle_options, false /* enable_model_namespacing */,
+      &model_repository_manager_);
   if (!status.IsOk()) {
     if (model_repository_manager_ == nullptr) {
       ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
@@ -469,7 +470,7 @@ InferenceServer::ModelReadyVersions(
     for (const auto& vs_pair : mv_pair.second) {
       versions.emplace_back(vs_pair.first);
     }
-    ready_model_versions->emplace(mv_pair.first, std::move(versions));
+    ready_model_versions->emplace(mv_pair.first.str(), std::move(versions));
   }
 
   return Status::Success;
@@ -601,12 +602,12 @@ InferenceServer::PrintBackendAndModelSummary()
 
   for (const auto& model_state : model_states) {
     auto model_version_map = model_state.second;
-    std::string model_name = model_state.first;
+    ModelIdentifier model_id = model_state.first;
 
     // If model_version_map size is zero, no version is found for this model
     if (model_version_map.size() == 0) {
       std::vector<std::string> model_record;
-      model_record.emplace_back(model_name);
+      model_record.emplace_back(model_id.str());
       model_record.emplace_back("-");
       model_record.emplace_back("Not loaded: No model version was found");
       models_table.InsertRow(model_record);
@@ -622,7 +623,7 @@ InferenceServer::PrintBackendAndModelSummary()
           model_status += ": " + model_status_pair.second;
         }
 
-        model_record.emplace_back(model_name);
+        model_record.emplace_back(model_id.str());
         model_record.emplace_back(model_version);
         model_record.emplace_back(model_status);
         models_table.InsertRow(model_record);

--- a/src/server.cc
+++ b/src/server.cc
@@ -106,7 +106,6 @@ InferenceServer::InferenceServer()
   buffer_manager_thread_count_ = 0;
   model_load_thread_count_ =
       std::max(2u, 2 * std::thread::hardware_concurrency());
-  // [WIP] change to false and expose option
   enable_model_namespacing_ = false;
 
 #ifdef TRITON_ENABLE_GPU

--- a/src/server.cc
+++ b/src/server.cc
@@ -106,6 +106,8 @@ InferenceServer::InferenceServer()
   buffer_manager_thread_count_ = 0;
   model_load_thread_count_ =
       std::max(2u, 2 * std::thread::hardware_concurrency());
+  // [WIP] change to false and expose option
+  enable_model_namespacing_ = false;
 
 #ifdef TRITON_ENABLE_GPU
   min_supported_compute_capability_ = TRITON_MIN_COMPUTE_CAPABILITY;
@@ -229,7 +231,7 @@ InferenceServer::Init()
   status = ModelRepositoryManager::Create(
       this, version_, model_repository_paths_, startup_models_,
       strict_model_config_, polling_enabled, model_control_enabled,
-      life_cycle_options, false /* enable_model_namespacing */,
+      life_cycle_options, enable_model_namespacing_,
       &model_repository_manager_);
   if (!status.IsOk()) {
     if (model_repository_manager_ == nullptr) {

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -238,7 +238,10 @@ class InferenceServer {
 
   void SetModelLoadThreadCount(unsigned int c) { model_load_thread_count_ = c; }
 
-  void SetModelNamespacingEnabled(const bool e) { enable_model_namespacing_ = e; }
+  void SetModelNamespacingEnabled(const bool e)
+  {
+    enable_model_namespacing_ = e;
+  }
 
   // Set a backend command-line configuration
   void SetBackendCmdlineConfig(
@@ -281,8 +284,7 @@ class InferenceServer {
         (ready_state_ != ServerReadyState::SERVER_EXITING)) {
       return Status(Status::Code::UNAVAILABLE, "Server not ready");
     }
-    return model_repository_manager_->GetModel(
-        model_id, model_version, model);
+    return model_repository_manager_->GetModel(model_id, model_version, model);
   }
 
   // Get the Backend Manager

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -272,6 +272,9 @@ class TritonServerOptions {
   unsigned int ModelLoadThreadCount() const { return model_load_thread_count_; }
   void SetModelLoadThreadCount(unsigned int c) { model_load_thread_count_ = c; }
 
+  bool ModelNamespacingEnabled() { return enable_model_namespacing_; }
+  void SetModelNamespacingEnabled(const bool e) { enable_model_namespacing_ = e; }
+
   bool Metrics() const { return metrics_; }
   void SetMetrics(bool b) { metrics_ = b; }
 
@@ -330,6 +333,7 @@ class TritonServerOptions {
   uint64_t response_cache_byte_size_;
   unsigned int buffer_manager_thread_count_;
   unsigned int model_load_thread_count_;
+  bool enable_model_namespacing_;
   std::map<int, uint64_t> cuda_memory_pool_size_;
   double min_compute_capability_;
   std::string backend_dir_;
@@ -348,6 +352,7 @@ TritonServerOptions::TritonServerOptions()
       response_cache_byte_size_(0), buffer_manager_thread_count_(0),
       model_load_thread_count_(
           std::max(2u, 2 * std::thread::hardware_concurrency())),
+      enable_model_namespacing_(false),
 #ifdef TRITON_ENABLE_GPU
       min_compute_capability_(TRITON_MIN_COMPUTE_CAPABILITY),
 #else
@@ -1221,6 +1226,16 @@ TRITONSERVER_ServerOptionsSetModelLoadThreadCount(
   TritonServerOptions* loptions =
       reinterpret_cast<TritonServerOptions*>(options);
   loptions->SetModelLoadThreadCount(thread_count);
+  return nullptr;  // Success
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetModelNamespacing(
+    TRITONSERVER_ServerOptions* options, bool enable_namespace)
+{
+  TritonServerOptions* loptions =
+      reinterpret_cast<TritonServerOptions*>(options);
+  loptions->SetModelNamespacingEnabled(enable_namespace);
   return nullptr;  // Success
 }
 
@@ -2116,6 +2131,7 @@ TRITONSERVER_ServerNew(
   lserver->SetRepoAgentDir(loptions->RepoAgentDir());
   lserver->SetBufferManagerThreadCount(loptions->BufferManagerThreadCount());
   lserver->SetModelLoadThreadCount(loptions->ModelLoadThreadCount());
+  lserver->SetModelNamespacingEnabled(loptions->ModelNamespacingEnabled());
 
   // SetBackendCmdlineConfig must be called after all AddBackendConfig calls
   // have completed.

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -273,7 +273,10 @@ class TritonServerOptions {
   void SetModelLoadThreadCount(unsigned int c) { model_load_thread_count_ = c; }
 
   bool ModelNamespacingEnabled() { return enable_model_namespacing_; }
-  void SetModelNamespacingEnabled(const bool e) { enable_model_namespacing_ = e; }
+  void SetModelNamespacingEnabled(const bool e)
+  {
+    enable_model_namespacing_ = e;
+  }
 
   bool Metrics() const { return metrics_; }
   void SetMetrics(bool b) { metrics_ = b; }

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -386,6 +386,10 @@ TRITONSERVER_ServerOptionsSetModelLoadThreadCount()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetModelNamespacing()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetLogFile()
 {
 }


### PR DESCRIPTION
This PR is to address https://github.com/triton-inference-server/server/issues/5150 where there are multiple ensemble repositories that happens to have composing models with the same name (see diagram below). Before the change, it will fail the model loading as the duplicated naming can't be resolved. So name-spacing is introduced to better differentiate the composing model: models with the same name will have different model identifier to be referred internal to the ensemble.

There are a few rules and assumptions when model name-spacing is enabled:
1. Different model repository will be assigned different namespaces.
2. Ensemble will use composing models that are in the same namespace, with 1. it implies locality, as we assume the models in the same repository should be coupled.
3. If composing model is not found in namespace, the ensemble will only use composing model in other namespace if it is not ambiguous by model name (i.e. there is only one such model across all registered model repositories).

![Screenshot from 2023-01-04 14-28-57](https://user-images.githubusercontent.com/41310872/218880566-281a3e6d-6c9f-44e4-842e-05a4f3155ae2.png)