### PR TITLE
Modify ensemble to better reflect composing model response pattern

### DIFF
--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -669,7 +669,7 @@ EnsembleContext::ConsumeResponse(const std::unique_ptr<Step>& completed_step)
         if (type != TRITONSERVER_PARAMETER_BOOL) {
           RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INVALID_ARG,
-              "expect paremeter 'sequence_start' to be "
+              "expect parameter 'sequence_start' to be "
               "TRITONSERVER_PARAMETER_BOOL"));
         } else {
           if (*reinterpret_cast<const bool*>(vvalue)) {
@@ -681,7 +681,7 @@ EnsembleContext::ConsumeResponse(const std::unique_ptr<Step>& completed_step)
         if (type != TRITONSERVER_PARAMETER_BOOL) {
           RETURN_IF_TRITONSERVER_ERROR(TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INVALID_ARG,
-              "expect paremeter 'sequence_end' to be "
+              "expect parameter 'sequence_end' to be "
               "TRITONSERVER_PARAMETER_BOOL"));
         } else {
           if (*reinterpret_cast<const bool*>(vvalue)) {


### PR DESCRIPTION
Previously ensemble will detect "decoupled" field and send responses that may not reflect the composing model's response pattern, i.e.:
if the composing model sends response and response complete flag separately,
```
TRITONBACKEND_ResponseSend(response, 0, nullptr /* success */);
TRITONBACKEND_ResponseFactorySendFlags(factory, TRITONSERVER_RESPONSE_COMPLETE_FINAL);
```
ensemble may send one response with the flag set or follow the same pattern, depending on whether "decoupled" is set in model config.

With this change the behavior will be more determined. And it reduces special handling in ensemble w.r.t. "decoupled" field in model config, which is meant to be used in server frontend (HTTP / gRPC).