### PR TITLE
Check the correct container during writeback

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -2156,10 +2156,10 @@ ModelRepositoryManager::DependencyGraph::Writeback(
   for (const auto& model_id : affected_models) {
     // An affected model can be deleted, so the presence of the model must be
     // checked.
-    auto node = FindNode(model_id, false /* allow_fuzzy_matching */);
-    if (node != nullptr) {
-      auto updated_node = updated_dependency_graph.FindNode(
-          model_id, false /* allow_fuzzy_matching */);
+    auto* updated_node = updated_dependency_graph.FindNode(
+        model_id, false /* allow_fuzzy_matching */);
+    if (updated_node != nullptr) {
+      auto* node = FindNode(model_id, false /* allow_fuzzy_matching */);
       // Writeback
       node->status_ = updated_node->status_;
       node->checked_ = updated_node->checked_;
@@ -2195,10 +2195,10 @@ ModelRepositoryManager::ModelInfoMap::Writeback(
   for (auto& model_id : affected_models) {
     // An affected model can be deleted, so the presence of the model must be
     // checked.
-    auto itr = map_.find(model_id);
-    if (itr != map_.end()) {
-      auto info = itr->second.get();
-      auto updated_info = updated_model_info.map_.at(model_id).get();
+    auto itr = updated_model_info.map_.find(model_id);
+    if (itr != updated_model_info.map_.end()) {
+      auto* updated_info = itr->second.get();
+      auto* info = map_.at(model_id).get();
       // Writeback
       info->mtime_nsec_ = updated_info->mtime_nsec_;
     }


### PR DESCRIPTION
When a model is deleted, it is deleted from both current set and update set. The existing check during writeback is on the current set, which is largely correct, but another model load thread may load the exact same model during delete, which will write the model identifier into the current set. If the delete thread sees the "deleted" model on the current set, it can cause undefined behavior. Thus, this PR modifies the writeback to check the update set, which cannot be modified by any other threads, and resolves the undefined behavior.

Different cases, if the model is:
1. On both current and update set
    - The model is being updated, and other threads will be blocked from updating it.
2. On current set, but not update set
    - The model is being updated by another thread (or completed update), so do not touch it.
3. Not on current set, but on update set
    - Invalid. The model on update set implies it is being updated, so it must also be on current set to block other threads from updating it.
4. Not on current or update set
    - Unknown model.

In other words, this PR fixes the issue from number 2. Given number 3 is invalid, so there is no further behavior change aside from the fix.