### PR TITLE
updating log message with input name

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -807,7 +807,9 @@ InferenceRequest::Normalize()
       if (!has_one_element) {
         return Status(
             Status::Code::INVALID_ARG, LogRequest() +
-                                           "For BYTE datatype raw input, the "
+                                           "For BYTE datatype raw input '" +
+                                           config_input.name() +
+                                           "', the "
                                            "model must have input shape [1]");
       }
       // In the case of BYTE data type, we will prepend the byte size to follow

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -946,13 +946,13 @@ InferenceRequest::Normalize()
     if (input.DType() != input_config->data_type()) {
       return Status(
           Status::Code::INVALID_ARG,
-          LogRequest() + "inference input data-type is '" +
+          LogRequest() + "inference input '" + pr.first + "' data-type is '" +
               std::string(
                   triton::common::DataTypeToProtocolString(input.DType())) +
-              "', model expects '" +
+              "', but model '" + ModelName() + "' expects '" +
               std::string(triton::common::DataTypeToProtocolString(
                   input_config->data_type())) +
-              "' for '" + ModelName() + "'");
+              "'");
     }
 
     // Validate input shape


### PR DESCRIPTION
based on feedback - adding the input name when logging mismatched data type.

Message is now:

inference input 'INPUT' data type is 'DATATYPE_1', but model 'MODEL' expects 'DATATYPE_2'

Open to other phrasing.