### PR TITLE
Fix InstanceGroup normalization when using backend attributes

### DIFF
--- a/src/backend_manager.cc
+++ b/src/backend_manager.cc
@@ -317,8 +317,7 @@ static std::weak_ptr<TritonBackendManager> backend_manager_;
 static std::mutex mu_;
 
 Status
-TritonBackendManager::Create(
-    std::shared_ptr<TritonBackendManager>* manager)
+TritonBackendManager::Create(std::shared_ptr<TritonBackendManager>* manager)
 {
   std::lock_guard<std::mutex> lock(mu_);
 

--- a/src/backend_manager.h
+++ b/src/backend_manager.h
@@ -25,14 +25,15 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <list>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <list>
-#include "filesystem/api.h"
+
 #include "backend_config.h"
 #include "constants.h"
+#include "filesystem/api.h"
 #include "server_message.h"
 #include "status.h"
 #include "triton/common/model_config.h"
@@ -155,8 +156,7 @@ class TritonBackend {
 //
 class TritonBackendManager {
  public:
-  static Status Create(
-      std::shared_ptr<TritonBackendManager>* manager);
+  static Status Create(std::shared_ptr<TritonBackendManager>* manager);
 
   Status CreateBackend(
       const std::string& name, const std::string& dir,

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -751,6 +751,8 @@ NormalizeInstanceGroup(
       if (pg.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         // Don't use preferred group with KIND_GPU if there is no GPU.
         if (supported_gpus.empty()) {
+          group->set_kind(inference::ModelInstanceGroup::KIND_AUTO);
+          group->set_count(0);
           continue;
         }
         // If preferred group sets GPUs, limit deployment onto those that

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -745,14 +745,10 @@ NormalizeInstanceGroup(
     group->set_name(config->name());
 
     for (const auto& pg : preferred_groups) {
-      group->set_kind(pg.kind());
-      group->set_count(pg.count());
       // handle preferred GPU setting differently based on kind
       if (pg.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         // Don't use preferred group with KIND_GPU if there is no GPU.
         if (supported_gpus.empty()) {
-          group->set_kind(inference::ModelInstanceGroup::KIND_AUTO);
-          group->set_count(0);
           continue;
         }
         // If preferred group sets GPUs, limit deployment onto those that
@@ -764,16 +760,17 @@ NormalizeInstanceGroup(
             }
           }
         }
-        break;
       } else if (pg.kind() == inference::ModelInstanceGroup::KIND_AUTO) {
         // if AUTO, then set preferred GPU as is, to align with KIND_AUTO
         // deduction specified below
         for (const int32_t gid : pg.gpus()) {
           group->add_gpus(gid);
         }
-        break;
       }
-      // Other kind should not set GPUs
+      group->set_kind(pg.kind());
+      group->set_count(pg.count());
+
+      // Found a valid preferred group.
       break;
     }
   }

--- a/src/server.cc
+++ b/src/server.cc
@@ -145,8 +145,7 @@ InferenceServer::Init()
   }
 
   // BackendManager
-  status = TritonBackendManager::Create(
-      &backend_manager_);
+  status = TritonBackendManager::Create(&backend_manager_);
   if (!status.IsOk()) {
     ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
     return status;

--- a/src/server.h
+++ b/src/server.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+
 #include "backend_manager.h"
 #include "cache_manager.h"
 #include "infer_parameter.h"


### PR DESCRIPTION
The change resets the kind setting from the instance group being auto-completed, if the preferred group is not supported because of unavailable GPUs.

On CPU only machines:

### Before
UNAVAILABLE: Invalid argument: instance group resnet_v1_50_savedmodel of model resnet_v1_50_savedmodel has kind KIND_GPU but no GPUs are available

### After
Model loads properly.