### PR TITLE
Remove unused local variable: slash_locations

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -1542,7 +1542,6 @@ S3FileSystem::CleanPath(const std::string& s3_path, std::string* clean_path)
 
   // Remove extra internal slashes
   std::string true_path = path.substr(ltrim_length, rtrim_length + 1);
-  std::vector<int> slash_locations;
   bool previous_slash = false;
   for (size_t i = 0; i < true_path.size(); i++) {
     if (true_path[i] == '/') {


### PR DESCRIPTION
This issue is originally found by [github-code-scanning](https://github.com/apps/github-code-scanning) in https://github.com/triton-inference-server/server/pull/5686