### PR TITLE
Affix S3 client to use HTTP 1.1 only

### DIFF
--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -61,7 +61,8 @@ class S3CurlHttpClient : public Aws::Http::CurlHttpClient {
  protected:
   void OverrideOptionsOnConnectionHandle(CURL* connectionHandle) const override
   {
-    curl_easy_setopt(connectionHandle, CURLOPT_HTTP_VERSION, 2L);  // HTTP 1.1
+    curl_easy_setopt(
+        connectionHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
   }
 };
 class S3HttpClientFactory : public Aws::Http::HttpClientFactory {

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -31,11 +31,9 @@
 #include <aws/core/auth/AWSCredentialsProvider.h>
 
 // [FIXME: DLIS-4973]
-#ifndef _WIN32
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/http/curl/CurlHttpClient.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
-#endif
 
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
@@ -51,7 +49,6 @@ namespace s3 = Aws::S3;
 // Remove once s3 fully supports HTTP/2 [FIXME: DLIS-4973].
 // Reference:
 // https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/cpp/example_code/s3/list_buckets_disabling_dns_cache.cpp
-#ifndef _WIN32
 static const char S3_ALLOCATION_TAG[] = "OverrideDefaultHttpClient";
 class S3CurlHttpClient : public Aws::Http::CurlHttpClient {
  public:
@@ -91,7 +88,6 @@ class S3HttpClientFactory : public Aws::Http::HttpClientFactory {
   void InitStaticState() override { S3CurlHttpClient::InitGlobalState(); }
   void CleanupStaticState() override { S3CurlHttpClient::CleanupGlobalState(); }
 };
-#endif
 
 struct S3Credential {
   std::string secret_key_;
@@ -284,10 +280,8 @@ S3FileSystem::S3FileSystem(
   std::call_once(onceFlag, [&options] { Aws::InitAPI(options); });
 
   // [FIXME: DLIS-4973]
-#ifndef _WIN32
   Aws::Http::SetHttpClientFactory(
       Aws::MakeShared<S3HttpClientFactory>(S3_ALLOCATION_TAG));
-#endif
 
   Aws::Client::ClientConfiguration config;
   Aws::Auth::AWSCredentials credentials;

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -29,6 +29,14 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+
+// [FIXME: DLIS-4973]
+#ifndef _WIN32
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/curl/CurlHttpClient.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#endif
+
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadBucketRequest.h>
@@ -38,6 +46,52 @@
 namespace triton { namespace core {
 
 namespace s3 = Aws::S3;
+
+// Override the default S3 Curl initialization for disabling HTTP/2 on s3.
+// Remove once s3 fully supports HTTP/2 [FIXME: DLIS-4973].
+// Reference:
+// https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/cpp/example_code/s3/list_buckets_disabling_dns_cache.cpp
+#ifndef _WIN32
+static const char S3_ALLOCATION_TAG[] = "OverrideDefaultHttpClient";
+class S3CurlHttpClient : public Aws::Http::CurlHttpClient {
+ public:
+  explicit S3CurlHttpClient(
+      const Aws::Client::ClientConfiguration& client_config)
+      : Aws::Http::CurlHttpClient(client_config)
+  {
+  }
+
+ protected:
+  void OverrideOptionsOnConnectionHandle(CURL* connectionHandle) const override
+  {
+    curl_easy_setopt(connectionHandle, CURLOPT_HTTP_VERSION, 2L);  // HTTP 1.1
+  }
+};
+class S3HttpClientFactory : public Aws::Http::HttpClientFactory {
+  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+      const Aws::Client::ClientConfiguration& client_config) const override
+  {
+    return Aws::MakeShared<S3CurlHttpClient>(S3_ALLOCATION_TAG, client_config);
+  }
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& stream_factory) const override
+  {
+    return CreateHttpRequest(Aws::Http::URI(uri), method, stream_factory);
+  }
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& stream_factory) const override
+  {
+    auto req = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+        S3_ALLOCATION_TAG, uri, method);
+    req->SetResponseStreamFactory(stream_factory);
+    return req;
+  }
+  void InitStaticState() override { S3CurlHttpClient::InitGlobalState(); }
+  void CleanupStaticState() override { S3CurlHttpClient::CleanupGlobalState(); }
+};
+#endif
 
 struct S3Credential {
   std::string secret_key_;
@@ -228,6 +282,12 @@ S3FileSystem::S3FileSystem(
   Aws::SDKOptions options;
   static std::once_flag onceFlag;
   std::call_once(onceFlag, [&options] { Aws::InitAPI(options); });
+
+  // [FIXME: DLIS-4973]
+#ifndef _WIN32
+  Aws::Http::SetHttpClientFactory(
+      Aws::MakeShared<S3HttpClientFactory>(S3_ALLOCATION_TAG));
+#endif
 
   Aws::Client::ClientConfiguration config;
   Aws::Auth::AWSCredentials credentials;


### PR DESCRIPTION
Server PR: https://github.com/triton-inference-server/server/pull/5911

This PR prevents the s3 sdk curl library from upgrading connections to HTTP 2.