### PR TITLE
Prevent infinity loop if cloud client falsely report file as directory

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -721,6 +721,13 @@ GCSFileSystem::GetDirectoryContents(
     // Let set take care of subdirectory contents
     std::string item = name.substr(item_start, item_end - item_start);
     contents->insert(item);
+
+    // Fail-safe check to ensure the item name is not empty
+    if (item.empty()) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Cannot handle item with empty name at " + path);
+    }
   }
   return Status::Success;
 }
@@ -1135,6 +1142,12 @@ ASFileSystem::GetDirectoryContents(
   auto func = [&](const as::list_blobs_segmented_item& item,
                   const std::string& dir) {
     contents->insert(dir);
+    // Fail-safe check to ensure the item name is not empty
+    if (dir.empty()) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Cannot handle item with empty name at " + path);
+    }
     return Status::Success;
   };
   std::string container, dir_path;
@@ -1777,6 +1790,13 @@ S3FileSystem::GetDirectoryContents(
       // Let set take care of subdirectory contents
       std::string item = name.substr(item_start, item_end - item_start);
       contents->insert(item);
+
+      // Fail-safe check to ensure the item name is not empty
+      if (item.empty()) {
+        return Status(
+            Status::Code::INTERNAL,
+            "Cannot handle item with empty name at " + true_path);
+      }
     }
   } else {
     return Status(

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -256,11 +256,6 @@ GetModifiedTime(const std::string& path)
   }
 
   for (const auto& child : contents) {
-    if (child.empty()) {
-      LOG_ERROR << "Failed to determine modification time for '" << path
-                << "': Directory has content with empty name";
-      return 0;
-    }
     const auto full_path = JoinPath({path, child});
     mtime = std::max(mtime, GetModifiedTime(full_path));
   }

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -256,6 +256,11 @@ GetModifiedTime(const std::string& path)
   }
 
   for (const auto& child : contents) {
+    if (child.empty()) {
+      LOG_ERROR << "Failed to determine modification time for '" << path
+                << "': Directory has content with empty name";
+      return 0;
+    }
     const auto full_path = JoinPath({path, child});
     mtime = std::max(mtime, GetModifiedTime(full_path));
   }


### PR DESCRIPTION
This is to prevent infinity loop like:
```
I0327 17:58:53.944686 1 http_server.cc:3372] HTTP request: 2 /v2/repository/models/debug/load
I0327 17:58:53.944736 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug
...
I0327 17:58:54.150433 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py
I0327 17:58:54.241710 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py/
I0327 17:58:54.268449 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py/
I0327 17:58:54.292619 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py/
I0327 17:58:54.330611 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py/
I0327 17:58:54.361050 1 filesystem.cc:2354] Using credential    for path  as://mystorage/triton/model_repo/debug/1/model.py/
... (infinity loop)
```
Ref: https://github.com/triton-inference-server/server/issues/5533#issuecomment-1485631131

When the cloud storage client falsely reports a file as a directory, probably due to permission, the current logic can infinitely loop on an invalid directory path like `as://mystorage/triton/model_repo/debug/1/model.py/` on [`GetModifiedTime()`](https://github.com/triton-inference-server/core/blob/r23.02/src/model_repository_manager.cc#L209-L253). This change prevents the infinity loop by heuristically checking if the name of the contents inside a directory is "". If the name is "", then it is invalid and will stop calling on the recursive loop. However, it is still the ultimate responsibility of the cloud storage client to correctly report if a content is a file or directory.