### PR TITLE
Opentelemetry support for Triton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,9 +269,14 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
   if(${TRITON_ENABLE_GPU})
     set(TRITON_DEPENDS ${TRITON_DEPENDS} cnmem)
   endif() # TRITON_ENABLE_GPU
-  if(${TRITON_ENABLE_TRACING})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} opentelemetry-cpp)
-  endif() # TRITON_ENABLE_TRACING
+  if (WIN32)
+    set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "")
+  else()
+    if(${TRITON_ENABLE_TRACING})
+      set(TRITON_DEPENDS ${TRITON_DEPENDS} opentelemetry-cpp)
+    endif() # TRITON_ENABLE_TRACING
+    set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp")
+  endif()
 
   ExternalProject_Add(triton-core
     PREFIX triton-core
@@ -301,7 +306,7 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
       -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-checksums/cmake
       -DCNMEM_PATH:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/cnmem
       -DCURL_DIR:STRING=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/curl/lib/cmake/CURL
-      -Dopentelemetry-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp
+      -Dopentelemetry-cpp_DIR:PATH=${_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR}
       -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
       -DTRITON_EXTRA_LIB_PATHS:PATH=${TRITON_EXTRA_LIB_PATHS}
       -DTRITON_ENABLE_NVTX:BOOL=${TRITON_ENABLE_NVTX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,9 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
   if(${TRITON_ENABLE_GPU})
     set(TRITON_DEPENDS ${TRITON_DEPENDS} cnmem)
   endif() # TRITON_ENABLE_GPU
+  if(${TRITON_ENABLE_TRACING})
+    set(TRITON_DEPENDS ${TRITON_DEPENDS} opentelemetry-cpp)
+  endif() # TRITON_ENABLE_TRACING
 
   ExternalProject_Add(triton-core
     PREFIX triton-core
@@ -297,6 +300,7 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
       -Daws-c-common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-c-common/cmake
       -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-checksums/cmake
       -DCNMEM_PATH:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/cnmem
+      -Dopentelemetry-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp
       -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
       -DTRITON_EXTRA_LIB_PATHS:PATH=${TRITON_EXTRA_LIB_PATHS}
       -DTRITON_ENABLE_NVTX:BOOL=${TRITON_ENABLE_NVTX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
       -Daws-c-common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-c-common/cmake
       -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-checksums/cmake
       -DCNMEM_PATH:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/cnmem
+      -DCURL_DIR:STRING=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/curl/lib/cmake/CURL
       -Dopentelemetry-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp
       -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
       -DTRITON_EXTRA_LIB_PATHS:PATH=${TRITON_EXTRA_LIB_PATHS}

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -719,6 +719,23 @@ typedef enum tritonserver_traceactivity_enum {
 TRITONSERVER_DECLSPEC const char* TRITONSERVER_InferenceTraceActivityString(
     TRITONSERVER_InferenceTraceActivity activity);
 
+/// Trace modes. 
+typedef enum tritonserver_tracemode_enum {
+  /// Default is Triton tracing API
+  TRITONSERVER_TRACE_MODE_TRITON = 0,
+  /// OpenTelemetry API for tracing
+  TRITONSERVER_TRACE_MODE_OPENTELEMETRY = 1
+} TRITONSERVER_InferenceTraceMode;
+
+/// Get the string representation of a trace mode. The returned
+/// string is not owned by the caller and so should not be modified or
+/// freed.
+///
+/// \param mode The trace mode.
+/// \return The string representation of the trace mode.
+TRITONSERVER_DECLSPEC const char* TRITONSERVER_InferenceTraceModeString(
+    TRITONSERVER_InferenceTraceMode mode);
+
 /// Type for trace timeline activity callback function. This callback function
 /// is used to report activity occurring for a trace. This function
 /// does not take ownership of 'trace' and so any information needed

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,9 @@ endif()
 # OpenTelemetry
 #
 if(${TRITON_ENABLE_TRACING})
+  find_package(absl CONFIG REQUIRED)
+  find_package(CURL CONFIG REQUIRED)
+  find_package(nlohmann_json CONFIG REQUIRED)
   find_package(opentelemetry-cpp CONFIG REQUIRED)
   message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,12 +102,14 @@ endif()
 #
 # OpenTelemetry
 #
-if(${TRITON_ENABLE_TRACING})
-  find_package(absl CONFIG REQUIRED)
-  find_package(CURL CONFIG REQUIRED)
-  find_package(nlohmann_json CONFIG REQUIRED)
-  find_package(opentelemetry-cpp CONFIG REQUIRED)
-  message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+if (NOT WIN32)
+  if(${TRITON_ENABLE_TRACING})
+    find_package(absl CONFIG REQUIRED)
+    find_package(CURL CONFIG REQUIRED)
+    find_package(nlohmann_json CONFIG REQUIRED)
+    find_package(opentelemetry-cpp CONFIG REQUIRED)
+    message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+  endif()
 endif()
 
 configure_file(libtritonserver.ldscript libtritonserver.ldscript COPYONLY)
@@ -328,11 +330,13 @@ if(${TRITON_ENABLE_AZURE_STORAGE})
   )
 endif() # TRITON_ENABLE_AZURE_STORAGE
 
-if(${TRITON_ENABLE_TRACING})
-  target_include_directories(
-    triton-core 
-    PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-  )
+if (NOT WIN32)
+  if(${TRITON_ENABLE_TRACING})
+    target_include_directories(
+      triton-core 
+      PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+    )
+  endif()
 endif()
 
 target_compile_definitions(
@@ -526,12 +530,14 @@ if(${TRITON_ENABLE_METRICS_GPU})
   )
 endif() # TRITON_ENABLE_METRICS_GPU
 
-if(${TRITON_ENABLE_TRACING})
-  target_link_libraries(
-    triton-core
-    PRIVATE
-      ${OPENTELEMETRY_CPP_LIBRARIES}
-  )
+if (NOT WIN32)
+  if(${TRITON_ENABLE_TRACING})
+    target_link_libraries(
+      triton-core
+      PRIVATE
+        ${OPENTELEMETRY_CPP_LIBRARIES}
+    )
+  endif()
 endif()
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,14 @@ if(${TRITON_ENABLE_S3})
   message(STATUS "Using aws-sdk-cpp ${AWSSDK_VERSION}")
 endif()
 
+#
+# OpenTelemetry
+#
+if(${TRITON_ENABLE_TRACING})
+  find_package(opentelemetry-cpp CONFIG REQUIRED)
+  message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+endif()
+
 configure_file(libtritonserver.ldscript libtritonserver.ldscript COPYONLY)
 
 set(
@@ -317,6 +325,13 @@ if(${TRITON_ENABLE_AZURE_STORAGE})
   )
 endif() # TRITON_ENABLE_AZURE_STORAGE
 
+if(${TRITON_ENABLE_TRACING})
+  target_include_directories(
+    triton-core 
+    PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+endif()
+
 target_compile_definitions(
   triton-core
   PRIVATE TRITON_VERSION="${TRITON_VERSION}"
@@ -507,6 +522,14 @@ if(${TRITON_ENABLE_METRICS_GPU})
       dcgm
   )
 endif() # TRITON_ENABLE_METRICS_GPU
+
+if(${TRITON_ENABLE_TRACING})
+  target_link_libraries(
+    triton-core
+    PRIVATE
+      ${OPENTELEMETRY_CPP_LIBRARIES}
+  )
+endif()
 
 install(
   TARGETS

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -922,6 +922,20 @@ TRITONSERVER_InferenceTraceActivityString(
   return "<unknown>";
 }
 
+TRITONAPI_DECLSPEC const char*
+TRITONSERVER_InferenceTraceModeString(
+    TRITONSERVER_InferenceTraceMode mode)
+{
+  switch (mode) {
+    case TRITONSERVER_TRACE_MODE_TRITON:
+      return "TRITON";
+    case TRITONSERVER_TRACE_MODE_OPENTELEMETRY:
+      return "OPENTELEMETRY";
+  }
+
+  return "<unknown>";
+}
+
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceTraceNew(
     TRITONSERVER_InferenceTrace** trace, TRITONSERVER_InferenceTraceLevel level,

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -146,6 +146,10 @@ TRITONSERVER_InferenceTraceActivityString()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_InferenceTraceModeString()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_InferenceTraceNew()
 {
 }


### PR DESCRIPTION
Related to: https://github.com/triton-inference-server/server/pull/5637

- Mostly build-related changes
- Adds `TRITONSERVER_InferenceTraceMode` similar to `TRITONSERVER_InferenceTraceLevel`