### PR TITLE
Add queue size (pending request count) metric per-model

### DIFF
--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -753,6 +753,7 @@ TritonModelInstance::TritonBackendThread::BackendThread()
         model_instances_, &payload);
     NVTX_RANGE(nvtx_, "BackendThread " + name_);
     payload->Execute(&should_exit);
+    // LOG_STATUS_ERROR(payload->Wait(), "Failed to execute payload");
     model_instances_.push_back(payload->GetInstance());
     // Release the payload to the RateLimiter
     model_->Server()->GetRateLimiter()->PayloadRelease(payload);

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -534,7 +534,7 @@ TritonModelInstance::GenerateWarmupData()
   return Status::Success;
 }
 
-void
+Status
 TritonModelInstance::Schedule(
     std::vector<std::unique_ptr<InferenceRequest>>&& requests,
     const std::function<void()>& OnCompletion)
@@ -545,16 +545,17 @@ TritonModelInstance::Schedule(
   triton_requests.clear();
   for (auto& r : requests) {
     // Load the input states for the inference request.
-    r->LoadInputStates();
+    RETURN_IF_ERROR(r->LoadInputStates());
     // Set request state to signtify that request is no longer pending.
-    r->SetState(InferenceRequest::State::EXECUTING);
+    RETURN_IF_ERROR(r->SetState(InferenceRequest::State::EXECUTING));
     triton_requests.push_back(
         reinterpret_cast<TRITONBACKEND_Request*>(r.release()));
   }
 
   Execute(triton_requests);
-
   OnCompletion();
+
+  return Status::Success;
 }
 
 Status

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -569,8 +569,7 @@ TritonModelInstance::PrepareRequestsOrRespond(
 
 Status
 TritonModelInstance::Schedule(
-    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-    const std::function<void()>& OnCompletion)
+    std::vector<std::unique_ptr<InferenceRequest>>&& requests)
 {
   // Prepare requests for execution, respond to requests if any error occur.
   RETURN_IF_ERROR(PrepareRequestsOrRespond(requests));
@@ -585,8 +584,6 @@ TritonModelInstance::Schedule(
   }
 
   Execute(triton_requests);
-  OnCompletion();
-
   return Status::Success;
 }
 

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -546,6 +546,8 @@ TritonModelInstance::Schedule(
   for (auto& r : requests) {
     // Load the input states for the inference request.
     r->LoadInputStates();
+    // Set request state to signtify that request is no longer pending.
+    r->SetState(InferenceRequest::State::EXECUTING);
     triton_requests.push_back(
         reinterpret_cast<TRITONBACKEND_Request*>(r.release()));
   }

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -116,7 +116,7 @@ class TritonModelInstance {
 
   Status Initialize();
   Status WarmUp();
-  void Schedule(
+  Status Schedule(
       std::vector<std::unique_ptr<InferenceRequest>>&& requests,
       const std::function<void()>& OnCompletion);
 

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -116,9 +116,7 @@ class TritonModelInstance {
 
   Status Initialize();
   Status WarmUp();
-  Status Schedule(
-      std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-      const std::function<void()>& OnCompletion);
+  Status Schedule(std::vector<std::unique_ptr<InferenceRequest>>&& requests);
 
   TritonModel* Model() const { return model_; }
   void* State() { return state_; }

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -220,6 +220,10 @@ class TritonModelInstance {
       const bool device_blocking);
   Status GenerateWarmupData();
 
+  Status PrepareRequestsForExecution(
+      std::vector<std::unique_ptr<InferenceRequest>>& requests);
+  Status PrepareRequestsOrRespond(
+      std::vector<std::unique_ptr<InferenceRequest>>& requests);
   void Execute(std::vector<TRITONBACKEND_Request*>& triton_requests);
 
   std::shared_ptr<TritonBackendThread> triton_backend_thread_;

--- a/src/constants.h
+++ b/src/constants.h
@@ -80,7 +80,7 @@ constexpr char kWarmupDataFolder[] = "warmup";
 constexpr char kInitialStateFolder[] = "initial_state";
 
 // Metric names
-constexpr char kQueueSizeMetricName[] = "inf_queue_size";
+constexpr char kPendingRequestMetric[] = "inf_pending_request_count";
 
 constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;

--- a/src/constants.h
+++ b/src/constants.h
@@ -79,6 +79,9 @@ constexpr char kMetricsLabelGpuUuid[] = "gpu_uuid";
 constexpr char kWarmupDataFolder[] = "warmup";
 constexpr char kInitialStateFolder[] = "initial_state";
 
+// Metric names
+constexpr char kQueueSizeMetricName[] = "inf_queue_size";
+
 constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;
 constexpr int MAX_GRPC_MESSAGE_SIZE = INT32_MAX;
@@ -90,7 +93,7 @@ constexpr size_t CUDA_IPC_STRUCT_SIZE = 64;
 // MetricModelReporter expects a device ID for GPUs, but we reuse this device
 // ID for other metrics as well such as for CPU and Response Cache metrics
 constexpr int METRIC_REPORTER_ID_CPU = -1;
-constexpr int METRIC_REPORTER_ID_RESPONSE_CACHE = -2;
+constexpr int METRIC_REPORTER_ID_UTILITY = -2;
 #endif
 
 // Note: This can be replaced with std::byte starting in c++17

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -181,8 +181,7 @@ DynamicBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
   // the beginning of the queueing and scheduling process. Otherwise,
   // dynamic batcher is used as component of another batcher and should not
   // overwrite the queue start timestamp.
-  const bool is_child_scheduler = (request->QueueStartNs() != 0);
-  if (!is_child_scheduler) {
+  if (request->QueueStartNs() == 0) {
     request->CaptureQueueStartNs();
     INFER_TRACE_ACTIVITY(
         request->TraceProxy(), TRITONSERVER_TRACE_QUEUE_START,

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -88,8 +88,6 @@ class DynamicBatchScheduler : public Scheduler {
   // \see Scheduler::Stop()
   void Stop() override { stop_ = true; }
 
-  MetricModelReporter* MetricReporter() const { return reporter_.get(); }
-
  private:
   DynamicBatchScheduler(
       TritonModel* model, TritonModelInstance* model_instance,

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -88,6 +88,11 @@ class DynamicBatchScheduler : public Scheduler {
   // \see Scheduler::Stop()
   void Stop() override { stop_ = true; }
 
+  std::shared_ptr<MetricModelReporter> MetricReporter() const
+  {
+    return reporter_;
+  }
+
  private:
   DynamicBatchScheduler(
       TritonModel* model, TritonModelInstance* model_instance,

--- a/src/ensemble_scheduler.h
+++ b/src/ensemble_scheduler.h
@@ -102,6 +102,11 @@ class EnsembleScheduler : public Scheduler {
   // \see Scheduler::Stop()
   void Stop() override {}
 
+  std::shared_ptr<MetricModelReporter> MetricReporter() const
+  {
+    return metric_reporter_;
+  }
+
  private:
   EnsembleScheduler(
       InferenceStatsAggregator* const stats_aggregator,

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -140,8 +140,8 @@ InferenceRequest::SetState(InferenceRequest::State new_state)
   // Generate error when called rather than copying it into every case below.
   const auto generate_error = [&]() {
     std::stringstream ss;
-    ss << "Invalid request state transition from " << state_ << " to "
-       << new_state;
+    ss << LogRequest() << "Invalid request state transition from " << state_
+       << " to " << new_state;
     return Status(Status::Code::INVALID_ARG, ss.str());
   };
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -448,8 +448,9 @@ InferenceRequest::Release(
   }
 #endif  // TRITON_ENABLE_TRACING
 
-  auto status = request->SetState(InferenceRequest::State::RELEASED);
-  LOG_STATUS_ERROR(status, status.Message());
+  LOG_STATUS_ERROR(
+      request->SetState(InferenceRequest::State::RELEASED),
+      "Failed to set released state");
   void* userp = request->release_userp_;
   auto& release_fn = request->release_fn_;
   release_fn(

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -796,6 +796,9 @@ class InferenceRequest {
 
   // The state of the request.
   InferenceRequest::State state_;
+  // Catch-all to correctly decrement pending count if needed on destruction
+  // if request doesn't follow normal execution path (error, unused, ensembles)
+  bool decrement_pending_count_;
 };
 
 std::ostream& operator<<(std::ostream& out, const InferenceRequest& request);

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -796,6 +796,9 @@ class InferenceRequest {
 
   // The state of the request.
   InferenceRequest::State state_;
+  // Whether this is a null request used for direct sequence batch padding or
+  // not.
+  bool null_request_;
   // Catch-all to correctly decrement pending count if needed on destruction
   // if request doesn't follow normal execution path (error, unused, ensembles)
   bool decrement_pending_count_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -57,6 +57,22 @@ class MetricModelReporter;
 //
 class InferenceRequest {
  public:
+  /// State for the request object.
+  enum class State {
+    // The request has been initialized, but not yet enqueued.
+    INITIALIZED,
+
+    // The request has been enqueued, but is not yet executing.
+    STARTED,
+
+    // The request has been picked up by a backend model instance for execution,
+    // but hasn't been released yet.
+    EXECUTING,
+
+    // The request has been released.
+    RELEASED
+  };
+
   // Input tensor
   class Input {
    public:
@@ -275,6 +291,7 @@ class InferenceRequest {
       const int64_t requested_model_version);
 
   InferenceRequest(Model* model, const int64_t requested_model_version);
+  ~InferenceRequest();
 
   const std::string& ModelName() const;
   int64_t RequestedModelVersion() const { return requested_model_version_; }
@@ -321,6 +338,9 @@ class InferenceRequest {
     cache_key_is_set_ = true;
   }
   bool CacheKeyIsSet() const { return cache_key_is_set_; }
+
+  // Define and validate state transitions for request.
+  Status SetState(InferenceRequest::State state);
 
 #ifdef TRITON_ENABLE_TRACING
   const std::shared_ptr<InferenceTraceProxy>& TraceProxy() const
@@ -666,8 +686,15 @@ class InferenceRequest {
   DISALLOW_COPY_AND_ASSIGN(InferenceRequest);
   friend std::ostream& operator<<(
       std::ostream& out, const InferenceRequest& request);
+  friend std::ostream& operator<<(
+      std::ostream& out, const InferenceRequest::State& state);
+
 
   Status Normalize();
+
+  // Helpers for pending request metrics
+  void IncrementPendingRequestCount();
+  void DecrementPendingRequestCount();
 
   // Has anything in the request potentially changed in a way that
   // causes normalization to be required when preparing the request
@@ -766,6 +793,9 @@ class InferenceRequest {
 
   // Sequence I/O states used for implicit state.
   std::shared_ptr<SequenceStates> sequence_states_;
+
+  // The state of the request.
+  InferenceRequest::State state_;
 };
 
 std::ostream& operator<<(std::ostream& out, const InferenceRequest& request);

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -151,6 +151,7 @@ MetricModelReporter::MetricModelReporter(
 
   // Initialize families and metrics
   InitializeCounters(labels);
+  InitializeGauges(labels);
   InitializeSummaries(labels);
 }
 
@@ -192,7 +193,6 @@ MetricModelReporter::InitializeCounters(
   counter_families_["inf_count"] = &Metrics::FamilyInferenceCount();
   counter_families_["inf_exec_count"] =
       &Metrics::FamilyInferenceExecutionCount();
-  gauge_families_[kPendingRequestMetric] = &Metrics::FamilyInferenceQueueSize();
 
   // Latency metrics will be initialized based on config
   if (config_.latency_counters_enabled_) {
@@ -227,6 +227,14 @@ MetricModelReporter::InitializeCounters(
       counters_[name] = CreateMetric<prometheus::Counter>(*family_ptr, labels);
     }
   }
+}
+
+void
+MetricModelReporter::InitializeGauges(
+    const std::map<std::string, std::string>& labels)
+{
+  // Always setup these inference request metrics, regardless of config
+  gauge_families_[kPendingRequestMetric] = &Metrics::FamilyInferenceQueueSize();
 
   for (auto& iter : gauge_families_) {
     const auto& name = iter.first;

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -165,7 +165,6 @@ MetricModelReporter::~MetricModelReporter()
     }
   }
 
-  // TODO: Can we consolidate all 3?
   for (auto& iter : gauge_families_) {
     const auto& name = iter.first;
     auto family_ptr = iter.second;
@@ -343,38 +342,35 @@ MetricModelReporter::IncrementCounter(const std::string& name, double value)
   counter->Increment(value);
 }
 
-void
-MetricModelReporter::SetGauge(const std::string& name, double value)
+prometheus::Gauge*
+MetricModelReporter::GetGauge(const std::string& name)
 {
   auto iter = gauges_.find(name);
   if (iter == gauges_.end()) {
     // No gauge metric exists with this name
-    return;
+    return nullptr;
   }
 
   auto gauge = iter->second;
-  if (!gauge) {
-    // gauge is uninitialized/nullptr
-    return;
+  return gauge;
+}
+
+void
+MetricModelReporter::SetGauge(const std::string& name, double value)
+{
+  auto gauge = GetGauge(name);
+  if (gauge) {
+    gauge->Set(value);
   }
-  gauge->Set(value);
 }
 
 void
 MetricModelReporter::IncrementGauge(const std::string& name, double value)
 {
-  auto iter = gauges_.find(name);
-  if (iter == gauges_.end()) {
-    // No gauge metric exists with this name
-    return;
+  auto gauge = GetGauge(name);
+  if (gauge) {
+    gauge->Increment(value);
   }
-
-  auto gauge = iter->second;
-  if (!gauge) {
-    // gauge is uninitialized/nullptr
-    return;
-  }
-  gauge->Increment(value);
 }
 
 

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -186,13 +186,13 @@ void
 MetricModelReporter::InitializeCounters(
     const std::map<std::string, std::string>& labels)
 {
-  // Always setup these counters, regardless of config
+  // Always setup these inference request metrics, regardless of config
   counter_families_["inf_success"] = &Metrics::FamilyInferenceSuccess();
   counter_families_["inf_failure"] = &Metrics::FamilyInferenceFailure();
   counter_families_["inf_count"] = &Metrics::FamilyInferenceCount();
   counter_families_["inf_exec_count"] =
       &Metrics::FamilyInferenceExecutionCount();
-  gauge_families_[kQueueSizeMetricName] = &Metrics::FamilyInferenceQueueSize();
+  gauge_families_[kPendingRequestMetric] = &Metrics::FamilyInferenceQueueSize();
 
   // Latency metrics will be initialized based on config
   if (config_.latency_counters_enabled_) {

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -356,15 +356,6 @@ MetricModelReporter::GetGauge(const std::string& name)
 }
 
 void
-MetricModelReporter::SetGauge(const std::string& name, double value)
-{
-  auto gauge = GetGauge(name);
-  if (gauge) {
-    gauge->Set(value);
-  }
-}
-
-void
 MetricModelReporter::IncrementGauge(const std::string& name, double value)
 {
   auto gauge = GetGauge(name);

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -187,7 +187,7 @@ void
 MetricModelReporter::InitializeCounters(
     const std::map<std::string, std::string>& labels)
 {
-  // Always setup these inference request metrics, regardless of config
+  // Always setup these counters, regardless of config
   counter_families_["inf_success"] = &Metrics::FamilyInferenceSuccess();
   counter_families_["inf_failure"] = &Metrics::FamilyInferenceFailure();
   counter_families_["inf_count"] = &Metrics::FamilyInferenceCount();
@@ -371,7 +371,6 @@ MetricModelReporter::IncrementGauge(const std::string& name, double value)
     gauge->Increment(value);
   }
 }
-
 
 void
 MetricModelReporter::DecrementGauge(const std::string& name, double value)

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -81,8 +81,6 @@ class MetricModelReporter {
   const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
-  // Lookup gauge metric by name. Return gauge if found, nullptr otherwise.
-  prometheus::Gauge* GetGauge(const std::string& name);
   // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);
   // Decrease gauge by value.
@@ -107,7 +105,12 @@ class MetricModelReporter {
       const std::map<std::string, std::string>& labels, Args&&... args);
 
   void InitializeCounters(const std::map<std::string, std::string>& labels);
+  void InitializeGauges(const std::map<std::string, std::string>& labels);
   void InitializeSummaries(const std::map<std::string, std::string>& labels);
+
+  // Lookup gauge metric by name. Return gauge if found, nullptr otherwise.
+  prometheus::Gauge* GetGauge(const std::string& name);
+
 
   // Metric Families
   std::unordered_map<std::string, prometheus::Family<prometheus::Counter>*>

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -81,6 +81,10 @@ class MetricModelReporter {
   const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
+  // Lookup gauge metric by name, and set its value if it exists.
+  void SetGauge(const std::string& name, double value);
+  void IncrementGauge(const std::string& name, double value);
+  void DecrementGauge(const std::string& name, double value);
   // Lookup summary metric by name, and observe the value if it exists.
   void ObserveSummary(const std::string& name, double value);
 
@@ -106,11 +110,14 @@ class MetricModelReporter {
   // Metric Families
   std::unordered_map<std::string, prometheus::Family<prometheus::Counter>*>
       counter_families_;
+  std::unordered_map<std::string, prometheus::Family<prometheus::Gauge>*>
+      gauge_families_;
   std::unordered_map<std::string, prometheus::Family<prometheus::Summary>*>
       summary_families_;
 
   // Metrics
   std::unordered_map<std::string, prometheus::Counter*> counters_;
+  std::unordered_map<std::string, prometheus::Gauge*> gauges_;
   std::unordered_map<std::string, prometheus::Summary*> summaries_;
 
   // Config

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -83,8 +83,6 @@ class MetricModelReporter {
   void IncrementCounter(const std::string& name, double value);
   // Lookup gauge metric by name. Return gauge if found, nullptr otherwise.
   prometheus::Gauge* GetGauge(const std::string& name);
-  // Set gauge to value.
-  void SetGauge(const std::string& name, double value);
   // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);
   // Decrease gauge by value.

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -81,9 +81,13 @@ class MetricModelReporter {
   const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
-  // Lookup gauge metric by name, and set its value if it exists.
+  // Lookup gauge metric by name. Return gauge if found, nullptr otherwise.
+  prometheus::Gauge* GetGauge(const std::string& name);
+  // Set gauge to value.
   void SetGauge(const std::string& name, double value);
+  // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);
+  // Decrease gauge by value.
   void DecrementGauge(const std::string& name, double value);
   // Lookup summary metric by name, and observe the value if it exists.
   void ObserveSummary(const std::string& name, double value);

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -105,7 +105,7 @@ Metrics::Metrics()
           prometheus::BuildGauge()
               .Name("nv_inference_queue_size")
               .Help("Instantaneous size of request queue per-model, measured "
-                    "with each new request.")
+                    "when requests enter or exit the model's queue.")
               .Register(*registry_)),
 
       // Per-model cache metric families

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -101,11 +101,11 @@ Metrics::Metrics()
                     "microseconds (does not include cached requests)")
               .Register(*registry_)),
 
-      inf_queue_size_family_(
+      inf_pending_request_count_family_(
           prometheus::BuildGauge()
-              .Name("nv_inference_queue_size")
-              .Help("Instantaneous size of request queue per-model, measured "
-                    "when requests enter or exit the model's queue.")
+              .Name("nv_inference_pending_request_count")
+              .Help("Instantaneous number of pending requests awaiting "
+                    "execution per-model.")
               .Register(*registry_)),
 
       // Per-model cache metric families

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -101,6 +101,13 @@ Metrics::Metrics()
                     "microseconds (does not include cached requests)")
               .Register(*registry_)),
 
+      inf_queue_size_family_(
+          prometheus::BuildGauge()
+              .Name("nv_inference_queue_size")
+              .Help("Instantaneous size of request queue per-model, measured "
+                    "with each new request.")
+              .Register(*registry_)),
+
       // Per-model cache metric families
       // NOTE: These are used in infer_stats for perf_analyzer
       cache_num_hits_model_family_(prometheus::BuildCounter()

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -29,16 +29,17 @@
 #ifdef TRITON_ENABLE_METRICS
 
 #include <atomic>
+#include <istream>
 #include <mutex>
 #include <thread>
 
-#include "cache_manager.h"
 #include "prometheus/counter.h"
 #include "prometheus/gauge.h"
 #include "prometheus/registry.h"
 #include "prometheus/serializer.h"
 #include "prometheus/summary.h"
 #include "prometheus/text_serializer.h"
+#include "status.h"
 
 #ifdef TRITON_ENABLE_METRICS_GPU
 #include <dcgm_agent.h>
@@ -203,6 +204,13 @@ class Metrics {
   {
     return GetSingleton()->inf_compute_output_duration_us_family_;
   }
+
+  // Metric family of instantaneous inference queue size per model
+  static prometheus::Family<prometheus::Gauge>& FamilyInferenceQueueSize()
+  {
+    return GetSingleton()->inf_queue_size_family_;
+  }
+
   // Metric families of per-model response cache metrics
   // NOTE: These are used in infer_stats for perf_analyzer
   static prometheus::Family<prometheus::Counter>& FamilyCacheHitCount()
@@ -285,6 +293,7 @@ class Metrics {
       inf_compute_infer_duration_us_family_;
   prometheus::Family<prometheus::Counter>&
       inf_compute_output_duration_us_family_;
+  prometheus::Family<prometheus::Gauge>& inf_queue_size_family_;
 
   // Per-model Response Cache metrics
   // NOTE: Per-model metrics are used in infer_stats for perf_analyzer. Global
@@ -341,7 +350,7 @@ class Metrics {
   CpuInfo last_cpu_info_;
 #endif  // TRITON_ENABLE_METRICS_CPU
 
-  // Thread for polling cache/gpu metrics periodically
+  // Thread for polling cpu/gpu metrics periodically
   std::unique_ptr<std::thread> poll_thread_;
   std::atomic<bool> poll_thread_exit_;
   bool metrics_enabled_;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -208,7 +208,7 @@ class Metrics {
   // Metric family of instantaneous inference queue size per model
   static prometheus::Family<prometheus::Gauge>& FamilyInferenceQueueSize()
   {
-    return GetSingleton()->inf_queue_size_family_;
+    return GetSingleton()->inf_pending_request_count_family_;
   }
 
   // Metric families of per-model response cache metrics
@@ -293,7 +293,7 @@ class Metrics {
       inf_compute_infer_duration_us_family_;
   prometheus::Family<prometheus::Counter>&
       inf_compute_output_duration_us_family_;
-  prometheus::Family<prometheus::Gauge>& inf_queue_size_family_;
+  prometheus::Family<prometheus::Gauge>& inf_pending_request_count_family_;
 
   // Per-model Response Cache metrics
   // NOTE: Per-model metrics are used in infer_stats for perf_analyzer. Global

--- a/src/model.h
+++ b/src/model.h
@@ -136,7 +136,7 @@ class Model {
   // Get the configuration of model being served.
   const inference::ModelConfig& Config() const { return config_; }
 
-  // Get / set whether response cache is enabled for this model.
+  // Get whether response cache is enabled for this model.
   bool ResponseCacheEnabled() const
   {
     return config_.response_cache().enable();
@@ -232,7 +232,7 @@ class Model {
 
   uint64_t MaxPriorityLevel() const { return max_priority_level_; }
 
-  // Returns the scheduler's metric reporter
+  // Returns the model's metric reporter
   std::shared_ptr<MetricModelReporter> MetricReporter() const
   {
     return reporter_;

--- a/src/model.h
+++ b/src/model.h
@@ -225,6 +225,12 @@ class Model {
 
   uint64_t MaxPriorityLevel() const { return max_priority_level_; }
 
+  // Returns the scheduler's metric reporter
+  std::shared_ptr<MetricModelReporter> MetricReporter()
+  {
+    return scheduler_->MetricReporter();
+  }
+
  protected:
   virtual std::map<TRITONSERVER_MemoryType, std::map<int64_t, size_t>>
   AccumulatedInstanceMemoryUsage() const

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -199,7 +199,7 @@ Payload::Execute(bool* should_exit)
   Status status;
   switch (op_type_) {
     case Operation::INFER_RUN:
-      status = instance_->Schedule(std::move(requests_), OnCallback_);
+      status = instance_->Schedule(std::move(requests_));
       break;
     case Operation::INIT:
       status = instance_->Initialize();
@@ -212,6 +212,8 @@ Payload::Execute(bool* should_exit)
   }
 
   status_->set_value(status);
+  // Call specified callback, notifying that execution has completed.
+  Callback();
 }
 
 }}  // namespace triton::core

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -75,6 +75,12 @@ Payload::MergePayload(std::shared_ptr<Payload>& payload)
       requests_.end(), std::make_move_iterator(payload->Requests().begin()),
       std::make_move_iterator(payload->Requests().end()));
 
+  // TODO: Merge internal release callbacks here too?
+  std::cout << "[DEBUG]~~~~~~~~ MERGING PAYLOAD OF SIZE: "
+            << payload->RequestCount()
+            << " INTO CURRENT PAYLOAD. NEW TOTAL SIZE: " << this->RequestCount()
+            << std::endl;
+
   payload->Callback();
 
   return Status::Success;

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -87,7 +87,6 @@ Payload::Reset(const Operation op_type, TritonModelInstance* instance)
   requests_.clear();
   OnCallback_ = []() {};
   release_callbacks_.clear();
-  execute_callbacks_.clear();
   instance_ = instance;
   state_ = State::UNINITIALIZED;
   status_.reset(new std::promise<Status>());
@@ -104,7 +103,6 @@ Payload::Release()
   requests_.clear();
   OnCallback_ = []() {};
   release_callbacks_.clear();
-  execute_callbacks_.clear();
   instance_ = nullptr;
   state_ = State::RELEASED;
   required_equal_inputs_ = RequiredEqualInputs();
@@ -158,12 +156,6 @@ Payload::AddInternalReleaseCallback(std::function<void()>&& callback)
 }
 
 void
-Payload::AddInternalExecuteCallback(std::function<void()>&& callback)
-{
-  execute_callbacks_.emplace_back(std::move(callback));
-}
-
-void
 Payload::MarkSaturated()
 {
   saturated_ = true;
@@ -200,20 +192,8 @@ Payload::OnRelease()
 }
 
 void
-Payload::OnExecute()
-{
-  // Invoke the execute callbacks added internally before executing the payload.
-  for (auto it = execute_callbacks_.rbegin(); it != execute_callbacks_.rend();
-       it++) {
-    (*it)();
-  }
-  execute_callbacks_.clear();
-}
-
-void
 Payload::Execute(bool* should_exit)
 {
-  OnExecute();
   *should_exit = false;
 
   Status status;

--- a/src/payload.cc
+++ b/src/payload.cc
@@ -199,7 +199,7 @@ Payload::Execute(bool* should_exit)
   Status status;
   switch (op_type_) {
     case Operation::INFER_RUN:
-      instance_->Schedule(std::move(requests_), OnCallback_);
+      status = instance_->Schedule(std::move(requests_), OnCallback_);
       break;
     case Operation::INIT:
       status = instance_->Initialize();

--- a/src/payload.h
+++ b/src/payload.h
@@ -65,10 +65,18 @@ class Payload {
     return requests_;
   }
   uint64_t BatcherStartNs() { return batcher_start_ns_; }
-  void SetCallback(std::function<void()> OnCallback);
+  // Callback used for internal optimizations around payload dequeueing and
+  // execution, such as informing schedulers that payload slot(s) are available.
+  // Only a single callback of this form is used. For resource cleanup, see
+  // the OnRelease callbacks.
   void Callback();
-  void AddInternalReleaseCallback(std::function<void()>&& callback);
+  void SetCallback(std::function<void()> OnCallback);
+  // Callbacks used for any resource cleanup when a payload is about to be
+  // released. Some payloads may be released early before execution, such as
+  // paylods can be merged together for efficiency. Multiple release callbacks
+  // may be specified.
   void OnRelease();
+  void AddInternalReleaseCallback(std::function<void()>&& callback);
   void SetInstance(TritonModelInstance* model_instance);
   TritonModelInstance* GetInstance() { return instance_; }
   void MarkSaturated();

--- a/src/payload.h
+++ b/src/payload.h
@@ -67,14 +67,8 @@ class Payload {
   uint64_t BatcherStartNs() { return batcher_start_ns_; }
   void SetCallback(std::function<void()> OnCallback);
   void Callback();
-  // Add callbacks to be called when payload is released
   void AddInternalReleaseCallback(std::function<void()>&& callback);
-  // Call on release callbacks
   void OnRelease();
-  // Add callbacks to be called when payload is executed
-  void AddInternalExecuteCallback(std::function<void()>&& callback);
-  // Call on execute callbacks
-  void OnExecute();
   void SetInstance(TritonModelInstance* model_instance);
   TritonModelInstance* GetInstance() { return instance_; }
   void MarkSaturated();
@@ -96,7 +90,6 @@ class Payload {
   std::vector<std::unique_ptr<InferenceRequest>> requests_;
   std::function<void()> OnCallback_;
   std::vector<std::function<void()>> release_callbacks_;
-  std::vector<std::function<void()>> execute_callbacks_;
   TritonModelInstance* instance_;
   State state_;
   std::unique_ptr<std::promise<Status>> status_;

--- a/src/payload.h
+++ b/src/payload.h
@@ -67,8 +67,14 @@ class Payload {
   uint64_t BatcherStartNs() { return batcher_start_ns_; }
   void SetCallback(std::function<void()> OnCallback);
   void Callback();
+  // Add callbacks to be called when payload is released
   void AddInternalReleaseCallback(std::function<void()>&& callback);
+  // Call on release callbacks
   void OnRelease();
+  // Add callbacks to be called when payload is executed
+  void AddInternalExecuteCallback(std::function<void()>&& callback);
+  // Call on execute callbacks
+  void OnExecute();
   void SetInstance(TritonModelInstance* model_instance);
   TritonModelInstance* GetInstance() { return instance_; }
   void MarkSaturated();
@@ -90,6 +96,7 @@ class Payload {
   std::vector<std::unique_ptr<InferenceRequest>> requests_;
   std::function<void()> OnCallback_;
   std::vector<std::function<void()>> release_callbacks_;
+  std::vector<std::function<void()>> execute_callbacks_;
   TritonModelInstance* instance_;
   State state_;
   std::unique_ptr<std::promise<Status>> status_;

--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -349,6 +349,8 @@ RateLimiter::DequeuePayload(
     }
   }
   for (auto& merge_payload : merged_payloads) {
+    // TODO: Maybe call OnExecute() here
+    LOG_WARNING << "RELEASING MERGED PAYLOAD";
     PayloadRelease(merge_payload);
   }
   (*payload)->Callback();

--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -351,6 +351,7 @@ RateLimiter::DequeuePayload(
   for (auto& merge_payload : merged_payloads) {
     PayloadRelease(merge_payload);
   }
+  // Call specified callback, notifying that payloads have been dequeued/merged.
   (*payload)->Callback();
   if ((*payload)->GetInstance() == nullptr) {
     (*payload)->SetInstance(instances.front());

--- a/src/rate_limiter.cc
+++ b/src/rate_limiter.cc
@@ -349,8 +349,6 @@ RateLimiter::DequeuePayload(
     }
   }
   for (auto& merge_payload : merged_payloads) {
-    // TODO: Maybe call OnExecute() here
-    LOG_WARNING << "RELEASING MERGED PAYLOAD";
     PayloadRelease(merge_payload);
   }
   (*payload)->Callback();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -28,7 +28,6 @@
 #include <functional>
 
 #include "infer_request.h"
-#include "infer_stats.h"
 #include "status.h"
 
 namespace triton { namespace core {

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -28,6 +28,7 @@
 #include <functional>
 
 #include "infer_request.h"
+#include "infer_stats.h"
 #include "status.h"
 
 namespace triton { namespace core {
@@ -76,6 +77,9 @@ class Scheduler {
   // Instruct the scheduler to stop processing future requests unless they are
   // considered as in-flight.
   virtual void Stop() = 0;
+
+  // Return the metric model reporter for the scheduler..
+  virtual std::shared_ptr<MetricModelReporter> MetricReporter() const = 0;
 };
 
 }}  // namespace triton::core

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -145,8 +145,11 @@ SequenceBatchScheduler::Create(
   const size_t model_batch_size = std::max(1, config.max_batch_size());
   sched->seq_slot_cnt_ = model_batch_size;
   if (config.sequence_batching().has_oldest()) {
-    sched->seq_slot_cnt_ = std::max(
-        1, config.sequence_batching().oldest().max_candidate_sequences());
+    const auto& max_candidate_seqs =
+        config.sequence_batching().oldest().max_candidate_sequences();
+    if (max_candidate_seqs > 0) {
+      sched->seq_slot_cnt_ = max_candidate_seqs;
+    }
   }
 
   // Create a batcher for each instance.

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -79,7 +79,7 @@ AddRequestToPayload(
   payload->AddRequest(std::move(request));
   // Decrement queue size when payload is released to backend for execution
   if (reporter) {
-    auto cb = [&]() { reporter->DecrementGauge(kQueueSizeMetricName, 1); };
+    auto cb = [=]() { reporter->DecrementGauge(kQueueSizeMetricName, 1); };
     payload->AddInternalReleaseCallback(cb);
   }
 }
@@ -1700,9 +1700,9 @@ DirectSequenceBatch::BatcherThread(const int nice)
                   null_irequest->GetSequenceStates());
               ni->SetSequenceStates(sequence_states);
             }
-            // TODO: Is this request considered in queue?
-            AddRequestToPayload(
-                curr_payload_, std::move(ni), base_->MetricReporter());
+            // NOTE: No need to update queue size metric for null requests used
+            // to pad slots in batch.
+            curr_payload_->AddRequest(std::move(ni));
           } else {
             std::unique_ptr<InferenceRequest>& irequest = queue.front();
 

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -1809,7 +1809,8 @@ OldestSequenceBatch::OldestSequenceBatch(
       model_instance->Model(), model_instance,
       triton::common::GetCpuNiceLevel(config),
       true /* dynamic_batching_enabled */, config.max_batch_size(),
-      enforce_equal_shape_tensors_, true /* preserve_ordering */,
+      enforce_equal_shape_tensors_,
+      config.sequence_batching().oldest().preserve_ordering(),
       false /* response_cache_enable */, preferred_batch_sizes,
       config.sequence_batching().oldest().max_queue_delay_microseconds(),
       &dynamic_batcher_);

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -26,8 +26,6 @@
 
 #include "sequence_batch_scheduler.h"
 
-#include "infer_request.h"
-
 #ifndef _WIN32
 #include <sys/resource.h>
 #include <sys/syscall.h>
@@ -72,7 +70,6 @@ SetThreadPriority(const int nice, const char* thread_name)
 }
 
 }  // namespace
-
 
 Status
 SequenceBatchScheduler::Create(
@@ -1672,6 +1669,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
                   null_irequest->GetSequenceStates());
               ni->SetSequenceStates(sequence_states);
             }
+
             curr_payload_->AddRequest(std::move(ni));
           } else {
             std::unique_ptr<InferenceRequest>& irequest = queue.front();
@@ -1687,6 +1685,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
               end_of_sequence = true;
             }
             curr_payload_->AddRequest(std::move(irequest));
+
             queue.pop_front();
           }
 

--- a/src/sequence_batch_scheduler.h
+++ b/src/sequence_batch_scheduler.h
@@ -124,14 +124,15 @@ class SequenceBatchScheduler : public Scheduler {
     return initial_state_;
   }
 
+  std::shared_ptr<MetricModelReporter> MetricReporter() const
+  {
+    return reporter_;
+  }
+
  private:
   SequenceBatchScheduler(
       TritonModel* model,
-      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors)
-      : model_(model),
-        enforce_equal_shape_tensors_(enforce_equal_shape_tensors), stop_(false)
-  {
-  }
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors);
 
   void StartBackgroundThreads();
   void StopBackgroundThreads();
@@ -274,6 +275,9 @@ class SequenceBatchScheduler : public Scheduler {
   // Initial state used for implicit state.
   std::unordered_map<std::string, SequenceStates::InitialStateData>
       initial_state_;
+
+  // Reporter for metrics, or nullptr if no metrics should be reported
+  std::shared_ptr<MetricModelReporter> reporter_;
 };
 
 // Base class for a scheduler that implements a particular scheduling

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -66,6 +66,8 @@ InferenceRequest::InferenceRequest(
   response_factory_.reset(new InferenceResponseFactory());
 }
 
+InferenceRequest::~InferenceRequest() {}
+
 InferenceRequest::Input::Input(
     const std::string& name, const inference::DataType datatype,
     const int64_t* shape, const uint64_t dim_count)


### PR DESCRIPTION
# Overview

Server/Tests PR: https://github.com/triton-inference-server/server/pull/6233

For simplicity, the definition of "queued" requests in this PR is **any** requests that are sitting somewhere in Triton core and have not yet been picked up by a backend model instance thread for execution.

This PR adds a new prometheus metric "nv_inference_pending_request_count" per-model:
```
# HELP nv_inference_pending_request_count Instantaneous number of pending requests awaiting execution per-model.
# TYPE nv_inference_pending_request_count gauge
nv_inference_pending_request_count{model="default",version="1"} 17
nv_inference_pending_request_count{model="dynamic",version="1"} 3
nv_inference_pending_request_count{model="sequence_direct",version="1"} 42
nv_inference_pending_request_count{model="sequence_oldest",version="1"} 26
```

## How It Works

Currently the code is reporting `count++` on every `request->Scheduler->Enqueue(request)`, and `count--` when a request is about to be passed to a backend in `TritonModelInstance::Execute(requests)`, both done via state transition. 

## State Transitions

In the event that a request encounters an error anywhere along the way within core, some state transitions were added to help detect if the count should be updated when the request is getting destructed.

These state transitions may also be helpful in the near future for handling a potential `CANCELLED` state.

Currently the `RELEASED` state is just for completeness to have a state after execution has finished. It's not doing very much right now other than some possible error checking that we're not moving a request from RELEASED state to some other state, as that is probably a sign of invalid behavior or code smell for now.

## Performance Implications

We use `prometheus-cpp` for our metric updates, and there is a thorough benchmark of each operation [here](https://github.com/jupp0r/prometheus-cpp#benchmarks). For queue size, we are using a `gauge` which can both increase and decrease in value, compared to monotonic `counter`s. The relevant operations are timed here:
```
BM_Gauge_Increment                                  12 ns         12 ns   51511873
BM_Gauge_Decrement                                  12 ns         12 ns   56831098
```
As shown, the `Increment(value)` and `Decrement(value)` operations should be quite fast, adding a 24 nanosecond (12ns increment +12ns decrement) cost per request for the benefit of instant queue size updates for client-side load balancing/tracking.

I'll do some perf analyzer runs before/after as a sanity check.

## Alternatives Considered

One alternative considered instead of updating on every queue size change:

Tracking the queue size internally, but only updating the metric on a certain `--metrics-interval-ms` with a polling thread, similar to the GPU/CPU metrics today.

However, doing so would likely require exposing a lot of data structures from ModelRepositoryManager / ModelLifecycle / Server to the Metrics class to iterate over all models/schedulers and get their current reported queue sizes. This would probably (a) be much more involved code, (b) contend with the locks around models/modelInfos used for repository management / request creation, and (c) update the metric with less precision. So ultimately, I decided for the live updates since the cost (~24ns) appeared minimal, and independent of backend execution.

## Tests/Docs

Tests/docs: https://github.com/triton-inference-server/server/pull/6233

Local testing for all scheduler types is looking pretty good so far.

I intend to add some detailed docs to [metrics.md](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md) detailing the definition of "queue size" similar to above. Let me know if there's anything you'd want to see in the docs called out specifically.

---

# Archived Notes

The following is an outdated payload-based approach compared to current request-based tracking approach. I'll leave it in as it has some nice details for future reference, but is not very relevant to the current PR.

<details>
  <summary>Expand</summary>

### Queues Involved Per Scheduler

Depending on the type of scheduler used by the model, the definition of "queue" is varied. Additionally, all schedulers (not counting ensemble) currently go through RateLimiter Payloads, and queue up some payloads there in addition to their own notions of queues.

**Default Scheduler:**
- No scheduler queue, immediately pushes all requests to payload queues in Rate Limiter (per-model: "general/model queue")

**Dynamic Batch Scheduler:**
- Internal queue for forming batches
- Pushes batches into payload queues in Rate Limiter (per-model: "general/model queue")

**Sequence Batch Scheduler Direct:**
- Sequence Backlogs
- Rate Limiter Queues (per-model-instance: "specific queues")

**Sequence Batch Scheduler Oldest:**
- Sequence Backlogs
- Dynamic Batch Scheduler queue
- Rate Limiter Queues (per-model-instance; "specific queues")

**Ensemble Scheduler:**
- No scheduler queue, immediately schedules requests to composing model schedulers, following per-scheduler logic above
- Currently, the ensemble level "queue size" will just remain zero, and be reflected in the composing models. It may be possible to improve this to reflect the sum of all composing model queues, but I left that out for now.

### En-queueing Requests

To simplify the logic around tracking and syncing all subsequent data structures involved for holding "queued" requests, I decided to simply add 1 to the "queue size" when hitting the `Scheduler->Enqueue(request)` function. 

### De-queueing Requests

Similarly, since all schedulers ultimately end up hitting the Rate Limiter payloads before execution in a backend model instance, I decided to take advantage of the `Payload::OnRelease` callback that is called when a backend picks up a payload for execution. Since these are exposed to the schedulers via `payload->AddInternalReleaseCallback(callback)`, it allows for a nice separation of scheduler-specific logic without going through and modifying the existing RateLimiter/Payload logic.

Depending on the scheduler used and whether batching is supported or not, the number of requests in each payload (or in other words the number of requests that are de-queued at once) can vary up to the defined `max_batch_size`. 

**EDIT**: The payload appears to not actually be released until the model instance finishes executing the request (not counting [merge_payloads](https://github.com/triton-inference-server/core/blob/fc2ada26cfbabd17c4f65058d4ee1531debc3495/src/rate_limiter.cc#L351-L353)), whereas I originally thought it was released as soon as the backend picked it up/started executing. So the metric includes currently executing request count as well. If we transition to the idea of adding an "OnExecute" callback to payloads, this fixes the problem of not counting requests in-execution, but it introduces a lot of special handling required if requests exit early for an errors before getting to the execution point.

</details>

Closes https://github.com/triton-inference-server/server/issues/5927.