### PR TITLE
Disable pre-fetching when using queue policy

### DIFF
--- a/src/instance_queue.h
+++ b/src/instance_queue.h
@@ -45,6 +45,11 @@ class InstanceQueue {
       std::shared_ptr<Payload>* payload,
       std::vector<std::shared_ptr<Payload>>* merged_payloads);
 
+  void IncrementConsumerCount();
+  void DecrementConsumerCount();
+  void WaitForConsumer();
+  int WaitingConsumerCount();
+
  private:
   size_t max_batch_size_;
   uint64_t max_queue_delay_ns_;
@@ -52,6 +57,10 @@ class InstanceQueue {
   std::deque<std::shared_ptr<Payload>> payload_queue_;
   std::shared_ptr<Payload> staged_payload_;
   std::mutex mu_;
+
+  int waiting_consumer_count_;
+  std::mutex waiting_consumer_mu_;
+  std::condition_variable waiting_consumer_cv_;
 };
 
 }}  // namespace triton::core

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -91,7 +91,14 @@ class RateLimiter {
   void UnregisterModel(const TritonModel* model);
 
   /// Returns true if there is a payload slot available for the given model.
-  /// \param model The pointer to TritonModel object to be removed.
+  /// Note the function can be a blocking call when support_prefetching is
+  /// false. In this case, the function will block until a slot is available to
+  /// start building the payload. force_non_blocking option can be set to True
+  /// to allow function to return back with availability. \param model The
+  /// pointer to TritonModel object to query for . \param model_instance The
+  /// pointer to TritonMode \param support_prefetching Whether or not
+  /// pre-fetching of payloads is enabled. \param force_non_blocking When set
+  /// true, function will not block for for the avialability of the slot.
   /// \return slot availability in boolean.
   bool PayloadSlotAvailable(
       const TritonModel* model, const TritonModelInstance* model_instance,

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -93,7 +93,9 @@ class RateLimiter {
   /// Returns true if there is a payload slot available for the given model.
   /// \param model The pointer to TritonModel object to be removed.
   /// \return slot availability in boolean.
-  bool PayloadSlotAvailable(const TritonModel* model);
+  bool PayloadSlotAvailable(
+      const TritonModel* model, const TritonModelInstance* model_instance,
+      const bool support_prefetching, const bool force_non_blocking = false);
 
   /// Enqueues the payload to rate limiter for scheduling on the given model.
   /// \param model The pointer to TritonModel object to be removed.
@@ -280,6 +282,17 @@ class RateLimiter {
   // Initializes payload queues for the given model instance. The queue
   // holds payloads that get scheduled by rate limiter.
   void InitializePayloadQueues(const TritonModelInstance* instance);
+
+  // Should wait till a consumer registers a pending dequeue request
+  // for the given instance(s) of the model. This implies that the
+  // call will wait for an idle runner.
+  void WaitForConsumer(
+      const TritonModel* model, const TritonModelInstance* model_instance);
+  // Returns the number of consumers who have a pending dequeue request for
+  // the given instance(s) of the model.
+  int WaitingConsumerCount(
+      const TritonModel* model, const TritonModelInstance* model_instance);
+
   // Defers scheduling of the payload to the future. Rate Limiter will
   // schedule the payload execution based upon the resource availability/
   // Note that OnSchedule function should only schedule(enqueued in payload

--- a/src/rate_limiter.h
+++ b/src/rate_limiter.h
@@ -94,11 +94,13 @@ class RateLimiter {
   /// Note the function can be a blocking call when support_prefetching is
   /// false. In this case, the function will block until a slot is available to
   /// start building the payload. force_non_blocking option can be set to True
-  /// to allow function to return back with availability. \param model The
-  /// pointer to TritonModel object to query for . \param model_instance The
-  /// pointer to TritonMode \param support_prefetching Whether or not
-  /// pre-fetching of payloads is enabled. \param force_non_blocking When set
-  /// true, function will not block for for the avialability of the slot.
+  /// to allow function to return back with availability.
+  /// \param model The pointer to TritonModel object to query for.
+  /// \param model_instance The pointer to TritonMode
+  /// \param support_prefetching Whether or not pre-fetching of payloads is
+  /// enabled.
+  /// \param force_non_blocking When set true, function will not block for
+  /// the availability of the slot.
   /// \return slot availability in boolean.
   bool PayloadSlotAvailable(
       const TritonModel* model, const TritonModelInstance* model_instance,

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -273,6 +273,10 @@ PriorityQueue::PriorityQueue(
   if (priority_levels == 0) {
     // Only default policy is instantiated
     queues_.emplace(0, PolicyQueue(default_policy_, true));
+    support_prefetching_ =
+        (default_policy_.default_timeout_microseconds() == 0) &&
+        (!default_policy_.allow_timeout_override()) &&
+        (default_policy_.max_queue_size() == 0);
   } else {
     // All priorities with user-given policy are instantiated. We do not
     // permanently add default PolicyQueue because those will be dynamically
@@ -280,6 +284,7 @@ PriorityQueue::PriorityQueue(
     for (const auto& qp : queue_policy_map) {
       queues_.emplace(qp.first, PolicyQueue(qp.second, true));
     }
+    support_prefetching_ = false;
   }
   front_priority_level_ = queues_.empty() ? 0 : queues_.begin()->first;
   ResetCursor();

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -148,6 +148,9 @@ class PriorityQueue {
   // Return the number of requests in pending batch.
   size_t PendingBatchCount() { return pending_cursor_.pending_batch_count_; }
 
+  // Whether the queue supports pre-fetching of the requests.
+  bool SupportPrefetching() { return support_prefetching_; }
+
  private:
   class PolicyQueue {
    public:
@@ -260,6 +263,9 @@ class PriorityQueue {
 
   Cursor pending_cursor_;
   Cursor current_mark_;
+
+  // Whether requests can be pre-fetched from the queue.
+  bool support_prefetching_{true};
 };
 
 }}  // namespace triton::core


### PR DESCRIPTION
Disabling pre-fetching so queue policy can be locally applied to the model queue.

Test PR: https://github.com/triton-inference-server/server/pull/6133

Fixes https://github.com/triton-inference-server/server/issues/5783