### PR TITLE
Reduce default model load thread count to 4

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -104,8 +104,7 @@ InferenceServer::InferenceServer()
   exit_timeout_secs_ = 30;
   pinned_memory_pool_size_ = 1 << 28;
   buffer_manager_thread_count_ = 0;
-  model_load_thread_count_ =
-      std::max(2u, 2 * std::thread::hardware_concurrency());
+  model_load_thread_count_ = 4;
   enable_model_namespacing_ = false;
 
 #ifdef TRITON_ENABLE_GPU

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -367,9 +367,7 @@ TritonServerOptions::TritonServerOptions()
       rate_limit_mode_(tc::RateLimitMode::RL_OFF), metrics_(true),
       gpu_metrics_(true), cpu_metrics_(true), metrics_interval_(2000),
       exit_timeout_(30), pinned_memory_pool_size_(1 << 28),
-      buffer_manager_thread_count_(0),
-      model_load_thread_count_(
-          std::max(2u, 2 * std::thread::hardware_concurrency())),
+      buffer_manager_thread_count_(0), model_load_thread_count_(4),
       enable_model_namespacing_(false),
 #ifdef TRITON_ENABLE_GPU
       min_compute_capability_(TRITON_MIN_COMPUTE_CAPABILITY),


### PR DESCRIPTION
CLI change corresponding to https://github.com/triton-inference-server/server/pull/5650