### PR TITLE
Change priority from uint32 to uint64

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1066,7 +1066,7 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
 /// \param priority Returns the priority level.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_InferenceRequestPriority(
-    TRITONSERVER_InferenceRequest* inference_request, uint32_t* priority);
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority);
 
 /// Set the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
@@ -1077,7 +1077,7 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error* TRITONSERVER_InferenceRequestPriority(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetPriority(
-    TRITONSERVER_InferenceRequest* inference_request, uint32_t priority);
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t priority);
 
 /// Get the timeout for a request, in microseconds. The default is 0
 /// which indicates that the request has no timeout.

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -63,7 +63,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds,
     const inference::ModelQueuePolicy& default_queue_policy,
-    const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
+    const uint64_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
     : model_(model), model_instance_(model_instance),
       model_name_(model->Name()),
       dynamic_batching_enabled_(dynamic_batching_enabled),

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -98,7 +98,7 @@ class DynamicBatchScheduler : public Scheduler {
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds,
       const inference::ModelQueuePolicy& default_queue_policy,
-      const uint32_t priority_levels,
+      const uint64_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
 
   void BatcherThread(const int nice);

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -334,7 +334,7 @@ class EnsembleContext {
   uint32_t flags_;
   std::string request_id_;
   InferenceRequest::SequenceId correlation_id_;
-  uint32_t priority_;
+  uint64_t priority_;
   uint64_t timeout_;
 
   // Objects related to the ensemble infer request

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -121,7 +121,7 @@ InferenceRequest::ActualModelVersion() const
 }
 
 void
-InferenceRequest::SetPriority(uint32_t p)
+InferenceRequest::SetPriority(uint64_t p)
 {
   if ((p == 0) || (p > model_raw_->MaxPriorityLevel())) {
     priority_ = model_raw_->DefaultPriorityLevel();

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -305,8 +305,8 @@ class InferenceRequest {
   // request is normalized.
   uint32_t BatchSize() const { return batch_size_; }
 
-  uint32_t Priority() const { return priority_; }
-  void SetPriority(uint32_t p);
+  uint64_t Priority() const { return priority_; }
+  void SetPriority(uint64_t p);
 
   uint64_t TimeoutMicroseconds() const { return timeout_us_; }
   void SetTimeoutMicroseconds(uint64_t t) { timeout_us_ = t; }
@@ -681,7 +681,7 @@ class InferenceRequest {
   uint32_t flags_;
   SequenceId correlation_id_;
   uint32_t batch_size_;
-  uint32_t priority_;
+  uint64_t priority_;
   uint64_t timeout_us_;
   std::string cache_key_ = "";
   // Helper to determine if request was successfully hashed

--- a/src/model.cc
+++ b/src/model.cc
@@ -125,7 +125,7 @@ Model::Init(const bool is_config_provided)
   } else if (config_.has_ensemble_scheduling()) {
     // For ensemble, allow any priority level to pass through
     default_priority_level_ = 0;
-    max_priority_level_ = UINT32_MAX;
+    max_priority_level_ = UINT64_MAX;
   } else {
     default_priority_level_ = 0;
     max_priority_level_ = 0;

--- a/src/model.h
+++ b/src/model.h
@@ -177,9 +177,9 @@ class Model {
   // Stop processing future requests unless they are considered as in-flight.
   void Stop() { scheduler_->Stop(); }
 
-  uint32_t DefaultPriorityLevel() const { return default_priority_level_; }
+  uint64_t DefaultPriorityLevel() const { return default_priority_level_; }
 
-  uint32_t MaxPriorityLevel() const { return max_priority_level_; }
+  uint64_t MaxPriorityLevel() const { return max_priority_level_; }
 
  protected:
   // Set the configuration of the model being served.
@@ -220,10 +220,10 @@ class Model {
   std::string model_dir_;
 
   // The default priority level for the model.
-  uint32_t default_priority_level_;
+  uint64_t default_priority_level_;
 
   // The largest priority value for the model.
-  uint32_t max_priority_level_;
+  uint64_t max_priority_level_;
 
   // Whether or not model config has been set.
   bool set_model_config_;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1850,8 +1850,11 @@ ValidateModelConfigInt64()
       "ModelConfig::output::reshape::shape",
       "ModelConfig::version_policy::specific::versions",
       "ModelConfig::dynamic_batching::max_queue_delay_microseconds",
+      "ModelConfig::dynamic_batching::priority_levels",
+      "ModelConfig::dynamic_batching::default_priority_levels",
       "ModelConfig::dynamic_batching::default_queue_policy::default_timeout_"
       "microseconds",
+      "ModelConfig::dynamic_batching::priority_queue_policy::key",
       "ModelConfig::dynamic_batching::priority_queue_policy::value::default_"
       "timeout_microseconds",
       "ModelConfig::sequence_batching::direct::max_queue_delay_microseconds",
@@ -2035,12 +2038,17 @@ ModelConfigToJson(
   }
 
   // Fix dynamic_batching::max_queue_delay_microseconds,
+  // dynamic_batching::priority_levels,
+  // dynamic_batching::default_priority_level,
   // dynamic_batching::default_queue_policy::default_timeout_microseconds,
+  // dynamic_batching::priority_queue_policy::key (TODO!!!)
   // dynamic_batching::priority_queue_policy::value::default_timeout_microseconds
   {
     triton::common::TritonJson::Value db;
     if (config_json.Find("dynamic_batching", &db)) {
       RETURN_IF_ERROR(FixInt(config_json, db, "max_queue_delay_microseconds"));
+      RETURN_IF_ERROR(FixInt(config_json, db, "priority_levels"));
+      RETURN_IF_ERROR(FixInt(config_json, db, "default_priority_level"));
       triton::common::TritonJson::Value dqp;
       if (db.Find("default_queue_policy", &dqp)) {
         RETURN_IF_ERROR(

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -2041,7 +2041,7 @@ ModelConfigToJson(
   // dynamic_batching::priority_levels,
   // dynamic_batching::default_priority_level,
   // dynamic_batching::default_queue_policy::default_timeout_microseconds,
-  // dynamic_batching::priority_queue_policy::key (TODO!!!)
+  // dynamic_batching::priority_queue_policy::key (not necessary)
   // dynamic_batching::priority_queue_policy::value::default_timeout_microseconds
   {
     triton::common::TritonJson::Value db;

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -266,8 +266,7 @@ PriorityQueue::PriorityQueue()
 PriorityQueue::PriorityQueue(
     const inference::ModelQueuePolicy& default_queue_policy,
     uint64_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
-    : size_(0), last_priority_level_(priority_levels),
-      default_policy_(default_queue_policy)
+    : size_(0), default_policy_(default_queue_policy)
 {
   // Permanently instantiate PolicyQueue with keep_instantiate=true
   // to prevent them from being erased & created during scheduling

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -265,7 +265,7 @@ PriorityQueue::PriorityQueue()
 
 PriorityQueue::PriorityQueue(
     const inference::ModelQueuePolicy& default_queue_policy,
-    uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
+    uint64_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
     : size_(0), last_priority_level_(priority_levels),
       default_policy_(default_queue_policy)
 {
@@ -279,7 +279,7 @@ PriorityQueue::PriorityQueue(
     // permanently add default PolicyQueue because those will be dynamically
     // created and erased to keep memory footprint low
     for (const auto& qp : queue_policy_map) {
-      queues_.emplace((uint32_t)qp.first, PolicyQueue(qp.second, true));
+      queues_.emplace((uint64_t)qp.first, PolicyQueue(qp.second, true));
     }
   }
   front_priority_level_ = queues_.empty() ? 0 : queues_.begin()->first;
@@ -288,7 +288,7 @@ PriorityQueue::PriorityQueue(
 
 Status
 PriorityQueue::Enqueue(
-    uint32_t priority_level, std::unique_ptr<InferenceRequest>& request)
+    uint64_t priority_level, std::unique_ptr<InferenceRequest>& request)
 {
   // Get corresponding PolicyQueue if it exists, otherwise insert it
   // via emplace with the default policy

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -254,7 +254,6 @@ class PriorityQueue {
   // Keep track of the priority level that the first request in the queue
   // is at to avoid traversing 'queues_'
   uint64_t front_priority_level_;
-  uint64_t last_priority_level_;
   inference::ModelQueuePolicy default_policy_;
 
   Cursor pending_cursor_;

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -57,7 +57,7 @@ struct RequiredEqualInputs {
 // PriorityQueue
 //
 using ModelQueuePolicyMap = ::google::protobuf::Map<
-    ::google::protobuf::uint32, inference::ModelQueuePolicy>;
+    ::google::protobuf::uint64, inference::ModelQueuePolicy>;
 
 class PriorityQueue {
  public:
@@ -70,7 +70,7 @@ class PriorityQueue {
   // 'queue_policy_map', otherwise, the 'default_queue_policy' will be used.
   PriorityQueue(
       const inference::ModelQueuePolicy& default_queue_policy,
-      uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map);
+      uint64_t priority_levels, const ModelQueuePolicyMap queue_policy_map);
 
   // Enqueue a request with priority set to 'priority_level'. If
   // Status::Success is returned then the queue has taken ownership of
@@ -78,7 +78,7 @@ class PriorityQueue {
   // non-success is returned then the caller still retains ownership
   // of 'request'.
   Status Enqueue(
-      uint32_t priority_level, std::unique_ptr<InferenceRequest>& request);
+      uint64_t priority_level, std::unique_ptr<InferenceRequest>& request);
 
   // Dequeue the request at the front of the queue.
   Status Dequeue(std::unique_ptr<InferenceRequest>* request);
@@ -228,7 +228,7 @@ class PriorityQueue {
     std::deque<std::unique_ptr<InferenceRequest>> delayed_queue_;
     std::deque<std::unique_ptr<InferenceRequest>> rejected_queue_;
   };
-  using PriorityQueues = std::map<uint32_t, PolicyQueue>;
+  using PriorityQueues = std::map<uint64_t, PolicyQueue>;
 
   // Cursor for tracking pending batch, the cursor points to the item after
   // the pending batch.
@@ -253,8 +253,8 @@ class PriorityQueue {
 
   // Keep track of the priority level that the first request in the queue
   // is at to avoid traversing 'queues_'
-  uint32_t front_priority_level_;
-  uint32_t last_priority_level_;
+  uint64_t front_priority_level_;
+  uint64_t last_priority_level_;
   inference::ModelQueuePolicy default_policy_;
 
   Cursor pending_cursor_;

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1670,7 +1670,7 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestPriority(
-    TRITONSERVER_InferenceRequest* inference_request, uint32_t* priority)
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority)
 {
   tc::InferenceRequest* lrequest =
       reinterpret_cast<tc::InferenceRequest*>(inference_request);
@@ -1680,7 +1680,7 @@ TRITONSERVER_InferenceRequestPriority(
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetPriority(
-    TRITONSERVER_InferenceRequest* inference_request, uint32_t priority)
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t priority)
 {
   tc::InferenceRequest* lrequest =
       reinterpret_cast<tc::InferenceRequest*>(inference_request);


### PR DESCRIPTION
Request priority is defined in [uint64 on client-side](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/library/common.h#:~:text=for%20the%20model.-,uint64_t,-priority_%3B) but [uint32 on server-side](https://github.com/triton-inference-server/core/blob/main/src/infer_request.h#:~:text=uint32_t%20batch_size_%3B-,uint32_t,-priority_%3B). This pull request removes this discrepancy and allows uint64 request priority on server-side. An application of this feature is to enable the use of unix timestamp as request priority.

This is linked to PR https://github.com/triton-inference-server/common/pull/82