### PR TITLE
Add --metrics-config and Summary support

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 21
+#define TRITONSERVER_API_VERSION_MINOR 22
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the
@@ -1301,7 +1301,8 @@ TRITONSERVER_InferenceRequestSetStringParameter(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetIntParameter(
-    TRITONSERVER_InferenceRequest* request, const char* key, const int64_t value);
+    TRITONSERVER_InferenceRequest* request, const char* key,
+    const int64_t value);
 
 /// Set a boolean parameter in the request.
 ///
@@ -2010,6 +2011,19 @@ TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetHostPolicy(
     TRITONSERVER_ServerOptions* options, const char* policy_name,
     const char* setting, const char* value);
+
+/// Set a configuration setting for metrics in server options.
+///
+/// \param options The server options object.
+/// \param name The name of the configuration group. An empty string indicates
+///             a global configuration option.
+/// \param setting The name of the setting.
+/// \param value The setting value.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetMetricsConfig(
+    TRITONSERVER_ServerOptions* options, const char* name, const char* setting,
+    const char* value);
 
 /// TRITONSERVER_Server
 ///

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -157,9 +157,14 @@ TritonModelInstance::TritonModelInstance(
     const int id = (kind_ == TRITONSERVER_INSTANCEGROUPKIND_GPU)
                        ? device_id_
                        : METRIC_REPORTER_ID_CPU;
+    // Let every metric reporter know if caching is enabled to correctly include
+    // cache miss time into request duration on cache misses.
+    const bool response_cache_enabled =
+        model_->Config().response_cache().enable() &&
+        model_->Server()->ResponseCacheEnabled();
     MetricModelReporter::Create(
-        model_->Name(), model_->Version(), id, model_->Config().metric_tags(),
-        &reporter_);
+        model_->Name(), model_->Version(), id, response_cache_enabled,
+        model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
 }

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -80,15 +80,13 @@ DynamicBatchScheduler::DynamicBatchScheduler(
   // Both the server and model config should specify
   // caching enabled for model to utilize response cache.
   response_cache_enabled_ =
-      (response_cache_enable && model_->Server()->ResponseCacheEnabled() &&
-       model_->Server()->CacheManager() &&
-       model_->Server()->CacheManager()->Cache());
+      response_cache_enable && model_->Server()->ResponseCacheEnabled();
 #ifdef TRITON_ENABLE_METRICS
   // Initialize metric reporter for cache statistics if cache enabled
   if (response_cache_enabled_) {
     MetricModelReporter::Create(
         model_name_, model_->Version(), METRIC_REPORTER_ID_RESPONSE_CACHE,
-        model_->Config().metric_tags(), &reporter_);
+        response_cache_enabled_, model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
   max_preferred_batch_size_ = 0;

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -1316,8 +1316,11 @@ EnsembleScheduler::EnsembleScheduler(
 
 #ifdef TRITON_ENABLE_METRICS
   if (Metrics::Enabled()) {
+    // Ensemble scheduler doesn't currently support response cache at top level.
     MetricModelReporter::Create(
-        config.name(), 1, METRIC_REPORTER_ID_CPU, config.metric_tags(),
+        config.name(), 1, METRIC_REPORTER_ID_CPU, 
+        false /* response_cache_enabled */,
+        config.metric_tags(),
         &metric_reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -39,6 +39,7 @@ namespace triton { namespace core {
 // MetricReporterConfig
 //
 struct MetricReporterConfig {
+#ifdef TRITON_ENABLE_METRICS
   // Parses Metrics::ConfigMap and sets fields if specified
   void ParseConfig(bool response_cache_enabled);
   // Parses pairs of quantiles "quantile1:error1, quantile2:error2, ..."
@@ -59,6 +60,7 @@ struct MetricReporterConfig {
   // Whether this reporter's model has caching enabled or not.
   // This helps handle infer_stats aggregation for summaries on cache misses.
   bool cache_enabled_ = false;
+#endif  // TRITON_ENABLE_METRICS
 };
 
 //

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -79,6 +79,7 @@ Metrics::Metrics()
               .Help("Cumulative inference queuing duration in microseconds "
                     "(includes cached requests)")
               .Register(*registry_)),
+
       inf_compute_input_duration_us_family_(
           prometheus::BuildCounter()
               .Name("nv_inference_compute_input_duration_us")
@@ -119,6 +120,52 @@ Metrics::Metrics()
               .Name("nv_cache_miss_duration_per_model")
               .Help("Total cache miss (insert+lookup) duration per model, in "
                     "microseconds")
+              .Register(*registry_)),
+
+      // Summaries
+      inf_request_summary_us_family_(
+          prometheus::BuildSummary()
+              .Name("nv_inference_request_summary_us")
+              .Help("Summary of inference request duration in microseconds "
+                    "(includes cached requests)")
+              .Register(*registry_)),
+      inf_queue_summary_us_family_(
+          prometheus::BuildSummary()
+              .Name("nv_inference_queue_summary_us")
+              .Help("Summary of inference queuing duration in microseconds "
+                    "(includes cached requests)")
+              .Register(*registry_)),
+      inf_compute_input_summary_us_family_(
+          prometheus::BuildSummary()
+              .Name("nv_inference_compute_input_summary_us")
+              .Help("Cumulative compute input duration in microseconds (does "
+                    "not include cached requests)")
+              .Register(*registry_)),
+      inf_compute_infer_summary_us_family_(
+          prometheus::BuildSummary()
+              .Name("nv_inference_compute_infer_summary_us")
+              .Help("Cumulative compute inference duration in microseconds "
+                    "(does not include cached requests)")
+              .Register(*registry_)),
+      inf_compute_output_summary_us_family_(
+          prometheus::BuildSummary()
+              .Name("nv_inference_compute_output_summary_us")
+              .Help("Cumulative inference compute output duration in "
+                    "microseconds (does not include cached requests)")
+              .Register(*registry_)),
+
+      cache_hit_summary_us_model_family_(
+          prometheus::BuildSummary()
+              .Name("nv_cache_hit_summary_per_model")
+              .Help("Summary of cache hit counts/durations per model, in "
+                    "microseconds.")
+              .Register(*registry_)),
+
+      cache_miss_summary_us_model_family_(
+          prometheus::BuildSummary()
+              .Name("nv_cache_miss_summary_per_model")
+              .Help("Summary of cache miss counts/durations per model, in "
+                    "microseconds.")
               .Register(*registry_)),
 
 #ifdef TRITON_ENABLE_METRICS_GPU
@@ -213,8 +260,15 @@ Metrics::~Metrics()
   }
 }
 
+const MetricsConfigMap&
+Metrics::ConfigMap()
+{
+  auto singleton = GetSingleton();
+  return singleton->config_;
+}
+
 void
-Metrics::SetConfig(MetricsConfigMap cfg)
+Metrics::SetConfigMap(MetricsConfigMap cfg)
 {
   auto singleton = GetSingleton();
   singleton->config_ = cfg;

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -213,6 +213,13 @@ Metrics::~Metrics()
   }
 }
 
+void
+Metrics::SetConfig(MetricsConfigMap cfg)
+{
+  auto singleton = GetSingleton();
+  singleton->config_ = cfg;
+}
+
 bool
 Metrics::Enabled()
 {

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -36,6 +36,7 @@
 #include "prometheus/gauge.h"
 #include "prometheus/registry.h"
 #include "prometheus/serializer.h"
+#include "prometheus/summary.h"
 #include "prometheus/text_serializer.h"
 
 #ifdef TRITON_ENABLE_METRICS_GPU
@@ -127,7 +128,10 @@ class Metrics {
   static void SetMetricsInterval(uint64_t metrics_interval_ms);
 
   // Set the config for Metrics to control various options generically
-  static void SetConfig(MetricsConfigMap cfg);
+  static void SetConfigMap(MetricsConfigMap cfg);
+
+  // Get the config for Metrics
+  static const MetricsConfigMap& ConfigMap();
 
   // Get the prometheus registry
   static std::shared_ptr<prometheus::Registry> GetRegistry();
@@ -217,6 +221,40 @@ class Metrics {
     return GetSingleton()->cache_miss_duration_us_model_family_;
   }
 
+  // Summaries
+  static prometheus::Family<prometheus::Summary>&
+  FamilyInferenceRequestSummary()
+  {
+    return GetSingleton()->inf_request_summary_us_family_;
+  }
+  static prometheus::Family<prometheus::Summary>& FamilyInferenceQueueSummary()
+  {
+    return GetSingleton()->inf_queue_summary_us_family_;
+  }
+  static prometheus::Family<prometheus::Summary>&
+  FamilyInferenceComputeInputSummary()
+  {
+    return GetSingleton()->inf_compute_input_summary_us_family_;
+  }
+  static prometheus::Family<prometheus::Summary>&
+  FamilyInferenceComputeInferSummary()
+  {
+    return GetSingleton()->inf_compute_infer_summary_us_family_;
+  }
+  static prometheus::Family<prometheus::Summary>&
+  FamilyInferenceComputeOutputSummary()
+  {
+    return GetSingleton()->inf_compute_output_summary_us_family_;
+  }
+  static prometheus::Family<prometheus::Summary>& FamilyCacheHitSummary()
+  {
+    return GetSingleton()->cache_hit_summary_us_model_family_;
+  }
+  static prometheus::Family<prometheus::Summary>& FamilyCacheMissSummary()
+  {
+    return GetSingleton()->cache_miss_summary_us_model_family_;
+  }
+
  private:
   Metrics();
   virtual ~Metrics();
@@ -233,6 +271,7 @@ class Metrics {
   std::shared_ptr<prometheus::Registry> registry_;
   std::unique_ptr<prometheus::Serializer> serializer_;
 
+  // DLIS-4761: Refactor into groups of families
   prometheus::Family<prometheus::Counter>& inf_success_family_;
   prometheus::Family<prometheus::Counter>& inf_failure_family_;
   prometheus::Family<prometheus::Counter>& inf_count_family_;
@@ -254,6 +293,16 @@ class Metrics {
   prometheus::Family<prometheus::Counter>& cache_hit_duration_us_model_family_;
   prometheus::Family<prometheus::Counter>& cache_num_misses_model_family_;
   prometheus::Family<prometheus::Counter>& cache_miss_duration_us_model_family_;
+
+  // Summaries
+  prometheus::Family<prometheus::Summary>& inf_request_summary_us_family_;
+  prometheus::Family<prometheus::Summary>& inf_queue_summary_us_family_;
+  prometheus::Family<prometheus::Summary>& inf_compute_input_summary_us_family_;
+  prometheus::Family<prometheus::Summary>& inf_compute_infer_summary_us_family_;
+  prometheus::Family<prometheus::Summary>&
+      inf_compute_output_summary_us_family_;
+  prometheus::Family<prometheus::Summary>& cache_hit_summary_us_model_family_;
+  prometheus::Family<prometheus::Summary>& cache_miss_summary_us_model_family_;
 
 #ifdef TRITON_ENABLE_METRICS_GPU
   prometheus::Family<prometheus::Gauge>& gpu_utilization_family_;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -44,6 +44,9 @@
 
 namespace triton { namespace core {
 
+using MetricsConfig = std::vector<std::pair<std::string, std::string>>;
+using MetricsConfigMap = std::unordered_map<std::string, MetricsConfig>;
+
 #ifdef TRITON_ENABLE_METRICS_CPU
 using MemInfo = std::unordered_map<std::string, uint64_t>;
 
@@ -122,6 +125,9 @@ class Metrics {
 
   // Set the time interval in secs at which metrics are collected
   static void SetMetricsInterval(uint64_t metrics_interval_ms);
+
+  // Set the config for Metrics to control various options generically
+  static void SetConfig(MetricsConfigMap cfg);
 
   // Get the prometheus registry
   static std::shared_ptr<prometheus::Registry> GetRegistry();
@@ -295,6 +301,7 @@ class Metrics {
   std::mutex metrics_enabling_;
   std::mutex poll_thread_starting_;
   uint64_t metrics_interval_ms_;
+  MetricsConfigMap config_;
 };
 
 }}  // namespace triton::core

--- a/src/server.h
+++ b/src/server.h
@@ -197,7 +197,11 @@ class InferenceServer {
 
   // Get / set whether response cache will be enabled server-wide.
   // NOTE: Models still need caching enabled in individual model configs.
-  bool ResponseCacheEnabled() const { return response_cache_enabled_; }
+  bool ResponseCacheEnabled()
+  {
+    // Only return true if cache was enabled, and has been initialized
+    return response_cache_enabled_ && CacheManager() && CacheManager()->Cache();
+  }
   void SetResponseCacheEnabled(bool e) { response_cache_enabled_ = e; }
   void SetCacheConfig(CacheConfigMap cfg) { cache_config_map_ = cfg; }
   std::string CacheDir() const { return cache_dir_; }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -198,6 +198,7 @@ target_link_libraries(
     triton-core
     GTest::gtest
     GTest::gtest_main
+    GTest::gmock
 )
 
 install(
@@ -483,6 +484,7 @@ if(${TRITON_ENABLE_METRICS})
       triton-core
       GTest::gtest
       GTest::gtest_main
+      GTest::gmock
       prometheus-cpp::core
       protobuf::libprotobuf
   )

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -288,10 +288,12 @@ class TritonServerOptions {
   uint64_t MetricsInterval() const { return metrics_interval_; }
   void SetMetricsInterval(uint64_t m) { metrics_interval_ = m; }
 
+#ifdef TRITON_ENABLE_METRICS
   const tc::MetricsConfigMap& MetricsConfigMap() { return metrics_config_map_; }
   TRITONSERVER_Error* AddMetricsConfig(
       const std::string& name, const std::string& setting,
       const std::string& value);
+#endif  // TRITON_ENABLE_METRICS
 
   const std::string& BackendDir() const { return backend_dir_; }
   void SetBackendDir(const std::string& bd) { backend_dir_ = bd; }
@@ -353,7 +355,9 @@ class TritonServerOptions {
   tc::CacheConfigMap cache_config_map_;
   triton::common::BackendCmdlineConfigMap backend_cmdline_config_map_;
   triton::common::HostPolicyCmdlineConfigMap host_policy_map_;
+#ifdef TRITON_ENABLE_METRICS
   tc::MetricsConfigMap metrics_config_map_;
+#endif  // TRITON_ENABLE_METRICS
 };
 
 TritonServerOptions::TritonServerOptions()
@@ -434,6 +438,7 @@ TritonServerOptions::AddCacheConfig(
   return nullptr;  // success
 }
 
+#ifdef TRITON_ENABLE_METRICS
 TRITONSERVER_Error*
 TritonServerOptions::AddMetricsConfig(
     const std::string& name, const std::string& setting,
@@ -443,6 +448,7 @@ TritonServerOptions::AddMetricsConfig(
   mc.push_back(std::make_pair(setting, value));
   return nullptr;  // success
 }
+#endif  // TRITON_ENABLE_METRICS
 
 TRITONSERVER_Error*
 TritonServerOptions::SetHostPolicy(
@@ -3184,9 +3190,14 @@ TRITONSERVER_ServerOptionsSetMetricsConfig(
     TRITONSERVER_ServerOptions* options, const char* name, const char* setting,
     const char* value)
 {
+#ifdef TRITON_ENABLE_METRICS
   TritonServerOptions* loptions =
       reinterpret_cast<TritonServerOptions*>(options);
   return loptions->AddMetricsConfig(name, setting, value);
+#else
+  return TRITONSERVER_ErrorNew(
+      TRITONSERVER_ERROR_UNSUPPORTED, "metrics not supported");
+#endif  // TRITON_ENABLE_METRICS
 }
 
 }  // extern C

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2214,7 +2214,7 @@ TRITONSERVER_ServerNew(
   if (loptions->Metrics()) {
     tc::Metrics::EnableMetrics();
     tc::Metrics::SetMetricsInterval(loptions->MetricsInterval());
-    tc::Metrics::SetConfig(loptions->MetricsConfigMap());
+    tc::Metrics::SetConfigMap(loptions->MetricsConfigMap());
   }
 #endif  // TRITON_ENABLE_METRICS
 

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -990,6 +990,11 @@ TRITONSERVER_GetMetricKind()
 }
 
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetMetricsConfig()
+{
+}
+
+TRITONAPI_DECLSPEC void
 TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup()
 {
 }


### PR DESCRIPTION
Merging side branch of PRs for `--metrics-config` and `summary` support into main. 

Waiting on: https://github.com/triton-inference-server/core/pull/186