### PR TITLE
Avoid rate limiter resource count update from iterating over all instances

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -274,6 +274,9 @@ TritonModel::UpdateInstanceGroup(
       this, backend_cmdline_config_map_, host_policy_map_, model_config);
   caller_lock->lock();
   if (!status.IsOk()) {
+    // Remove any pending instances if created.
+    bg_instances_.clear();
+    bg_passive_instances_.clear();
     return status;
   }
 

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -181,9 +181,7 @@ TritonModelInstance::~TritonModelInstance()
     triton_backend_thread_->StopBackendThread();
   }
 
-  LOG_STATUS_ERROR(
-      model_->Server()->GetRateLimiter()->UnregisterModelInstance(this),
-      "failed unregistering model instance");
+  model_->Server()->GetRateLimiter()->UnregisterModelInstance(this);
 
   // Model finalization is optional...
   if (model_->Backend()->ModelInstanceFiniFn() != nullptr) {

--- a/src/model_lifecycle.cc
+++ b/src/model_lifecycle.cc
@@ -640,10 +640,12 @@ ModelLifeCycle::UpdateModelConfig(
 
   std::unique_lock<std::mutex> model_info_lock(model_info->mtx_);
 
+  // Make sure the state reason is empty before attempting to update.
+  model_info->state_reason_.clear();
+
   // Downcast 'Model' to 'TritonModel'.
   TritonModel* model = (TritonModel*)model_info->model_.get();
   if (model == nullptr) {
-    model_info->state_ = ModelReadyState::UNAVAILABLE;
     model_info->state_reason_ =
         "Unable to downcast '" + model_id.str() +
         "' from 'Model' to 'TritonModel' during model update.";
@@ -654,8 +656,8 @@ ModelLifeCycle::UpdateModelConfig(
   Status status =
       model->UpdateInstanceGroup(new_model_config, &model_info_lock);
   if (!status.IsOk()) {
-    model_info->state_ = ModelReadyState::UNAVAILABLE;
     model_info->state_reason_ = status.AsString();
+    return;
   }
 
   // Write new config into 'model_info'.
@@ -682,10 +684,10 @@ ModelLifeCycle::OnLoadComplete(
     std::lock_guard<std::mutex> model_info_lock(model_info->mtx_);
 
     // Write failed to load reason into tracker, if any.
-    // A newly created model should be at state 'LOADING' unless failed to load.
-    // A updated model should be at state 'READY' unless failed to update.
+    // A newly created model is at 'LOADING' state unless it failed to load.
+    // An updated model has an empty state reason unless it failed to update.
     if ((!is_update && model_info->state_ != ModelReadyState::LOADING) ||
-        (is_update && model_info->state_ != ModelReadyState::READY)) {
+        (is_update && !model_info->state_reason_.empty())) {
       load_tracker->load_failed_ = true;
       load_tracker->reason_ +=
           ("version " + std::to_string(version) + " is at " +

--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -798,9 +798,9 @@ RateLimiter::ResourceManager::RemoveModelInstance(
     if (ditr != max_resources_.end()) {
       for (const auto& resource : resource_device_map.second) {
         auto ritr = ditr->second.find(resource.first);
-        if (ritr != ditr->second.end() && ritr->second >= resource.second) {
+        if (ritr != ditr->second.end() && ritr->second <= resource.second) {
           update_needed = true;
-          if (ritr->second > resource.second) {
+          if (ritr->second < resource.second) {
             LOG_ERROR << "Should not print this! Removing an instance with "
                          "resource above max resource.";
           }

--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -116,6 +116,17 @@ RateLimiter::UnregisterModelInstance(TritonModelInstance* triton_model_instance)
     model_instances.erase(i_it);
   }
 
+  {
+    std::lock_guard<std::mutex> lk(payload_queues_mu_);
+    auto p_it = payload_queues_.find(model);
+    if (p_it != payload_queues_.end()) {
+      auto s_it = p_it->second->specific_queues_.find(triton_model_instance);
+      if (s_it != p_it->second->specific_queues_.end()) {
+        p_it->second->specific_queues_.erase(s_it);
+      }
+    }
+  }
+
   return Status::Success;
 }
 

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -245,12 +245,9 @@ class RateLimiter {
         const ResourceMap& resource_map,
         std::unique_ptr<ResourceManager>* resource_manager);
     // Adds the model instance to the resource manager
-    void AddModelInstance(const ModelInstanceContext* instance);
+    Status AddModelInstance(const ModelInstanceContext* instance);
     // Removes the model instance from the resource manager
     Status RemoveModelInstance(const ModelInstanceContext* instance);
-    // Based upon the model instances being managed by resource manager,
-    // this function will update the available resource counts.
-    Status UpdateResourceLimits();
     // Allocate resources for the given model instance. Returns
     // false if resources are not available at this time.
     bool AllocateResources(const ModelInstanceContext* instance);
@@ -260,6 +257,9 @@ class RateLimiter {
 
    private:
     ResourceManager(const ResourceMap& resource_map);
+    void ComputeResourceLimits();
+    void UpdateMaxResource(const ResourceMap& instance_resource_map);
+    Status ParseAndValidateResources();
     Status ValidateMaxResources();
     Status ParseAndValidateExplicitResources();
 

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -84,13 +84,11 @@ class RateLimiter {
   /// Unregisters the model instance with the rate limiter.
   /// \param instance The pointer to the TritonModelInstance object to
   /// unregister with the rate limiter.
-  /// \return Status object indicating success or failure.
-  Status UnregisterModelInstance(TritonModelInstance* instance);
+  void UnregisterModelInstance(TritonModelInstance* instance);
 
   /// Remove model from the set of models being managed by the rate limiter.
   /// \param model The pointer to TritonModel object to be removed.
-  /// \return Status object indicating success or failure.
-  Status UnregisterModel(const TritonModel* model);
+  void UnregisterModel(const TritonModel* model);
 
   /// Returns true if there is a payload slot available for the given model.
   /// \param model The pointer to TritonModel object to be removed.


### PR DESCRIPTION
This PR optimize the logic on rate limiter instance max resource update, after an instance is added or removed. The previous logic will iterate over all instances once for each instance added or removed. For adding an instance, the new logic will only compare the resource limit between the new instance and the max resource, and update the max resource if the new instance has a higher limit. For removing an instance, the resource on the instance being removed is compared with the max resource. If the max resource is greater than the resource on the instance being removed, then no update will be performed. If the removed instance has higher or equal limit to the max resource, then the max resource is discarded and re-computed, which iterates over the instances once.

Server PR: https://github.com/triton-inference-server/server/pull/5885