### PR TITLE
Improve rate limiter and dynamic batch scheduler handling on model instance removal

### DIFF
--- a/src/backend_model.h
+++ b/src/backend_model.h
@@ -134,9 +134,6 @@ class TritonModel : public Model {
   // Gets the execution policy setting from the backend.
   Status GetExecutionPolicy(const inference::ModelConfig& model_config);
 
-  // Set or update the scheduler.
-  Status SetSchedulerMutable(std::unique_ptr<Scheduler> scheduler);
-
   // Set the scheduler based on the model configuration and foreground
   // 'instances'.
   Status SetConfiguredScheduler();

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -162,7 +162,8 @@ class RateLimiter {
     Status Stage(StandardScheduleFunc OnSchedule);
     Status Allocate();
     Status DirectAllocate(StandardScheduleFunc OnSchedule);
-    void WaitForRemoval();
+    void RequestRemoval();
+    bool IsRemovalInProgress();
 
     TritonModelInstance* triton_model_instance_;
     ModelContext* model_context_;
@@ -176,8 +177,6 @@ class RateLimiter {
     std::mutex state_mtx_;
 
     StandardScheduleFunc OnSchedule_;
-
-    std::condition_variable cv_;
   };
 
   class ScaledPriorityComparator {
@@ -223,7 +222,7 @@ class RateLimiter {
     // Will wait for all enqueued model instance requests to complete.
     void RequestRemoval() { removal_in_progress_ = true; }
     // Whether or not model context is decommissioned
-    bool isRemovalInProgress() { return removal_in_progress_; }
+    bool IsRemovalInProgress() { return removal_in_progress_; }
 
    private:
     bool removal_in_progress_;


### PR DESCRIPTION
This PR fixes 2 issues:
1. When the exit payload is released back to the rate limiter, this implies the `ModelInstanceContext` underneath the payload is exiting. Then, the `ModelInstanceContext` is marked as `removal_in_progress`, which it cannot be staged after the release, so any pending requests on the generic queue cannot be scheduled onto this `ModelInstanceContext`. Thus, the `ModelInstanceContext` is safe to be removed from the rate limiter from this point.
2. The `backend_model` will update the model config instead of replacing it with the new one, because there could be references to the model config while update is underway.

Note: The mechanism on point 1 implies the exit payload must be the last one on the specific queue, meaning the sequence batch scheduler must have received all sequence requests from the client and flush any pending requests into the rate limiter before the `model_instance` may be destructed. Sequence models are not currently updatable, so this part is left out on this PR.