### PR TITLE
Disable request_duration summary when caching is enabled

### DIFF
--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -157,11 +157,14 @@ TritonModelInstance::TritonModelInstance(
     const int id = (kind_ == TRITONSERVER_INSTANCEGROUPKIND_GPU)
                        ? device_id_
                        : METRIC_REPORTER_ID_CPU;
+    // Let every metric reporter know if caching is enabled to correctly include
+    // cache miss time into request duration on cache misses.
+    const bool response_cache_enabled =
+        model_->Config().response_cache().enable() &&
+        model_->Server()->ResponseCacheEnabled();
     MetricModelReporter::Create(
-        model_->Name(), model_->Version(), id, 
-        model_->Config().response_cache().enable(), 
-        model_->Config().metric_tags(),
-        &reporter_);
+        model_->Name(), model_->Version(), id, response_cache_enabled,
+        model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
 }

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -158,7 +158,9 @@ TritonModelInstance::TritonModelInstance(
                        ? device_id_
                        : METRIC_REPORTER_ID_CPU;
     MetricModelReporter::Create(
-        model_->Name(), model_->Version(), id, model_->Config().metric_tags(),
+        model_->Name(), model_->Version(), id, 
+        model_->Config().response_cache().enable(), 
+        model_->Config().metric_tags(),
         &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -80,16 +80,13 @@ DynamicBatchScheduler::DynamicBatchScheduler(
   // Both the server and model config should specify
   // caching enabled for model to utilize response cache.
   response_cache_enabled_ =
-      (response_cache_enable && model_->Server()->ResponseCacheEnabled() &&
-       model_->Server()->CacheManager() &&
-       model_->Server()->CacheManager()->Cache());
+      response_cache_enable && model_->Server()->ResponseCacheEnabled();
 #ifdef TRITON_ENABLE_METRICS
   // Initialize metric reporter for cache statistics if cache enabled
   if (response_cache_enabled_) {
     MetricModelReporter::Create(
         model_name_, model_->Version(), METRIC_REPORTER_ID_RESPONSE_CACHE,
-        response_cache_enable,
-        model_->Config().metric_tags(), &reporter_);
+        response_cache_enabled_, model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
   max_preferred_batch_size_ = 0;

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -88,6 +88,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
   if (response_cache_enabled_) {
     MetricModelReporter::Create(
         model_name_, model_->Version(), METRIC_REPORTER_ID_RESPONSE_CACHE,
+        response_cache_enable,
         model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -1316,8 +1316,11 @@ EnsembleScheduler::EnsembleScheduler(
 
 #ifdef TRITON_ENABLE_METRICS
   if (Metrics::Enabled()) {
+    // Ensemble scheduler doesn't currently support response cache at top level.
     MetricModelReporter::Create(
-        config.name(), 1, METRIC_REPORTER_ID_CPU, config.metric_tags(),
+        config.name(), 1, METRIC_REPORTER_ID_CPU, 
+        false /* response_cache_enabled */,
+        config.metric_tags(),
         &metric_reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -46,15 +46,19 @@ struct MetricReporterConfig {
   prometheus::Summary::Quantiles ParseQuantiles(std::string options);
 
   // Create and use Counters for per-model latency related metrics
-  bool enable_latency_counters_ = true;
+  bool latency_counters_enabled_ = true;
   // Create and use Summaries for per-model latency related metrics
-  bool enable_latency_summaries_ = false;
+  bool latency_summaries_enabled_ = false;
   // Quantiles used for any summary metrics. Each pair of values represents
   // { quantile, error }. For example, {0.90, 0.01} means to compute the
   // 90th percentile with 1% error on either side, so the approximate 90th
   // percentile value will be between the 89th and 91st percentiles.
   prometheus::Summary::Quantiles quantiles_ = {
       {0.5, 0.05}, {0.9, 0.01}, {0.95, 0.001}, {0.99, 0.001}, {0.999, 0.001}};
+
+  // Whether this reporter's model has caching enabled or not.
+  // This helps handle infer_stats aggregation for summaries on cache misses.
+  bool cache_enabled_ = false;
 };
 
 //
@@ -69,6 +73,9 @@ class MetricModelReporter {
       std::shared_ptr<MetricModelReporter>* metric_model_reporter);
 
   ~MetricModelReporter();
+
+  // Get this reporter's config
+  const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
   // Lookup summary metric by name, and observe the value if it exists.

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -40,7 +40,7 @@ namespace triton { namespace core {
 //
 struct MetricReporterConfig {
   // Parses Metrics::ConfigMap and sets fields if specified
-  void ParseConfig();
+  void ParseConfig(bool response_cache_enabled);
   // Parses pairs of quantiles "quantile1:error1, quantile2:error2, ..."
   // and overwrites quantiles_ field if successful.
   prometheus::Summary::Quantiles ParseQuantiles(std::string options);
@@ -69,7 +69,8 @@ class MetricModelReporter {
 #ifdef TRITON_ENABLE_METRICS
   static Status Create(
       const std::string& model_name, const int64_t model_version,
-      const int device, const triton::common::MetricTagsMap& model_tags,
+      const int device, bool response_cache_enabled,
+      const triton::common::MetricTagsMap& model_tags,
       std::shared_ptr<MetricModelReporter>* metric_model_reporter);
 
   ~MetricModelReporter();
@@ -84,7 +85,8 @@ class MetricModelReporter {
  private:
   MetricModelReporter(
       const std::string& model_name, const int64_t model_version,
-      const int device, const triton::common::MetricTagsMap& model_tags);
+      const int device, bool response_cache_enabled,
+      const triton::common::MetricTagsMap& model_tags);
 
   static void GetMetricLabels(
       std::map<std::string, std::string>* labels, const std::string& model_name,

--- a/src/server.h
+++ b/src/server.h
@@ -197,7 +197,11 @@ class InferenceServer {
 
   // Get / set whether response cache will be enabled server-wide.
   // NOTE: Models still need caching enabled in individual model configs.
-  bool ResponseCacheEnabled() const { return response_cache_enabled_; }
+  bool ResponseCacheEnabled()
+  {
+    // Only return true if cache was enabled, and has been initialized
+    return response_cache_enabled_ && CacheManager() && CacheManager()->Cache();
+  }
   void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
   void SetCacheConfig(CacheConfigMap cfg) { cache_config_map_ = cfg; }
   std::string CacheDir() const { return cache_dir_; }


### PR DESCRIPTION
When caching is enabled for a model, cache misses spend additional time inserting into the cache (invoked by scheduler) after a backend has returned the response. This additional time has to be considered in the end-to-end request_duration. 
- For `counter` metrics, this is simply added on top of the backend-reported request_duration with an additional `Counter::Increment` API call as it is jts a monotonically increasing number:
  ```
  counter->Increment(backend_duration)
  counter->Increment(cache_miss_duration)
  ```
- For `summary` metrics, the underlying behavior is more complex, and the final request duration (including the cache miss time) should only be reported once:
  ```
  summary->Observe(backend_duration + cache_miss_duration)
  ```
  If the two values were reported separately, they'd be considered 2 separate request durations and skew the derived summary statistics reported (quantiles).


This is rather trick to correctly get both values `backend_duration + cache_miss_duration` so the `request_duration` summary will be disabled for now.

---

For the non-decoupled case, I think per-response statistics would be the cleanest way of reporting the metrics internally, as we can do any internal business logic that we need, and when the response is finally ready, we can report the statistics just once. However, I think there were some issues with the per-response stats feature and it was shelved, so I will discuss some alternatives for now below.

The request may not be valid when the scheduler is handling cache-misses, as a backend can release the request before that happens - so we cannot store the request_duration intermediate values within the request object. 

It may be possible to store a short-lived map of request_durations based on request_id or similar identifier. So when a backend reports stats:
```cpp
// Called from TRITONBACKEND
UpdateSuccess(request_start_ns, request_end_ns, ...) {
  // Cache enabled, should store request_start now and 
  // substract it from cache_end in UpdateCacheMiss()
  if (cache_enabled) {
    request_start_map[identifier] = request_start_ns;
  }
  // No caching, can report duration right away 
  else {
    request_summary.Observe(request_end_ns  - request_start_ns)
  }

  queue_summary.Observe(queue_duration_ns);
  compute_input_summary.Observe(compute_input_duration_ns);
  ...
}

UpdateCacheMiss(cache_miss_start_ns, cache_miss_end_ns) {
  request_start_ns = request_start_map[identifier];
  request_summary.Observe(cache_miss_end_ns - request_start_ns);
  cache_miss_summary.Observe(cache_miss_end_ns - cache_miss_start_ns)
}
```

However I'm not sure what `identifier` will be yet, as `request->Id()` appears to be usually unset unless explicitly set by the user or application?