### PR TITLE
Upgrade S3 ListObjects version, allow >1000 model files

### DIFF
--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -501,31 +501,30 @@ S3FileSystem::GetDirectoryContents(
               list_objects_outcome.GetError().GetExceptionName() +
               ", error message: " +
               list_objects_outcome.GetError().GetMessage());
-    } else {
-      const auto& list_objects_result = list_objects_outcome.GetResult();
-      for (const auto& s3_object : list_objects_result.GetContents()) {
-        // In the case of empty directories, the directory itself will appear
-        // here
-        if (s3_object.GetKey().c_str() == full_dir) {
-          continue;
-        }
+    }
+    const auto& list_objects_result = list_objects_outcome.GetResult();
+    for (const auto& s3_object : list_objects_result.GetContents()) {
+      // In the case of empty directories, the directory itself will appear
+      // here
+      if (s3_object.GetKey().c_str() == full_dir) {
+        continue;
+      }
 
-        // We have to make sure that subdirectory contents do not appear here
-        std::string name(s3_object.GetKey().c_str());
-        int item_start = name.find(full_dir) + full_dir.size();
-        // S3 response prepends parent directory name
-        int item_end = name.find("/", item_start);
+      // We have to make sure that subdirectory contents do not appear here
+      std::string name(s3_object.GetKey().c_str());
+      int item_start = name.find(full_dir) + full_dir.size();
+      // S3 response prepends parent directory name
+      int item_end = name.find("/", item_start);
 
-        // Let set take care of subdirectory contents
-        std::string item = name.substr(item_start, item_end - item_start);
-        contents->insert(item);
+      // Let set take care of subdirectory contents
+      std::string item = name.substr(item_start, item_end - item_start);
+      contents->insert(item);
 
-        // Fail-safe check to ensure the item name is not empty
-        if (item.empty()) {
-          return Status(
-              Status::Code::INTERNAL,
-              "Cannot handle item with empty name at " + true_path);
-        }
+      // Fail-safe check to ensure the item name is not empty
+      if (item.empty()) {
+        return Status(
+            Status::Code::INTERNAL,
+            "Cannot handle item with empty name at " + true_path);
       }
       // If there are more pages to retrieve, set the marker to the next page.
       if (list_objects_result.GetIsTruncated()) {

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -493,7 +493,15 @@ S3FileSystem::GetDirectoryContents(
   while (!done_listing) {
     auto list_objects_outcome = client_->ListObjectsV2(objects_request);
 
-    if (list_objects_outcome.IsSuccess()) {
+    if (!list_objects_outcome.IsSuccess()) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Could not list contents of directory at " + true_path +
+              " due to exception: " +
+              list_objects_outcome.GetError().GetExceptionName() +
+              ", error message: " +
+              list_objects_outcome.GetError().GetMessage());
+    } else {
       const auto& list_objects_result = list_objects_outcome.GetResult();
       for (const auto& s3_object : list_objects_result.GetContents()) {
         // In the case of empty directories, the directory itself will appear
@@ -526,14 +534,6 @@ S3FileSystem::GetDirectoryContents(
       } else {
         done_listing = true;
       }
-    } else {
-      return Status(
-          Status::Code::INTERNAL,
-          "Could not list contents of directory at " + true_path +
-              " due to exception: " +
-              list_objects_outcome.GetError().GetExceptionName() +
-              ", error message: " +
-              list_objects_outcome.GetError().GetMessage());
     }
   }
   return Status::Success;

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -38,8 +38,8 @@
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
-#include <aws/s3/model/ListObjectsOutcome.h>
 #include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/Object.h>
 
 namespace triton { namespace core {
 
@@ -495,7 +495,7 @@ S3FileSystem::GetDirectoryContents(
 
     if (list_objects_outcome.IsSuccess()) {
       const auto& list_objects_result = list_objects_outcome.GetResult();
-      for (const auto& s3_object : list_objects_result.getContents()) {
+      for (const auto& s3_object : list_objects_result.GetContents()) {
         // In the case of empty directories, the directory itself will appear
         // here
         if (s3_object.GetKey().c_str() == full_dir) {

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -526,13 +526,13 @@ S3FileSystem::GetDirectoryContents(
             Status::Code::INTERNAL,
             "Cannot handle item with empty name at " + true_path);
       }
-      // If there are more pages to retrieve, set the marker to the next page.
-      if (list_objects_result.GetIsTruncated()) {
-        objects_request.SetContinuationToken(
-            list_objects_result.GetNextContinuationToken());
-      } else {
-        done_listing = true;
-      }
+    }
+    // If there are more pages to retrieve, set the marker to the next page.
+    if (list_objects_result.GetIsTruncated()) {
+      objects_request.SetContinuationToken(
+          list_objects_result.GetNextContinuationToken());
+    } else {
+      done_listing = true;
     }
   }
   return Status::Success;

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -39,6 +39,7 @@
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
 #include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/ListObjectsOutcome.h>
 
 namespace triton { namespace core {
 
@@ -487,42 +488,52 @@ S3FileSystem::GetDirectoryContents(
   s3::Model::ListObjectsRequest objects_request;
   objects_request.SetBucket(bucket.c_str());
   objects_request.SetPrefix(full_dir.c_str());
-  auto list_objects_outcome = client_->ListObjects(objects_request);
 
-  if (list_objects_outcome.IsSuccess()) {
-    Aws::Vector<Aws::S3::Model::Object> object_list =
-        list_objects_outcome.GetResult().GetContents();
-    for (auto const& s3_object : object_list) {
-      // In the case of empty directories, the directory itself will appear here
-      if (s3_object.GetKey().c_str() == full_dir) {
-        continue;
-      }
+    bool done_listing = false;
+    while (!done_listing)
+    {
+      auto list_objects_outcome = client_->ListObjects(objects_request);
 
-      // We have to make sure that subdirectory contents do not appear here
-      std::string name(s3_object.GetKey().c_str());
-      int item_start = name.find(full_dir) + full_dir.size();
-      // S3 response prepends parent directory name
-      int item_end = name.find("/", item_start);
+      if (list_objects_outcome.IsSuccess()) {
+        const auto& list_objects_result = list_objects_outcome.GetResult();
+        for (const auto& s3_object : list_objects_result.getContents()) {
+          // In the case of empty directories, the directory itself will appear here
+          if (s3_object.GetKey().c_str() == full_dir) {
+            continue;
+          }
 
-      // Let set take care of subdirectory contents
-      std::string item = name.substr(item_start, item_end - item_start);
-      contents->insert(item);
+          // We have to make sure that subdirectory contents do not appear here
+          std::string name(s3_object.GetKey().c_str());
+          int item_start = name.find(full_dir) + full_dir.size();
+          // S3 response prepends parent directory name
+          int item_end = name.find("/", item_start);
 
-      // Fail-safe check to ensure the item name is not empty
-      if (item.empty()) {
+          // Let set take care of subdirectory contents
+          std::string item = name.substr(item_start, item_end - item_start);
+          contents->insert(item);
+
+          // Fail-safe check to ensure the item name is not empty
+          if (item.empty()) {
+            return Status(
+                Status::Code::INTERNAL,
+                "Cannot handle item with empty name at " + true_path);
+          }
+        }
+        // If there are more pages to retrieve, set the marker to the next page.
+        if(list_objects_result.GetIsTruncated()){
+          objects_request.WithMarker(list_objects_result.GetNextMarker());
+        } else {
+          done_listing = true;
+        }
+      } else {
         return Status(
             Status::Code::INTERNAL,
-            "Cannot handle item with empty name at " + true_path);
+            "Could not list contents of directory at " + true_path +
+                " due to exception: " +
+                list_objects_outcome.GetError().GetExceptionName() +
+                ", error message: " + list_objects_outcome.GetError().GetMessage());
       }
     }
-  } else {
-    return Status(
-        Status::Code::INTERNAL,
-        "Could not list contents of directory at " + true_path +
-            " due to exception: " +
-            list_objects_outcome.GetError().GetExceptionName() +
-            ", error message: " + list_objects_outcome.GetError().GetMessage());
-  }
   return Status::Success;
 }
 

--- a/src/filesystem/implementations/s3.h
+++ b/src/filesystem/implementations/s3.h
@@ -521,7 +521,8 @@ S3FileSystem::GetDirectoryContents(
       }
       // If there are more pages to retrieve, set the marker to the next page.
       if (list_objects_result.GetIsTruncated()) {
-        objects_request.SetContinuationToken(list_objects_result.GetNextContinuationToken());
+        objects_request.SetContinuationToken(
+            list_objects_result.GetNextContinuationToken());
       } else {
         done_listing = true;
       }


### PR DESCRIPTION
This PR upgrades the version of ListObjectsRequest and ListObjectsResult, as per AWS recommendations [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html) to switch to V2. It also enables Triton to load all files in an S3 bucket, beyond the [page limit of 1000](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html).