### PR TITLE
[DO NOT MERGE] Python binding / wrapper look and feel

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,7 +1,10 @@
 # Import higher-level Python wrappers
 from ._common import *
+from ._infer import *
+from ._logger import *
 from ._metrics import *
 from ._server import *
+from ._trace import *
 
 # [FIXME] exposing the actual C API binding below for users who want
 # more customization over what the Python wrapper provides.

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,29 @@
+# Import higher-level Python wrappers
+from ._common import *
+from ._metrics import *
+from ._server import *
+
+# [FIXME] exposing the actual C API binding below for users who want
+# more customization over what the Python wrapper provides.
+# one may invoke the API using bindings.xxx()
+import _pybind as bindings
+
+TARGET_TRITONSERVER_API_VERSION_MAJOR: int = 1
+TARGET_TRITONSERVER_API_VERSION_MINOR: int = 23
+
+# static check of the version, use to make sure the Python binding
+# aligns with the shipped in-process API
+major, minor = version()
+if (major != TARGET_TRITONSERVER_API_VERSION_MAJOR) or (
+        minor < TARGET_TRITONSERVER_API_VERSION_MINOR):
+    raise "The Python binding is generated for incompatible version of the API, target '{}.{}', got '{}.{}'".format(
+        TARGET_TRITONSERVER_API_VERSION_MAJOR,
+        TARGET_TRITONSERVER_API_VERSION_MINOR, major, minor)
+
+# Sanity check for keeping the Python binding up-to-date, should look for
+# this message as part of the pipeline
+if (minor > TARGET_TRITONSERVER_API_VERSION_MINOR):
+    print(
+        "WARNING: The Python binding is generated for an older minor version of the API, target '{}.{}', got '{}.{}'"
+        .format(TARGET_TRITONSERVER_API_VERSION_MAJOR,
+                TARGET_TRITONSERVER_API_VERSION_MINOR, major, minor))

--- a/python/_common.py
+++ b/python/_common.py
@@ -1,0 +1,134 @@
+
+from typing import Tuple
+from enum import Enum
+
+def version() -> Tuple[int, int]:
+    # TRITONSERVER_ApiVersion
+    raise "Not Implemented"
+
+class TritonError(Exception):
+    pass
+
+# Dedicated exception type for different error code
+class TritonErrorUnknown(TritonError):
+    pass
+class TritonErrorInternal(TritonError):
+    pass
+class TritonErrorNotFound(TritonError):
+    pass
+class TritonErrorInvalidArgument(TritonError):
+    pass
+class TritonErrorUnavailable(TritonError):
+    pass
+class TritonErrorUnsupported(TritonError):
+    pass
+class TritonErrorAlreadyExists(TritonError):
+    pass
+
+class InstanceGroupKind(Enum):
+    AUTO: int = 0
+    CPU: int = 1
+    GPU: int = 2
+    MODEL: int = 3
+
+    def __str__(self) -> str:
+        # TRITONSERVER_InstanceGroupKindString
+        raise "Not implemented"
+        return "mock"
+
+class MemoryType(Enum):
+    CPU: int = 0
+    CPU_PINNED: int = 1
+    GPU: int = 2
+
+    def __str__(self) -> str:
+        # TRITONSERVER_MemoryTypeString
+        raise "Not implemented"
+        return "mock"
+
+class DataType(Enum):
+    INVALID: int = 0
+    BOOL: int = 1
+    UINT8: int = 2
+    UINT16: int = 3
+    UINT32: int = 4
+    UINT64: int = 5
+    INT8: int = 6
+    INT16: int = 7
+    INT32: int = 8
+    INT64: int = 9
+    FP16: int = 10
+    FP32: int = 11
+    FP64: int = 12
+    BYTES: int = 13
+    BF16: int = 14
+
+    # 1-1 mapping from DataType to TRITONSERVER_DataType
+    @classmethod
+    def str_to_type(cls, type : str) -> "DataType":
+        # TRITONSERVER_StringToDataType
+        mock_triton_type = 1
+        raise "Not implemented"
+        return DataType(mock_triton_type)
+    
+    def __str__(self) -> str:
+        # TRITONSERVER_DataTypeString
+        raise "Not implemented"
+        return "mock"
+    
+    def byte_size(self) -> int:
+        # TRITONSERVER_DataTypeByteSize
+        raise "Not implemented"
+        return 0
+
+# [FIXME] TRITONSERVER_Parameter will be implicit to the actual API calls
+# [FIXME] Triton API reflection of the error object, not expose to user
+class Code(Enum):
+    UNKNOWN: int = 0
+    INTERNAL: int = 1
+    NOT_FOUND: int = 2
+    INVALID_ARG: int = 3
+    UNAVAILABLE: int = 4
+    UNSUPPORTED: int = 5
+    ALREADY_EXISTS: int = 6
+
+class Error:
+    def __init__(self, triton_error) -> None:
+        self._err = triton_error
+        pass
+    def __del__(self):
+        # TRITONSERVER_ErrorDelete
+        raise "Not implemented"
+
+    @property
+    def code(self) -> Code:
+        # TRITONSERVER_ErrorCode
+        raise "Not implemented"
+    
+    @property
+    def message(self) -> str:
+        # TRITONSERVER_ErrorMessage
+        raise "Not implemented"
+
+def raise_if_triton_error(err: Error = None):
+    match err.code:
+        case Code.UNKNOWN:
+            raise TritonErrorUnknown(err.message)
+        case Code.INTERNAL:
+            raise TritonErrorInternal(err.message)
+        case Code.NOT_FOUND:
+            raise TritonErrorNotFound(err.message)
+        case Code.INVALID_ARG:
+            raise TritonErrorInvalidArgument(err.message)
+        case Code.UNAVAILABLE:
+            raise TritonErrorUnavailable(err.message)
+        case Code.UNSUPPORTED:
+            raise TritonErrorUnsupported(err.message)
+        case Code.ALREADY_EXISTS:
+            raise TritonErrorAlreadyExists(err.message)
+
+def optional_callabck(func):
+    # additional function attribute to be checked when
+    # this module interacts with Triton in-process API.
+    func._triton_callback_not_provided = True
+    return func

--- a/python/_common.py
+++ b/python/_common.py
@@ -81,8 +81,8 @@ class DataType(Enum):
         raise "Not implemented"
         return 0
 
-# [FIXME] TRITONSERVER_Parameter will be implicit to the actual API calls
-# [FIXME] Triton API reflection of the error object, not expose to user
+# [FIXME] Triton API reflection of the error object, not expose to user.
+# User should interact with TritonException above.
 class Code(Enum):
     UNKNOWN: int = 0
     INTERNAL: int = 1
@@ -111,6 +111,8 @@ class Error:
         raise "Not implemented"
 
 def raise_if_triton_error(err: Error = None):
+    if err is None:
+        return
     match err.code:
         case Code.UNKNOWN:
             raise TritonErrorUnknown(err.message)

--- a/python/_infer.py
+++ b/python/_infer.py
@@ -99,16 +99,20 @@ class RequestFlag(IntEnum):
 # Release callback is hidden, user don't need to be exposed to
 # Triton request detail.
 # Variables should not be changed until "consumed", an callback may be
-# provided to be invoked when the request is no longer in used
+# provided to be invoked when the request is no longer in used.
+# Similarly, a response callback may be provided when response has arrived
+# or completed
 class InferenceRequest:
 
     def __init__(self,
                  name: str,
                  version: int = -1,
-                 consumed_callback: Callable = None) -> None:
+                 consumed_callback: Callable = None,
+                 response_callabck: Callable = None) -> None:
         self.name = name
         self.version = version
         self.consumed_callback = consumed_callback
+        self.response_callback = response_callabck
 
         self.request_id: str = ""
         self.timeout_ms: int = 0
@@ -189,6 +193,7 @@ class InferenceResponse:
 #         if isinstance(output, NumpyTensor):
 #             res.append(output.as_numpy())
 #         else:
+#             # May also interact with Tensor attributes directly
 #             res.append(numpy.from_dlpack(output))
 import numpy
 class NumpyTensor(Tensor):

--- a/python/_infer.py
+++ b/python/_infer.py
@@ -1,0 +1,147 @@
+from typing import Any
+from ._common import *
+from enum import IntEnum
+from collections.abc import Iterable, Union, Tuple, Mapping, Callable
+import abc
+import queue
+
+
+# [FIXME] implement dlpack interface, buffer attribute?
+class Tensor:
+
+    def __init__(self) -> None:
+        # buffer attributes..
+        # [FIXME] need to point out where exactly the buffer is managed
+        self.buffer: int = 0
+        self.byte_size: int = 0
+        self.memory_type: Tuple(MemoryType, int) = (MemoryType.CPU, 0)
+        # [FIXME] CUDA specific.. how to / should introduce CUDA dependency?
+        self.cuda_ipc_handle: Any = None
+        self.host_policy_name: str = None
+
+    def __dlpack__(self, stream=None):
+        raise "Not Implemented"
+
+    def __dlpack_device__(self):
+        raise "Not Implemented"
+
+
+class ResponseAllocator(abc.ABC):
+    _allocator: Any = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Create Triton allocator once and for all as
+        # a Triton allocator is collection of callbacks and
+        # can be reused across inference
+        if type(self)._allocator is None:
+            # TRITONSERVER_ResponseAllocatorNew
+            raise "Not Implemented"
+
+    # [FIXME] 'response_allocator_userp' can be enclosed in the derieved
+    # allocator instance.
+    @optional_callabck
+    def start(self):
+        # is TRITONSERVER_ResponseAllocatorStartFn_t
+        raise "Not Implemented"
+
+    # [FIXME] Should tensor be returned? Or a more primal form?
+    # [FIXME] return 'buffer_userp'?
+    @abc.abstractmethod
+    def alloc(self, tensor_name: str,
+              requested_tensor: Tensor) -> Tuple[Tensor, Any]:
+        # is TRITONSERVER_InferenceTraceTensorActivityFn_t
+        raise "Not Implemented"
+
+    @abc.abstractmethod
+    def release(self, tensor: Tensor, buffer_user_object: Any = None):
+        # is TRITONSERVER_ResponseAllocatorReleaseFn_t
+        raise "Not Implemented"
+
+    @optional_callabck
+    def last_alloc(self,
+                   tensor_name: str,
+                   user_object: Any = None,
+                   buffer_user_object: Any = None) -> Tensor:
+        # is TRITONSERVER_ResponseAllocatorBufferAttributesFn_t
+        raise "Not Implemented"
+
+    # [FIXME] pre-alloc? Query the Tensor to be returned if the same parameters
+    # are used for alloc() function. This function may be called to configure
+    # internal optimization in preparation for handling the allocated tensor.
+    @optional_callabck
+    def query(self, tensor: Tensor, tensor_name: str = None) -> Tensor:
+        # is TRITONSERVER_ResponseAllocatorQueryFn_t
+        raise "Not Implemented"
+
+
+class RequestFlag(IntEnum):
+    SEQUENCE_START: int = 1
+    SEQUENCE_END: int = 2
+
+
+# Release callback is hidden, user don't need to be exposed to
+# Triton request detail.
+# Variables should not be changed until "consumed", an callback may be
+# provided to be invoked when the request is no longer in used
+class InferenceRequest:
+
+    def __init__(self,
+                 name: str,
+                 version: int = -1,
+                 consumed_callback: Callable = None) -> None:
+        self.name = name
+        self.version = version
+        self.consumed_callback = consumed_callback
+
+        self.request_id: str = ""
+        self.timeout_ms: int = 0
+        self.priority: int = 0
+        # Sequence..
+        self.request_flag: int = 0
+        self.correlation_id: Union[str, int] = 0
+
+        self.inputs: Mapping[str, Union[Tensor, Any]] = {}
+        self.requested_outputs: set = set()
+        self.parameters: Mapping[str, Union[str, int, bool]] = {}
+
+        self._in_use_count: int = 0
+
+    def consumed(self) -> bool:
+        return self._in_use_count == 0
+
+
+# Returned from infer async, use as receiver of the response or
+# exception that represents the response error. On each retrival of
+# the response, the return value will be
+# Union[InferenceResponse, TritonError, None]
+# [FIXME] Note that response complete flag is hidden from user and it is
+# currently reflected as the "end" state of the handle
+class ResponseHandle(queue.Queue):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._end = False
+
+    def __iter__(self):
+        while not self.exhausted():
+            yield self.get()
+
+    def exhausted(self) -> bool:
+        return self._end and self.empty()
+
+
+# [WIP] manage Triton response -> internally control output validity
+class InferenceResponse:
+
+    def __init__(self, name: str, version: int = -1) -> None:
+        self.name = name
+        self.version = version
+        self.request_id: str = ""
+        self.parameters: Mapping[str, Union[str, int, bool]] = {}
+
+        # Currently the equivalent of
+        # TRITONSERVER_InferenceResponseOutputClassificationLabel
+        # will not be provided. If request, may provide 'top_k_labels'
+        # function that is built on top of the C API.
+        self.outputs: Mapping[str, Tensor] = {}

--- a/python/_logger.py
+++ b/python/_logger.py
@@ -1,0 +1,108 @@
+from enum import Enum
+from collections.abc import Iterable
+
+
+class LogLevel(Enum):
+    INFO: int = 0
+    WARNING: int = 1  # Warn in Triton in-process API
+    ERROR: int = 2
+    VERBOSE: int = 3
+
+
+class LogFormat(Enum):
+    DEFAULT: int = 0
+    ISO8601: int = 1
+
+
+# [WIP] figure out "singleton"
+class GlobalLogger:
+
+    def __init__(self,
+                 format: LogFormat = LogFormat.DEFAULT,
+                 file: str = "") -> None:
+        # Below will raise exception if 'format' is not the proper class
+        format in LogFormat
+        self.format(format)
+        self.file(file)
+
+    # Log APIs
+    def info(self, message: str) -> None:
+        self.log(LogLevel.INFO, message)
+
+    def warning(self, message: str) -> None:
+        self.log(LogLevel.WARNING, message)
+
+    def error(self, message: str) -> None:
+        self.log(LogLevel.ERROR, message)
+
+    def verbose(self, message: str) -> None:
+        self.log(LogLevel.VERBOSE, message)
+
+    # use by handler to "emit" the LogRecord
+    def log(self, level, message) -> None:
+        # [FIXME] get line and file name
+        # TRITONSERVER_LogMessage
+        raise "Not Implemented"
+
+    # property getters / setters
+    @property
+    def format(self) -> LogFormat:
+        return self._format
+
+    @format.setter
+    def format(self, f: LogFormat) -> None:
+        # TRITONSERVER_ServerOptionsSetLogFormat
+        self._format = format
+
+    @property
+    def file(self) -> str:
+        return self._file
+
+    @format.setter
+    def file(self, f: str) -> None:
+        # TRITONSERVER_ServerOptionsSetLogFile
+        self._file = f
+
+    @property
+    def enabled_info(self) -> bool:
+        # TRITONSERVER_LogIsEnabled(INFO, ...)
+        raise "Not Implemented"
+        return False
+
+    @enabled_info.setter
+    def enable_info(self, v: bool) -> None:
+        # TRITONSERVER_ServerOptionsSetLogInfo
+        raise "Not Implemented"
+
+    @property
+    def enabled_warning(self) -> bool:
+        # TRITONSERVER_LogIsEnabled(WARN, ...)
+        raise "Not Implemented"
+        return False
+
+    @enabled_warning.setter
+    def enable_warning(self, v: bool) -> None:
+        # TRITONSERVER_ServerOptionsSetLogWarn
+        raise "Not Implemented"
+
+    @property
+    def enabled_error(self) -> bool:
+        # TRITONSERVER_LogIsEnabled(ERROR, ...)
+        raise "Not Implemented"
+        return False
+
+    @enabled_error.setter
+    def enable_error(self, v: bool) -> None:
+        # TRITONSERVER_ServerOptionsSetLogError
+        raise "Not Implemented"
+
+    @property
+    def enabled_verbose(self) -> bool:
+        # TRITONSERVER_LogIsEnabled(VERBOSE, ...)
+        raise "Not Implemented"
+        return False
+
+    @enabled_verbose.setter
+    def enable_verbose(self, v: int) -> None:
+        # TRITONSERVER_ServerOptionsSetLogVerbose
+        raise "Not Implemented"

--- a/python/_metrics.py
+++ b/python/_metrics.py
@@ -1,0 +1,95 @@
+from enum import Enum
+from collections.abc import Iterable
+
+
+class Format(Enum):
+    PROMETHEUS: int = 0
+
+
+class Kind(Enum):
+    COUNTER: int = 0
+    GAUGE: int = 1
+
+
+class Metric:
+
+    def __init__(self, family, labels) -> None:
+        self._closed = False
+        # labels -> TRITONSERVER_Parameter
+        # TRITONSERVER_MetricNew
+        # finally: delete TRITONSERVER_Parameter
+        pass
+
+    def close(self):
+        if self._closed:
+            return
+
+        self._closed = True
+        # if self._metric is not None: TRITONSERVER_MetricDelete
+        raise "Not Implemented"
+
+    def __del__(self):
+        self.close()
+
+    @property
+    def kind(self) -> Kind:
+        # TRITONSERVER_GetMetricKind
+        raise "Not Implemented"
+        return Kind.COUNTER
+
+    @property
+    def value(self) -> float:
+        # TRITONSERVER_MetricValue
+        raise "Not Implemented"
+        return 0.0
+
+    @value.setter
+    def value(self, v: float):
+        # TRITONSERVER_MetricSet
+        raise "Not Implemented"
+
+    def increment(self, v: float):
+        # TRITONSERVER_MetricIncrement
+        raise "Not Implemented"
+
+
+class Family:
+
+    def __init__(self, kind: Kind, name: str, description: str) -> None:
+        # TRITONSERVER_MetricFamilyNew
+        self._metrics = []
+        pass
+
+    def __del__(self):
+        # Make sure all associated metrics are deleted
+        for metric in self._metrics:
+            metric.close()
+        # TRITONSERVER_MetricFamilyDelete
+
+    def add_metric(self, labels: Iterable[str]):
+        # self._metrics.append(Metric(self, labels))
+        pass
+
+
+# [WIP] figure out "singleton"
+class GlobalMetrics:
+
+    def __init__(self, format: Format = Format.Prometheus) -> None:
+        # Below will raise exception if 'format' is not the proper class
+        format in Format
+        self._format = format
+        self._metric_families = {}
+
+    def report(self) -> str:
+        # TRITONSERVER_ServerMetrics
+        # TRITONSERVER_MetricsFormatted
+        # convert to string
+        # TRITONSERVER_MetricsDelete
+        raise "Not Implemented"
+        return ""
+
+    # custom metric..
+    def add_family(self, kind: Kind, name: str, description: str) -> Family:
+        # self._metric_families[name] = Family(kind, name, description)
+        # return newed object
+        raise "Not Implemented"

--- a/python/_pybind.py
+++ b/python/_pybind.py
@@ -1,0 +1,4 @@
+"""
+This is the placeholder for the "module" created by PyBind,
+this will be 1-1 mapping of the in-process API
+"""

--- a/python/_server.py
+++ b/python/_server.py
@@ -111,7 +111,7 @@ class Options:
 
 class TritonCore:
 
-    def __init__(self, option: Options = None) -> None:
+    def __init__(self, options: Options = None) -> None:
         self._stop = True
         # Create TRITONSERVER_ServerOptions
         # TRITONSERVER_ServerNew
@@ -228,3 +228,25 @@ class TritonCore:
         # If 'allocator' not provided, use DefaultAllocator
         # set with pre-define callbacks..
         raise "Not Implemented"
+
+
+# Example usage of the module:
+#   # Init
+#   options = Options()
+#   options.model_repositories = ["/path/to/models"]
+#   triton = TritonCore(options)
+#
+#   # Prepare inference
+#   request = InferenceRequest("simple")
+#   request.inputs["INPUT"] = numpy.ones([16,16])
+#
+#   # infer
+#   res = triton.infer_async(request)
+#
+#   # read result
+#   for response in res:
+#       if isinstance(response, TritonException):
+#           raise response # response has error
+#       for output in res.outputs:
+#           # default allocator is numpy based.. see ._infer
+#           print(output.as_numpy())

--- a/python/_server.py
+++ b/python/_server.py
@@ -1,7 +1,8 @@
 from enum import Enum, IntEnum
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Tuple
 from typing import Any, Union
 from ._infer import *
+from ._trace import *
 
 
 class ModelControlMode(Enum):
@@ -52,7 +53,7 @@ class RateLimiterOptions:
 
 class Options:
     # in-process API doesn't provide proper getter,
-    # there is no way to reflect actual default value.
+    # can't reflect the default / current value.
     # NOTE: TRITONSERVER_ServerOptions creation will be in place
     # during server initialization
     def __init__(self) -> None:
@@ -76,7 +77,7 @@ class Options:
         self.strict_model_config: bool = None
         self.model_load_thread_count: int = None
         self.model_namespacing: bool = None
-        # [FIXME] proper type specification
+        # [WIP] proper type specification
         self.model_load_device_limit: Any = None
 
         # Rate limiter
@@ -99,14 +100,12 @@ class Options:
 
         # Backends
         self.backend_directory: str = None
-        # [FIXME] proper type
         self.backend_config: dict[str, list[tuple[str, str]]] = None
 
         self.host_policy: dict[str, list[tuple[str, str]]] = None
 
         self.repoagent_directory: str = None
 
-        # [WIP] log? should be moved out (global like metric..)
         pass
 
 
@@ -181,18 +180,18 @@ class TritonCore:
         # TRITONSERVER_ServerModelIsReady
         raise "Not Implemented"
 
-    def model_batch_properties(self,
-                               name: str,
-                               version: int = -1) -> Mapping[BatchProperty,
-                                                             Any]:
+    def model_batch_properties(
+            self,
+            name: str,
+            version: int = -1) -> Tuple[Iterable[BatchProperty], Any]:
         # TRITONSERVER_ServerModelBatchProperties
         # demultiplex the properties
         raise "Not Implemented"
 
-    def model_transaction_properties(self,
-                                     name: str,
-                                     version: int = -1
-                                    ) -> Mapping[BatchProperty, Any]:
+    def model_transaction_properties(
+            self,
+            name: str,
+            version: int = -1) -> Tuple[Iterable[TransactionProperty], Any]:
         # TRITONSERVER_ServerModelTransactionProperties
         # demultiplex the properties
         raise "Not Implemented"
@@ -223,11 +222,9 @@ class TritonCore:
 
     def infer_async(self,
                     request: InferenceRequest,
-                    allocator: ResponseAllocator = None) -> ResponseHandle:
+                    allocator: ResponseAllocator = None,
+                    trace_reportor: TraceReportor = None) -> ResponseHandle:
         # TRITONSERVER_InferenceRequestNew and initialization
         # If 'allocator' not provided, use DefaultAllocator
         # set with pre-define callbacks..
         raise "Not Implemented"
-
-
-# [FIXME][WIP] trace

--- a/python/_server.py
+++ b/python/_server.py
@@ -1,0 +1,233 @@
+from enum import Enum, IntEnum
+from collections.abc import Iterable, Mapping
+from typing import Any, Union
+from ._infer import *
+
+
+class ModelControlMode(Enum):
+    NONE: int = 0
+    POLL: int = 1
+    EXPLICIT: int = 2
+
+
+# Use IntEnum for flags that may be multiplexed
+class BatchProperty(IntEnum):
+    UNKNOWN: int = 1
+    FIRST_DIM: int = 2
+
+
+class TransactionProperty(IntEnum):
+    ONE_TO_ONE: int = 1
+    DECOUPLED: int = 2
+
+
+class ModelIndexFlag(IntEnum):
+    READY: int = 1
+
+
+class RateLimiterOptions:
+
+    class Mode(Enum):
+        OFF: int = 0
+        EXECUTION_COUNT: int = 1
+
+    class Resource:
+
+        def __init__(self, name: str, count: int, device_id: int) -> None:
+            self._name = name
+            self._count = count
+            self._device_id = device_id
+
+    def __init__(self, mode: Mode = None) -> None:
+        self._mode = mode
+        self._resources: Iterable[RateLimiterOptions.Resource] = None
+        pass
+
+    def add_resource(self, name: str, count: int, device_id: int) -> None:
+        if self._resources is None:
+            self._resources = []
+        self._resources.append(
+            RateLimiterOptions.Resource(name, count, device_id))
+
+
+class Options:
+    # in-process API doesn't provide proper getter,
+    # there is no way to reflect actual default value.
+    # NOTE: TRITONSERVER_ServerOptions creation will be in place
+    # during server initialization
+    def __init__(self) -> None:
+        # List the set of options, 'None' implies that the value is not
+        # specified and the default value will be used
+        self.server_id: str = None
+        self.minimum_compute_capability: float = None
+        self.strict_readiness: bool = None
+        self.exit_on_error: bool = None
+        self.exit_timeout: int = None
+
+        # [FIXME] this option is actually not in used in core
+        # TRITONSERVER_ServerOptionsSetBufferManagerThreadCount
+        self.buffer_manager_thread_count: int = None
+
+        # Model stuff..
+        self.model_repositories: Iterable[str] = None
+        self.model_control_mode: ModelControlMode = None
+        self.startup_models: Iterable[str] = None
+        # [FIXME] turn to auto-complete-config?
+        self.strict_model_config: bool = None
+        self.model_load_thread_count: int = None
+        self.model_namespacing: bool = None
+        # [FIXME] proper type specification
+        self.model_load_device_limit: Any = None
+
+        # Rate limiter
+        self.rate_limiter: RateLimiterOptions = None
+
+        # memory pool
+        self.pinned_memory_pool_size: int = None
+        self.cuda_memory_pool_size: dict[str, int] = None
+
+        # cache
+        self.cache_directory: str = None
+        self.cache_config: dict[str, str] = None
+
+        # Option for Server-provided part of the Metrics
+        self.enable_metrics: bool = None
+        self.enable_gpu_metrics: bool = None
+        self.enable_cpu_metrics: bool = None
+        self.metrics_interval: int = None
+        self.metrics_config: dict[str, list[tuple[str, str]]] = None
+
+        # Backends
+        self.backend_directory: str = None
+        # [FIXME] proper type
+        self.backend_config: dict[str, list[tuple[str, str]]] = None
+
+        self.host_policy: dict[str, list[tuple[str, str]]] = None
+
+        self.repoagent_directory: str = None
+
+        # [WIP] log? should be moved out (global like metric..)
+        pass
+
+
+class TritonCore:
+
+    def __init__(self, option: Options = None) -> None:
+        self._stop = True
+        # Create TRITONSERVER_ServerOptions
+        # TRITONSERVER_ServerNew
+        # finally: delete TRITONSERVER_ServerOptions
+        self._stop = False
+        pass
+
+    def __del__(self) -> None:
+        self.stop()
+
+    def stop(self) -> None:
+        if not self._stop:
+            self._stop = True
+            # TRITONSERVER_ServerStop
+
+    # [FIXME] context manager...
+
+    def ready(self) -> bool:
+        # TRITONSERVER_ServerIsReady
+        raise "Not Implemented"
+
+    def live(self) -> bool:
+        # TRITONSERVER_ServerIsLive
+        raise "Not Implemented"
+
+    def metadata(self) -> dict:
+        # TRITONSERVER_ServerMetadata
+        # TRITONSERVER_MessageSerializeToJson
+        # json -> Python dict
+        # (general procedure to present Triton message to the user)
+        raise "Not Implemented"
+
+    # Repository APIs
+    def register_repository(self,
+                            path: str,
+                            name_mapping: Mapping[str, str] = None):
+        # TRITONSERVER_ServerRegisterModelRepository
+        raise "Not Implemented"
+
+    def unregister_repository(self, path: str):
+        # TRITONSERVER_ServerUnregisterModelRepository
+        raise "Not Implemented"
+
+    def poll_repository(self):
+        # TRITONSERVER_ServerPollModelRepository
+        raise "Not Implemented"
+
+    def model_index(self, flags: Union[ModelIndexFlag, int] = None):
+        # TRITONSERVER_ServerModelIndex
+        raise "Not Implemented"
+
+    def load_model(self, name: str, parameters: Mapping[str, str] = None):
+        # TRITONSERVER_ServerLoadModelWithParameters
+        raise "Not Implemented"
+
+    def unload_model(self, name: str, recursive_unload=False):
+        if recursive_unload:
+            # TRITONSERVER_ServerUnloadModelAndDependents
+            raise "Not Implemented"
+        else:
+            # TRITONSERVER_ServerUnloadModel
+            raise "Not Implemented"
+
+    # Models [FIXME] another abstraction?
+    def model_ready(self, name: str, version: int = -1) -> bool:
+        # TRITONSERVER_ServerModelIsReady
+        raise "Not Implemented"
+
+    def model_batch_properties(self,
+                               name: str,
+                               version: int = -1) -> Mapping[BatchProperty,
+                                                             Any]:
+        # TRITONSERVER_ServerModelBatchProperties
+        # demultiplex the properties
+        raise "Not Implemented"
+
+    def model_transaction_properties(self,
+                                     name: str,
+                                     version: int = -1
+                                    ) -> Mapping[BatchProperty, Any]:
+        # TRITONSERVER_ServerModelTransactionProperties
+        # demultiplex the properties
+        raise "Not Implemented"
+
+    def model_metadata(self, name: str, version: int = -1) -> dict:
+        # TRITONSERVER_ServerModelMetadata
+        # TRITONSERVER_MessageSerializeToJson
+        # json -> Python dict
+        # (general procedure to present Triton message to the user)
+        raise "Not Implemented"
+
+    def model_statistics(self, name: str, version: int = -1) -> dict:
+        # TRITONSERVER_ServerModelStatistics
+        # TRITONSERVER_MessageSerializeToJson
+        # json -> Python dict
+        # (general procedure to present Triton message to the user)
+        raise "Not Implemented"
+
+    def model_config(self,
+                     name: str,
+                     version: int = -1,
+                     config_version: int = 1) -> dict:
+        # TRITONSERVER_ServerModelConfig
+        # TRITONSERVER_MessageSerializeToJson
+        # json -> Python dict
+        # (general procedure to present Triton message to the user)
+        raise "Not Implemented"
+
+    def infer_async(self,
+                    request: InferenceRequest,
+                    allocator: ResponseAllocator = None) -> ResponseHandle:
+        # TRITONSERVER_InferenceRequestNew and initialization
+        # If 'allocator' not provided, use DefaultAllocator
+        # set with pre-define callbacks..
+        raise "Not Implemented"
+
+
+# [FIXME][WIP] trace

--- a/python/_trace.py
+++ b/python/_trace.py
@@ -1,5 +1,6 @@
 from enum import IntEnum, Enum
 from ._common import *
+from ._infer import Tensor
 from typing import Iterable, Any, Union
 import abc
 
@@ -78,13 +79,9 @@ class TraceReportor(abc.ABC):
         # is TRITONSERVER_InferenceTraceActivityFn_t
         raise "Not Implemented"
 
-    # [FIXME] optional
-    # [WIP] Tensor abstraction
-    @abc.abstractmethod
+    @optional_callabck
     def trace_tensor(self, activity: TraceTensorActivity, name: str,
-                     data_type: DataType, base: int, byte_size: int,
-                     shape: Iterable[int], memory_type: MemoryType,
-                     memory_type_id: int, trace: Trace):
+                     tensor: Tensor, trace: Trace):
         # is TRITONSERVER_InferenceTraceTensorActivityFn_t
         raise "Not Implemented"
 

--- a/python/_trace.py
+++ b/python/_trace.py
@@ -1,0 +1,111 @@
+from enum import IntEnum, Enum
+from ._common import *
+from typing import Iterable, Any, Union
+import abc
+
+
+class TraceLevel(IntEnum):
+    TIMESTAMPS: int = 4
+    TENSORS: int = 8
+
+    def __str__(self) -> str:
+        # TRITONSERVER_InferenceTraceLevelString
+        raise "Not Implemented"
+
+
+# Activity related to timeline tracing
+class TraceActivity(Enum):
+    REQUEST_START: int = 0
+    QUEUE_START: int = 1
+    COMPUTE_START: int = 2
+    COMPUTE_INPUT_END: int = 3
+    COMPUTE_OUTPUT_START: int = 4
+    COMPUTE_END: int = 5
+    REQUEST_END: int = 6
+
+    def __str__(self) -> str:
+        # TRITONSERVER_InferenceTraceActivityString
+        raise "Not Implemented"
+
+
+# Activity related to tensor tracing
+class TraceTensorActivity(Enum):
+    TENSOR_QUEUE_INPUT: int = 7
+    TENSOR_BACKEND_INPUT: int = 8
+    TENSOR_BACKEND_OUTPUT: int = 9
+
+    def __str__(self) -> str:
+        # TRITONSERVER_InferenceTraceActivityString
+        raise "Not Implemented"
+
+
+# Trace object that Triton will provide
+class Trace:
+
+    @property
+    def id(self) -> int:
+        pass
+
+    @property
+    def parent_id(self) -> int:
+        pass
+
+    @property
+    def request_id(self) -> int:
+        pass
+
+    @property
+    def model_name(self) -> str:
+        pass
+
+    @property
+    def model_version(self) -> int:
+        pass
+
+
+class TraceReportor(abc.ABC):
+
+    def __init__(self, level: Union[TraceLevel, int]) -> None:
+        super().__init__()
+        self._level = int(level)
+
+    # Callback that Triton will invoke to report timestamp of the
+    # given activity. Note that this invocation does not imply that
+    # the activity is ocurring at the moment.
+    @abc.abstractmethod
+    def trace_activity(self, activity: TraceActivity, timestamp: int,
+                       trace: Trace):
+        # is TRITONSERVER_InferenceTraceActivityFn_t
+        raise "Not Implemented"
+
+    # [FIXME] optional
+    # [WIP] Tensor abstraction
+    @abc.abstractmethod
+    def trace_tensor(self, activity: TraceTensorActivity, name: str,
+                     data_type: DataType, base: int, byte_size: int,
+                     shape: Iterable[int], memory_type: MemoryType,
+                     memory_type_id: int, trace: Trace):
+        # is TRITONSERVER_InferenceTraceTensorActivityFn_t
+        raise "Not Implemented"
+
+    @abc.abstractmethod
+    def trace_release(self, trace: Trace):
+        # is TRITONSERVER_InferenceTraceReleaseFn_t
+        raise "Not Implemented"
+
+
+# Usage:
+# inherit from TraceReportor to the abstract functions,
+# intiantiate the reportor() object with the desire configuration
+# Detail:
+# obj(TraceReportor) ->
+#     TraceTensorNew(&trace, obj._level, obj.trace_activity,
+#         obj.trace_tensor,
+#         [](){
+#             obj.trace_release;
+#             TraceDelete();
+#             // assumping root trace is always released last..
+#             if trace.parent_id == -1 {
+#                 obj.ref_dec();
+#             }}, obj);
+#     obj.ref_inc()


### PR DESCRIPTION
`FIXME` are the sections that further discussion is desired.

The wrapper is restricted that a lot of interaction with in-process API is pre-defined (i.e. how to handle released `TRITONSERVER_Request` and `TRITONSERVER_Response`). The intention is that user shouldn't need to handle object lifecycle explicitly. The lower level binding will also be provided if they want finer control (i.e. reuse underlying objects to avoid alloc/release overhead).

At the end of `_server.py` is a basic example usage of the wrapper. At the end of `_infer.py` is an example implementation of allocator.