### PR TITLE
Updating core APIs for uint64 Request Priority

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1058,9 +1058,11 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
     struct TRITONSERVER_InferenceRequest* inference_request,
     const char* correlation_id);
 
+/// Deprecated. See TRITONSERVER_InferenceRequestPriorityU64 instead.
+///  
 /// Get the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
-/// model's default priority.
+/// model's default priority. 
 ///
 /// \param inference_request The request object.
 /// \param priority Returns the priority level.
@@ -1068,6 +1070,18 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_InferenceRequestPriority(
     struct TRITONSERVER_InferenceRequest* inference_request, uint32_t* priority);
 
+/// Get the priority for a request. The default is 0 indicating that
+/// the request does not specify a priority and so will use the
+/// model's default priority.
+///
+/// \param inference_request The request object.
+/// \param priority Returns the priority level.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_InferenceRequestPriorityU64(
+    struct TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority);
+
+/// Deprecated. See TRITONSERVER_InferenceRequestSetPriorityU64 instead.
+///  
 /// Set the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
 /// model's default priority.
@@ -1078,6 +1092,17 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_InferenceRequestPr
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetPriority(
     struct TRITONSERVER_InferenceRequest* inference_request, uint32_t priority);
+  
+/// Set the priority for a request. The default is 0 indicating that
+/// the request does not specify a priority and so will use the
+/// model's default priority.
+///
+/// \param inference_request The request object.
+/// \param priority The priority level.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
+TRITONSERVER_InferenceRequestSetPriorityU64(
+    struct TRITONSERVER_InferenceRequest* inference_request, uint64_t priority);
 
 /// Get the timeout for a request, in microseconds. The default is 0
 /// which indicates that the request has no timeout.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1059,7 +1059,7 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
     const char* correlation_id);
 
 /// Deprecated. See TRITONSERVER_InferenceRequestPriorityU64 instead.
-///  
+///
 /// Get the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
 /// model's default priority.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1058,7 +1058,7 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
     struct TRITONSERVER_InferenceRequest* inference_request,
     const char* correlation_id);
 
-/// Deprecated. See TRITONSERVER_InferenceRequestPriorityU64 instead.
+/// Deprecated. See TRITONSERVER_InferenceRequestPriorityUInt64 instead.
 ///
 /// Get the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
@@ -1077,11 +1077,13 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_InferenceRequestPr
 /// \param inference_request The request object.
 /// \param priority Returns the priority level.
 /// \return a TRITONSERVER_Error indicating success or failure.
-TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_InferenceRequestPriorityU64(
-    struct TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority);
+TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
+TRITONSERVER_InferenceRequestPriorityUInt64(
+    struct TRITONSERVER_InferenceRequest* inference_request,
+    uint64_t* priority);
 
-/// Deprecated. See TRITONSERVER_InferenceRequestSetPriorityU64 instead.
-///  
+/// Deprecated. See TRITONSERVER_InferenceRequestSetPriorityUInt64 instead.
+///
 /// Set the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
 /// model's default priority.
@@ -1101,7 +1103,7 @@ TRITONSERVER_InferenceRequestSetPriority(
 /// \param priority The priority level.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
-TRITONSERVER_InferenceRequestSetPriorityU64(
+TRITONSERVER_InferenceRequestSetPriorityUInt64(
     struct TRITONSERVER_InferenceRequest* inference_request, uint64_t priority);
 
 /// Get the timeout for a request, in microseconds. The default is 0

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1062,7 +1062,7 @@ TRITONSERVER_InferenceRequestSetCorrelationIdString(
 ///  
 /// Get the priority for a request. The default is 0 indicating that
 /// the request does not specify a priority and so will use the
-/// model's default priority. 
+/// model's default priority.
 ///
 /// \param inference_request The request object.
 /// \param priority Returns the priority level.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 22
+#define TRITONSERVER_API_VERSION_MINOR 23
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -63,7 +63,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
     const std::set<int32_t>& preferred_batch_sizes,
     const uint64_t max_queue_delay_microseconds,
     const inference::ModelQueuePolicy& default_queue_policy,
-    const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
+    const uint64_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
     : model_(model), model_instance_(model_instance),
       model_name_(model->Name()),
       dynamic_batching_enabled_(dynamic_batching_enabled),

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -98,7 +98,7 @@ class DynamicBatchScheduler : public Scheduler {
       const std::set<int32_t>& preferred_batch_sizes,
       const uint64_t max_queue_delay_microseconds,
       const inference::ModelQueuePolicy& default_queue_policy,
-      const uint32_t priority_levels,
+      const uint64_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
 
   void BatcherThread(const int nice);

--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -334,7 +334,7 @@ class EnsembleContext {
   uint32_t flags_;
   std::string request_id_;
   InferenceRequest::SequenceId correlation_id_;
-  uint32_t priority_;
+  uint64_t priority_;
   uint64_t timeout_;
 
   // Objects related to the ensemble infer request

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -122,7 +122,7 @@ InferenceRequest::ActualModelVersion() const
 }
 
 void
-InferenceRequest::SetPriority(uint32_t p)
+InferenceRequest::SetPriority(uint64_t p)
 {
   if ((p == 0) || (p > model_raw_->MaxPriorityLevel())) {
     priority_ = model_raw_->DefaultPriorityLevel();

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -305,8 +305,8 @@ class InferenceRequest {
   // request is normalized.
   uint32_t BatchSize() const { return batch_size_; }
 
-  uint32_t Priority() const { return priority_; }
-  void SetPriority(uint32_t p);
+  uint64_t Priority() const { return priority_; }
+  void SetPriority(uint64_t p);
 
   uint64_t TimeoutMicroseconds() const { return timeout_us_; }
   void SetTimeoutMicroseconds(uint64_t t) { timeout_us_ = t; }
@@ -691,7 +691,7 @@ class InferenceRequest {
   uint32_t flags_;
   SequenceId correlation_id_;
   uint32_t batch_size_;
-  uint32_t priority_;
+  uint64_t priority_;
   uint64_t timeout_us_;
   std::string cache_key_ = "";
   // Helper to determine if request was successfully hashed

--- a/src/model.cc
+++ b/src/model.cc
@@ -125,7 +125,7 @@ Model::Init(const bool is_config_provided)
   } else if (config_.has_ensemble_scheduling()) {
     // For ensemble, allow any priority level to pass through
     default_priority_level_ = 0;
-    max_priority_level_ = UINT32_MAX;
+    max_priority_level_ = UINT64_MAX;
   } else {
     default_priority_level_ = 0;
     max_priority_level_ = 0;

--- a/src/model.h
+++ b/src/model.h
@@ -220,9 +220,9 @@ class Model {
   // Stop processing future requests unless they are considered as in-flight.
   void Stop() { scheduler_->Stop(); }
 
-  uint32_t DefaultPriorityLevel() const { return default_priority_level_; }
+  uint64_t DefaultPriorityLevel() const { return default_priority_level_; }
 
-  uint32_t MaxPriorityLevel() const { return max_priority_level_; }
+  uint64_t MaxPriorityLevel() const { return max_priority_level_; }
 
  protected:
   virtual std::map<TRITONSERVER_MemoryType, std::map<int64_t, size_t>>
@@ -273,10 +273,10 @@ class Model {
   std::string model_dir_;
 
   // The default priority level for the model.
-  uint32_t default_priority_level_;
+  uint64_t default_priority_level_;
 
   // The largest priority value for the model.
-  uint32_t max_priority_level_;
+  uint64_t max_priority_level_;
 
   // Whether or not model config has been set.
   bool set_model_config_;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1856,6 +1856,7 @@ ValidateModelConfigInt64()
       "ModelConfig::dynamic_batching::priority_queue_policy::value::default_"
       "timeout_microseconds",
       "ModelConfig::dynamic_batching::priority_levels",
+      "ModelConfig::dynamic_batching::priority_queue_policy::key",
       "ModelConfig::dynamic_batching::default_priority_level",
       "ModelConfig::sequence_batching::direct::max_queue_delay_microseconds",
       "ModelConfig::sequence_batching::state::dims",
@@ -2068,6 +2069,9 @@ ModelConfigToJson(
   // Fix dynamic_batching::max_queue_delay_microseconds,
   // dynamic_batching::default_queue_policy::default_timeout_microseconds,
   // dynamic_batching::priority_queue_policy::value::default_timeout_microseconds
+  // dynamic_batching::priority_levels
+  // dynamic_batching::default_priority_level
+  // dynamic_batching::priority_queue_policy::key is left as JSON only allows strings for keys
   {
     triton::common::TritonJson::Value db;
     if (config_json.Find("dynamic_batching", &db)) {
@@ -2089,21 +2093,6 @@ ModelConfigToJson(
           RETURN_IF_ERROR(pqp.MemberAsObject(m.c_str(), &el));
           RETURN_IF_ERROR(
               FixUInt(config_json, el, "default_timeout_microseconds"));
-
-	  uint64_t index;
-
-	  try {
-	    index = std::strtoull(m.c_str(),nullptr,10);
-	  }
-	  catch (...) {
-	    return Status(
-			  Status::Code::INTERNAL,
-			  (std::string("unable to convert '") + m + "' to unsigned integer"));
-	  }
-
-	  pqp.Add(index,std::move(el));
-	  pqp.Remove(m.c_str());
-	  
         }
       }
     }

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1855,6 +1855,8 @@ ValidateModelConfigInt64()
       "microseconds",
       "ModelConfig::dynamic_batching::priority_queue_policy::value::default_"
       "timeout_microseconds",
+      "ModelConfig::dynamic_batching::priority_levels",
+      "ModelConfig::dynamic_batching::default_priority_level",
       "ModelConfig::sequence_batching::direct::max_queue_delay_microseconds",
       "ModelConfig::sequence_batching::state::dims",
       "ModelConfig::sequence_batching::state::initial_state::dims",
@@ -1871,6 +1873,34 @@ ValidateModelConfigInt64()
     return Status(
         Status::Code::INTERNAL, "ModelConfig 64-bit field needs update");
   }
+
+  return Status::Success;
+}
+
+Status
+FixUInt(
+    triton::common::TritonJson::Value& document,
+    triton::common::TritonJson::Value& io, const std::string& name)
+{
+  triton::common::TritonJson::Value str_value;
+  if (!io.Find(name.c_str(), &str_value)) {
+    return Status::Success;
+  }
+
+  std::string str;
+  RETURN_IF_ERROR(str_value.AsString(&str));
+
+  uint64_t d;
+  try {
+    d = std::strtoull(str.c_str(),nullptr,10);
+  }
+  catch (...) {
+    return Status(
+        Status::Code::INTERNAL,
+        (std::string("unable to convert '") + str + "' to unsigned integer"));
+  }
+
+  str_value.SetUInt(d);
 
   return Status::Success;
 }
@@ -2041,11 +2071,13 @@ ModelConfigToJson(
   {
     triton::common::TritonJson::Value db;
     if (config_json.Find("dynamic_batching", &db)) {
-      RETURN_IF_ERROR(FixInt(config_json, db, "max_queue_delay_microseconds"));
+      RETURN_IF_ERROR(FixUInt(config_json, db, "max_queue_delay_microseconds"));
+      RETURN_IF_ERROR(FixUInt(config_json, db, "priority_levels"));
+      RETURN_IF_ERROR(FixUInt(config_json, db, "default_priority_level"));
       triton::common::TritonJson::Value dqp;
       if (db.Find("default_queue_policy", &dqp)) {
         RETURN_IF_ERROR(
-            FixInt(config_json, dqp, "default_timeout_microseconds"));
+            FixUInt(config_json, dqp, "default_timeout_microseconds"));
       }
       triton::common::TritonJson::Value pqp;
       if (db.Find("priority_queue_policy", &pqp)) {
@@ -2056,7 +2088,22 @@ ModelConfigToJson(
           triton::common::TritonJson::Value el;
           RETURN_IF_ERROR(pqp.MemberAsObject(m.c_str(), &el));
           RETURN_IF_ERROR(
-              FixInt(config_json, el, "default_timeout_microseconds"));
+              FixUInt(config_json, el, "default_timeout_microseconds"));
+
+	  uint64_t index;
+
+	  try {
+	    index = std::strtoull(m.c_str(),nullptr,10);
+	  }
+	  catch (...) {
+	    return Status(
+			  Status::Code::INTERNAL,
+			  (std::string("unable to convert '") + m + "' to unsigned integer"));
+	  }
+
+	  pqp.Add(index,std::move(el));
+	  pqp.Remove(m.c_str());
+	  
         }
       }
     }
@@ -2069,16 +2116,16 @@ ModelConfigToJson(
     triton::common::TritonJson::Value sb;
     if (config_json.Find("sequence_batching", &sb)) {
       RETURN_IF_ERROR(
-          FixInt(config_json, sb, "max_sequence_idle_microseconds"));
+          FixUInt(config_json, sb, "max_sequence_idle_microseconds"));
       triton::common::TritonJson::Value oldest;
       if (sb.Find("oldest", &oldest)) {
         RETURN_IF_ERROR(
-            FixInt(config_json, oldest, "max_queue_delay_microseconds"));
+            FixUInt(config_json, oldest, "max_queue_delay_microseconds"));
       }
       triton::common::TritonJson::Value direct;
       if (sb.Find("direct", &direct)) {
         RETURN_IF_ERROR(
-            FixInt(config_json, direct, "max_queue_delay_microseconds"));
+            FixUInt(config_json, direct, "max_queue_delay_microseconds"));
       }
 
       triton::common::TritonJson::Value states;

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -264,7 +264,7 @@ PriorityQueue::PriorityQueue()
 
 PriorityQueue::PriorityQueue(
     const inference::ModelQueuePolicy& default_queue_policy,
-    uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
+    uint64_t priority_levels, const ModelQueuePolicyMap queue_policy_map)
     : size_(0), default_policy_(default_queue_policy)
 {
   // Permanently instantiate PolicyQueue with keep_instantiate=true
@@ -286,7 +286,7 @@ PriorityQueue::PriorityQueue(
 
 Status
 PriorityQueue::Enqueue(
-    uint32_t priority_level, std::unique_ptr<InferenceRequest>& request)
+    uint64_t priority_level, std::unique_ptr<InferenceRequest>& request)
 {
   // Get corresponding PolicyQueue if it exists, otherwise insert it
   // via emplace with the default policy

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -277,7 +277,7 @@ PriorityQueue::PriorityQueue(
     // permanently add default PolicyQueue because those will be dynamically
     // created and erased to keep memory footprint low
     for (const auto& qp : queue_policy_map) {
-      queues_.emplace((uint32_t)qp.first, PolicyQueue(qp.second, true));
+      queues_.emplace(qp.first, PolicyQueue(qp.second, true));
     }
   }
   front_priority_level_ = queues_.empty() ? 0 : queues_.begin()->first;

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -70,7 +70,7 @@ class PriorityQueue {
   // 'queue_policy_map', otherwise, the 'default_queue_policy' will be used.
   PriorityQueue(
       const inference::ModelQueuePolicy& default_queue_policy,
-      uint32_t priority_levels, const ModelQueuePolicyMap queue_policy_map);
+      uint64_t priority_levels, const ModelQueuePolicyMap queue_policy_map);
 
   // Enqueue a request with priority set to 'priority_level'. If
   // Status::Success is returned then the queue has taken ownership of
@@ -78,7 +78,7 @@ class PriorityQueue {
   // non-success is returned then the caller still retains ownership
   // of 'request'.
   Status Enqueue(
-      uint32_t priority_level, std::unique_ptr<InferenceRequest>& request);
+      uint64_t priority_level, std::unique_ptr<InferenceRequest>& request);
 
   // Dequeue the request at the front of the queue.
   Status Dequeue(std::unique_ptr<InferenceRequest>* request);
@@ -229,7 +229,7 @@ class PriorityQueue {
     std::deque<std::unique_ptr<InferenceRequest>> delayed_queue_;
     std::deque<std::unique_ptr<InferenceRequest>> rejected_queue_;
   };
-  using PriorityQueues = std::map<uint32_t, PolicyQueue>;
+  using PriorityQueues = std::map<uint64_t, PolicyQueue>;
 
   // Cursor for tracking pending batch, the cursor points to the item after
   // the pending batch.
@@ -254,7 +254,7 @@ class PriorityQueue {
 
   // Keep track of the priority level that the first request in the queue
   // is at to avoid traversing 'queues_'
-  uint32_t front_priority_level_;
+  uint64_t front_priority_level_;
   inference::ModelQueuePolicy default_policy_;
 
   Cursor pending_cursor_;

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -57,7 +57,7 @@ struct RequiredEqualInputs {
 // PriorityQueue
 //
 using ModelQueuePolicyMap = ::google::protobuf::Map<
-    ::google::protobuf::uint32, inference::ModelQueuePolicy>;
+    ::google::protobuf::uint64, inference::ModelQueuePolicy>;
 
 class PriorityQueue {
  public:

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1693,8 +1693,9 @@ TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestPriority(
     TRITONSERVER_InferenceRequest* inference_request, uint32_t* priority)
 {
-  uint64_t temp;  
-  auto error = TRITONSERVER_InferenceRequestPriorityU64(inference_request, &temp);
+  uint64_t temp;
+  auto error =
+      TRITONSERVER_InferenceRequestPriorityUInt64(inference_request, &temp);
   if (error != nullptr) {
     return error;
   }
@@ -1702,14 +1703,16 @@ TRITONSERVER_InferenceRequestPriority(
     *priority = temp;
     return nullptr; // Success
   }
-  return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG,
-			       (std::string(
-				   "request priority overflows uint32_t, priority=") +
-				std::to_string(temp)).c_str());
+  return TRITONSERVER_ErrorNew(
+      TRITONSERVER_ERROR_INVALID_ARG,
+      (std::string("request priority overflows uint32_t, use "
+                   "TRITONSERVER_InferenceRequestPriorityUInt64, priority=") +
+       std::to_string(temp))
+          .c_str());
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_InferenceRequestPriorityU64(
+TRITONSERVER_InferenceRequestPriorityUInt64(
     TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority)
 {
   tc::InferenceRequest* lrequest =
@@ -1722,11 +1725,12 @@ TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetPriority(
     TRITONSERVER_InferenceRequest* inference_request, uint32_t priority)
 {
-  return TRITONSERVER_InferenceRequestSetPriorityU64(inference_request, priority);
+  return TRITONSERVER_InferenceRequestSetPriorityUInt64(
+      inference_request, priority);
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_InferenceRequestSetPriorityU64(
+TRITONSERVER_InferenceRequestSetPriorityUInt64(
     TRITONSERVER_InferenceRequest* inference_request, uint64_t priority)
 {
   tc::InferenceRequest* lrequest =

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1700,8 +1700,25 @@ TRITONSERVER_InferenceRequestPriority(
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_InferenceRequestPriorityU64(
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t* priority)
+{
+  tc::InferenceRequest* lrequest =
+      reinterpret_cast<tc::InferenceRequest*>(inference_request);
+  *priority = lrequest->Priority();
+  return nullptr;  // Success
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_InferenceRequestSetPriority(
     TRITONSERVER_InferenceRequest* inference_request, uint32_t priority)
+{
+  return TRITONSERVER_InferenceRequestSetPriorityU64(inference_request,priority);
+}
+
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_InferenceRequestSetPriorityU64(
+    TRITONSERVER_InferenceRequest* inference_request, uint64_t priority)
 {
   tc::InferenceRequest* lrequest =
       reinterpret_cast<tc::InferenceRequest*>(inference_request);

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1699,16 +1699,16 @@ TRITONSERVER_InferenceRequestPriority(
   if (error != nullptr) {
     return error;
   }
-  if (temp <= std::numeric_limits<uint32_t>::max()) {
-    *priority = temp;
-    return nullptr; // Success
+  if (temp > std::numeric_limits<uint32_t>::max()) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        (std::string("request priority overflows uint32_t, use "
+                     "TRITONSERVER_InferenceRequestPriorityUInt64, priority=") +
+         std::to_string(temp))
+            .c_str());
   }
-  return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_INVALID_ARG,
-      (std::string("request priority overflows uint32_t, use "
-                   "TRITONSERVER_InferenceRequestPriorityUInt64, priority=") +
-       std::to_string(temp))
-          .c_str());
+  *priority = temp;
+  return nullptr;  // Success
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -222,7 +222,7 @@ TRITONSERVER_InferenceRequestPriority()
 {
 }
 TRITONAPI_DECLSPEC void
-TRITONSERVER_InferenceRequestPriorityU64()
+TRITONSERVER_InferenceRequestPriorityUInt64()
 {
 }
 TRITONAPI_DECLSPEC void
@@ -230,7 +230,7 @@ TRITONSERVER_InferenceRequestSetPriority()
 {
 }
 TRITONAPI_DECLSPEC void
-TRITONSERVER_InferenceRequestSetPriorityU64()
+TRITONSERVER_InferenceRequestSetPriorityUInt64()
 {
 }
 TRITONAPI_DECLSPEC void

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -222,7 +222,15 @@ TRITONSERVER_InferenceRequestPriority()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_InferenceRequestPriorityU64()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_InferenceRequestSetPriority()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONSERVER_InferenceRequestSetPriorityU64()
 {
 }
 TRITONAPI_DECLSPEC void


### PR DESCRIPTION
Updating request priority apis to support uint64.

See discussion here https://github.com/triton-inference-server/common/pull/82#issuecomment-1547650136.

Major changes:

- Add TRITONSERVER_InferenceRequestPriorityUint64
- Add TRITONSERVER_InferenceRequestSetPriorityUint64
- Update handling of uint64 fields in model config to json
- Add error handling for overflow