### PR TITLE
[DO NOT MERGE] Python binding of Triton server C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,3 +415,25 @@ export(
 )
 
 export(PACKAGE TritonCore)
+
+FetchContent_Declare(
+  pybind11
+  GIT_REPOSITORY "https://github.com/pybind/pybind11"
+  # COMMIT ID for v2.10.0
+  GIT_TAG "aa304c9c7d725ffb9d10af08a3b34cb372307020"
+  GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(pybind11)
+set(
+  PYTHON_BINDING_SRCS
+  python/binding/tritonserver_pybind.cc
+)
+
+pybind11_add_module(triton_bindings SHARED ${PYTHON_BINDING_SRCS})
+target_link_libraries(
+  triton_bindings
+  PRIVATE
+  triton-core-serverapi           # from repo-core
+  triton-core-serverstub          # from repo-core
+)
+target_compile_features(triton_bindings PRIVATE cxx_std_17)

--- a/python/_infer.py
+++ b/python/_infer.py
@@ -7,7 +7,6 @@ import queue
 
 
 class Tensor:
-
     def __init__(self) -> None:
         # tensor metadata
         self.data_type: DataType = None

--- a/python/_logger.py
+++ b/python/_logger.py
@@ -58,7 +58,7 @@ class GlobalLogger:
     def file(self) -> str:
         return self._file
 
-    @format.setter
+    @file.setter
     def file(self, f: str) -> None:
         # TRITONSERVER_ServerOptionsSetLogFile
         self._file = f

--- a/python/binding/tritonserver_pybind.cc
+++ b/python/binding/tritonserver_pybind.cc
@@ -1,0 +1,1267 @@
+
+
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <triton/core/tritonserver.h>
+
+// This binding is merely used to map Triton C API into Python equivalent,
+// and therefore, the naming will be the same as the one used in corresponding
+// sections. However, there are a few exceptions to better transit to Python:
+//  * Triton structs are encapsulated in a thin wrapper to isolate raw pointer
+//    operations which is not supported in pure Python.
+//  * Output parameters are converted to return value, so the APIs return a
+//    tuple of (error, *ret_vals), where user will check if `error is None`
+//    before examining the return values. The same applies to callbacks
+
+namespace py = pybind11;
+namespace triton { namespace core { namespace python {
+
+#define DISALLOW_COPY(TypeName) TypeName(const TypeName&) = delete;
+#define DISALLOW_ASSIGN(TypeName) void operator=(const TypeName&) = delete;
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  DISALLOW_COPY(TypeName)                  \
+  DISALLOW_ASSIGN(TypeName)
+
+// [FIXME] GIL
+
+// base exception for all Triton error code
+struct TritonError : public std::runtime_error {
+  explicit TritonError(const std::string& what) : std::runtime_error(what) {}
+};
+
+// triton::core::python exceptions map 1:1 to TRITONSERVER_Error_Code.
+struct Unknown : public TritonError {
+  explicit Unknown(const std::string& what) : TritonError(what) {}
+};
+struct Internal : public TritonError {
+  explicit Internal(const std::string& what) : TritonError(what) {}
+};
+struct NotFound : public TritonError {
+  explicit NotFound(const std::string& what) : TritonError(what) {}
+};
+struct InvalidArgument : public TritonError {
+  explicit InvalidArgument(const std::string& what) : TritonError(what) {}
+};
+struct Unavailable : public TritonError {
+  explicit Unavailable(const std::string& what) : TritonError(what) {}
+};
+struct Unsupported : public TritonError {
+  explicit Unsupported(const std::string& what) : TritonError(what) {}
+};
+struct AlreadyExists : public TritonError {
+  explicit AlreadyExists(const std::string& what) : TritonError(what) {}
+};
+
+// [WIP] to convertor and helper function
+TRITONSERVER_Error*
+CreateTRITONSERVER_ErrorFrom(const py::error_already_set& ex)
+{
+  // Reserved lookup to get Python type of the exceptions,
+  // 'TRITONSERVER_ERROR_UNKNOWN' is the fallback error code.
+  // static auto uk = py::module::import("triton_bindings").attr("Unknown");
+  static auto it = py::module::import("triton_bindings").attr("Internal");
+  static auto nf = py::module::import("triton_bindings").attr("NotFound");
+  static auto ia =
+      py::module::import("triton_bindings").attr("InvalidArgument");
+  static auto ua = py::module::import("triton_bindings").attr("Unavailable");
+  static auto us = py::module::import("triton_bindings").attr("Unsupported");
+  static auto ae = py::module::import("triton_bindings").attr("AlreadyExists");
+  TRITONSERVER_Error_Code code = TRITONSERVER_ERROR_UNKNOWN;
+  if (ex.matches(it.ptr())) {
+    code = TRITONSERVER_ERROR_INTERNAL;
+  } else if (ex.matches(nf.ptr())) {
+    code = TRITONSERVER_ERROR_NOT_FOUND;
+  } else if (ex.matches(ia.ptr())) {
+    code = TRITONSERVER_ERROR_INVALID_ARG;
+  } else if (ex.matches(ua.ptr())) {
+    code = TRITONSERVER_ERROR_UNAVAILABLE;
+  } else if (ex.matches(us.ptr())) {
+    code = TRITONSERVER_ERROR_UNSUPPORTED;
+  } else if (ex.matches(ae.ptr())) {
+    code = TRITONSERVER_ERROR_ALREADY_EXISTS;
+  }
+  return TRITONSERVER_ErrorNew(code, ex.what());
+}
+
+void
+ThrowIfError(TRITONSERVER_Error* err)
+{
+  if (err == nullptr) {
+    return;
+  }
+  std::shared_ptr<TRITONSERVER_Error> managed_err(
+      err, TRITONSERVER_ErrorDelete);
+  std::string msg = TRITONSERVER_ErrorMessage(err);
+  switch (TRITONSERVER_ErrorCode(err)) {
+    case TRITONSERVER_ERROR_INTERNAL:
+      throw Internal(std::move(msg));
+    case TRITONSERVER_ERROR_NOT_FOUND:
+      throw NotFound(std::move(msg));
+    case TRITONSERVER_ERROR_INVALID_ARG:
+      throw InvalidArgument(std::move(msg));
+    case TRITONSERVER_ERROR_UNAVAILABLE:
+      throw Unavailable(std::move(msg));
+    case TRITONSERVER_ERROR_UNSUPPORTED:
+      throw Unsupported(std::move(msg));
+    case TRITONSERVER_ERROR_ALREADY_EXISTS:
+      throw AlreadyExists(std::move(msg));
+    default:
+      throw Unknown(std::move(msg));
+  }
+}
+
+void
+LogIfError(TRITONSERVER_Error* err)
+{
+  if (err == nullptr) {
+    return;
+  }
+  std::shared_ptr<TRITONSERVER_Error> managed_err(
+      err, TRITONSERVER_ErrorDelete);
+  py::print(TRITONSERVER_ErrorMessage(err));
+}
+
+class PyParameter {
+ public:
+  PyParameter(
+      TRITONSERVER_Parameter* parameter,
+      const bool owned /* [FIXME] check if needed*/)
+      : parameter_(parameter_), owned_(owned)
+  {
+  }
+
+  PyParameter(
+      const char* name, TRITONSERVER_ParameterType type, const void* value)
+      : parameter_(TRITONSERVER_ParameterNew(name, type, value)), owned_(true)
+  {
+  }
+
+  PyParameter(const char* name, const void* byte_ptr, uint64_t size)
+      : parameter_(TRITONSERVER_ParameterBytesNew(name, byte_ptr, size)),
+        owned_(true)
+  {
+  }
+
+  ~PyParameter()
+  {
+    if (owned_ && parameter_) {
+      TRITONSERVER_ParameterDelete(parameter_);
+    }
+  }
+
+  DISALLOW_COPY_AND_ASSIGN(PyParameter);
+
+  // Use internally when interacting with C APIs that takes ownership
+  TRITONSERVER_Parameter* Release()
+  {
+    owned_ = false;
+    return parameter_;
+  }
+
+ private:
+  TRITONSERVER_Parameter* parameter_{nullptr};
+  // [FIXME] may need to transfer ownership
+  bool owned_{false};
+};
+
+class PyBufferAttributes {
+ public:
+  // [WIP] need this?
+  explicit PyBufferAttributes()
+  {
+    ThrowIfError(TRITONSERVER_BufferAttributesNew(&buffer_attributes_));
+    owned_ = true;
+  }
+
+  PyBufferAttributes(
+      TRITONSERVER_BufferAttributes* ba,
+      const bool owned /* [FIXME] check if needed*/)
+      : buffer_attributes_(ba), owned_(owned)
+  {
+  }
+
+  // Use internally when interacting with C APIs that takes ownership
+  TRITONSERVER_BufferAttributes* Release()
+  {
+    owned_ = false;
+    return buffer_attributes_;
+  }
+
+  TRITONSERVER_BufferAttributes* Ptr() { return buffer_attributes_; }
+
+  ~PyBufferAttributes()
+  {
+    if (owned_ && buffer_attributes_) {
+      owned_ = false;
+      LogIfError(TRITONSERVER_BufferAttributesDelete(buffer_attributes_));
+    }
+  }
+
+  void SetMemoryTypeId(int64_t memory_type_id)
+  {
+    ThrowIfError(TRITONSERVER_BufferAttributesSetMemoryTypeId(
+        buffer_attributes_, memory_type_id));
+  }
+
+  void SetMemoryType(TRITONSERVER_MemoryType memory_type)
+  {
+    ThrowIfError(TRITONSERVER_BufferAttributesSetMemoryType(
+        buffer_attributes_, memory_type));
+  }
+
+  void SetCudaIpcHandle(size_t cuda_ipc_handle)
+  {
+    ThrowIfError(TRITONSERVER_BufferAttributesSetCudaIpcHandle(
+        buffer_attributes_, reinterpret_cast<void*>(cuda_ipc_handle)));
+  }
+
+  void SetByteSize(size_t byte_size)
+  {
+    ThrowIfError(TRITONSERVER_BufferAttributesSetByteSize(
+        buffer_attributes_, byte_size));
+  }
+
+  // Define methods to get buffer attribute fields
+  int64_t MemoryTypeId()
+  {
+    int64_t memory_type_id = 0;
+    ThrowIfError(TRITONSERVER_BufferAttributesMemoryTypeId(
+        buffer_attributes_, &memory_type_id));
+    return memory_type_id;
+  }
+
+  TRITONSERVER_MemoryType MemoryType()
+  {
+    TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
+    ThrowIfError(TRITONSERVER_BufferAttributesMemoryType(
+        buffer_attributes_, &memory_type));
+    return memory_type;
+  }
+
+  size_t CudaIpcHandle()
+  {
+    void* cuda_ipc_handle = nullptr;
+    ThrowIfError(TRITONSERVER_BufferAttributesCudaIpcHandle(
+        buffer_attributes_, &cuda_ipc_handle));
+    return reinterpret_cast<size_t>(cuda_ipc_handle);
+  }
+
+  size_t ByteSize()
+  {
+    size_t byte_size;
+    ThrowIfError(
+        TRITONSERVER_BufferAttributesByteSize(buffer_attributes_, &byte_size));
+    return byte_size;
+  }
+
+ private:
+  struct TRITONSERVER_BufferAttributes* buffer_attributes_{nullptr};
+  bool owned_{false};
+};
+
+class PyResponseAllocator {
+ public:
+  struct CallbackResource {
+    CallbackResource(py::object a, py::object uo)
+        : allocator(a), user_object(uo)
+    {
+    }
+    py::object allocator;
+    py::object user_object;
+  };
+  using AllocFn = std::function<
+      std::tuple<size_t, py::object, TRITONSERVER_MemoryType, int64_t>(
+          py::object, std::string, size_t, TRITONSERVER_MemoryType, int64_t,
+          py::object)>;
+  using ReleaseFn = std::function<void(
+      py::object, size_t, py::object, size_t, TRITONSERVER_MemoryType,
+      int64_t)>;
+  using StartFn = std::function<void(py::object, py::object)>;
+
+  // size as input, optional?
+  using QueryFn = std::function<std::tuple<TRITONSERVER_MemoryType, int64_t>(
+      py::object, py::object, std::string, std::optional<size_t>,
+      TRITONSERVER_MemoryType, int64_t)>;
+  using BufferAttributesFn = std::function<py::object(
+      py::object, std::string, py::object, py::object, py::object)>;
+
+  DISALLOW_COPY_AND_ASSIGN(PyResponseAllocator);
+
+  // Use internally when interacting with C APIs that takes ownership
+  TRITONSERVER_ResponseAllocator* Release()
+  {
+    owned_ = false;
+    return allocator_;
+  }
+
+  PyResponseAllocator(AllocFn alloc, ReleaseFn release, StartFn start)
+      : alloc_fn_(alloc), release_fn_(release), start_fn_(start)
+  {
+    // [WIP] error -> exception in general
+    ThrowIfError(TRITONSERVER_ResponseAllocatorNew(
+        &allocator_, PyTritonAllocFn, PyTritonReleaseFn, PyTritonStartFn));
+    owned_ = true;
+  }
+
+  // Below implements the Triton callbacks, note that when registering the
+  // callbacks in Triton, an wrapped 'CallbackResource' must be used to bridge
+  // the gap between the Python API and C API.
+  static TRITONSERVER_Error* PyTritonAllocFn(
+      struct TRITONSERVER_ResponseAllocator* allocator, const char* tensor_name,
+      size_t byte_size, TRITONSERVER_MemoryType memory_type,
+      int64_t memory_type_id, void* userp, void** buffer, void** buffer_userp,
+      TRITONSERVER_MemoryType* actual_memory_type,
+      int64_t* actual_memory_type_id)
+  {
+    TRITONSERVER_Error* err = nullptr;
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    try {
+      auto res = cr->allocator.cast<PyResponseAllocator*>()->alloc_fn_(
+          cr->allocator, tensor_name, byte_size, memory_type, memory_type_id,
+          cr->user_object);
+      *buffer = reinterpret_cast<void*>(std::get<0>(res));
+      {
+        // In C API usage, its typical to allocate user object within the
+        // callback and place the release logic in release callback. The same
+        // logic can't trivially ported to Python as user object is scoped,
+        // therefore the binding needs to wrap the object to ensure the user
+        // object will not be garbage collected until after release callback.
+        *buffer_userp = new CallbackResource(cr->allocator, std::get<1>(res));
+      }
+      *actual_memory_type = std::get<2>(res);
+      *actual_memory_type_id = std::get<3>(res);
+    }
+    catch (py::error_already_set& ex) {
+      err = CreateTRITONSERVER_ErrorFrom(ex);
+    }
+    return err;
+  }
+
+  static TRITONSERVER_Error* PyTritonReleaseFn(
+      struct TRITONSERVER_ResponseAllocator* allocator, void* buffer,
+      void* buffer_userp, size_t byte_size, TRITONSERVER_MemoryType memory_type,
+      int64_t memory_type_id)
+  {
+    TRITONSERVER_Error* err = nullptr;
+    auto cr = reinterpret_cast<CallbackResource*>(buffer_userp);
+    try {
+      cr->allocator.cast<PyResponseAllocator*>()->release_fn_(
+          cr->allocator, reinterpret_cast<size_t>(buffer), cr->user_object,
+          byte_size, memory_type, memory_type_id);
+    }
+    catch (py::error_already_set& ex) {
+      err = CreateTRITONSERVER_ErrorFrom(ex);
+    }
+    // Done with CallbackResource
+    delete cr;
+    return err;
+  }
+
+  static TRITONSERVER_Error* PyTritonStartFn(
+      struct TRITONSERVER_ResponseAllocator* allocator, void* userp)
+  {
+    TRITONSERVER_Error* err = nullptr;
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    try {
+      cr->allocator.cast<PyResponseAllocator*>()->start_fn_(
+          cr->allocator, cr->user_object);
+    }
+    catch (py::error_already_set& ex) {
+      err = CreateTRITONSERVER_ErrorFrom(ex);
+    }
+    return err;
+  }
+
+  static TRITONSERVER_Error* PyTritonQueryFn(
+      struct TRITONSERVER_ResponseAllocator* allocator, void* userp,
+      const char* tensor_name, size_t* byte_size,
+      TRITONSERVER_MemoryType* memory_type, int64_t* memory_type_id)
+  {
+    TRITONSERVER_Error* err = nullptr;
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    try {
+      std::optional<size_t> bs;
+      if (byte_size) {
+        bs = *byte_size;
+      }
+      auto res = cr->allocator.cast<PyResponseAllocator*>()->query_fn_(
+          cr->allocator, cr->user_object, tensor_name, bs, *memory_type,
+          *memory_type_id);
+      *memory_type = std::get<0>(res);
+      *memory_type_id = std::get<1>(res);
+    }
+    catch (py::error_already_set& ex) {
+      err = CreateTRITONSERVER_ErrorFrom(ex);
+    }
+    return err;
+  }
+
+  static TRITONSERVER_Error* PyTritonBufferAttributesFn(
+      struct TRITONSERVER_ResponseAllocator* allocator, const char* tensor_name,
+      struct TRITONSERVER_BufferAttributes* buffer_attributes, void* userp,
+      void* buffer_userp)
+  {
+    TRITONSERVER_Error* err = nullptr;
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    auto bcr = reinterpret_cast<CallbackResource*>(buffer_userp);
+    PyBufferAttributes pba{buffer_attributes, false /* owned_ */};
+    try {
+      // Python version of BufferAttributes callback has return value
+      // to be the filled buffer attributes. The callback implementation
+      // should modify the passed PyBufferAttributes object and return it.
+      // However, the implementation may construct new PyBufferAttributes
+      // which requires additional checking to properly return the attributes
+      // through C API.
+      auto res =
+          cr->allocator.cast<PyResponseAllocator*>()->buffer_attributes_fn_(
+              cr->allocator, tensor_name,
+              py::cast(pba, py::return_value_policy::reference),
+              cr->user_object, bcr->user_object);
+      // Copy if 'res' is new object, otherwise the attributes have been set.
+      auto res_pba = res.cast<PyBufferAttributes*>();
+      if (res_pba->Ptr() != buffer_attributes) {
+        pba.SetMemoryTypeId(res_pba->MemoryTypeId());
+        pba.SetMemoryType(res_pba->MemoryType());
+        pba.SetCudaIpcHandle(res_pba->CudaIpcHandle());
+        pba.SetByteSize(res_pba->ByteSize());
+      }
+    }
+    catch (py::error_already_set& ex) {
+      err = CreateTRITONSERVER_ErrorFrom(ex);
+    }
+    return err;
+  }
+
+  void SetBufferAttributesFunction(BufferAttributesFn baf)
+  {
+    buffer_attributes_fn_ = baf;
+    ThrowIfError(TRITONSERVER_ResponseAllocatorSetBufferAttributesFunction(
+        allocator_, PyTritonBufferAttributesFn));
+  }
+
+  void SetQueryFunction(QueryFn qf)
+  {
+    query_fn_ = qf;
+    ThrowIfError(TRITONSERVER_ResponseAllocatorSetQueryFunction(
+        allocator_, PyTritonQueryFn));
+  }
+
+  ~PyResponseAllocator()
+  {
+    if (owned_ && allocator_) {
+      TRITONSERVER_ResponseAllocatorDelete(allocator_);
+    }
+  }
+
+  //  private:
+  TRITONSERVER_ResponseAllocator* allocator_{nullptr};
+  // [FIXME] may need to transfer ownership
+  bool owned_{false};
+
+  AllocFn alloc_fn_{nullptr};
+  ReleaseFn release_fn_{nullptr};
+  StartFn start_fn_{nullptr};
+  QueryFn query_fn_{nullptr};
+  BufferAttributesFn buffer_attributes_fn_{nullptr};
+};
+
+class PyMessage {
+ public:
+  explicit PyMessage(const std::string& serialized_json) : owned_(true)
+  {
+    ThrowIfError(TRITONSERVER_MessageNewFromSerializedJson(
+        &message_, serialized_json.c_str(), serialized_json.size()));
+  }
+
+  ~PyMessage()
+  {
+    if (owned_ && message_) {
+      // Only log error in destructor.
+      LogIfError(TRITONSERVER_MessageDelete(message_));
+    }
+  }
+
+  std::string SerializeToJson()
+  {
+    const char* base = nullptr;
+    size_t byte_size = 0;
+    ThrowIfError(
+        TRITONSERVER_MessageSerializeToJson(message_, &base, &byte_size));
+    return std::string(base, byte_size);
+  }
+
+ private:
+  struct TRITONSERVER_Message* message_{nullptr};
+  bool owned_{false};
+};
+
+class PyMetrics {
+ public:
+  explicit PyMetrics(struct TRITONSERVER_Metrics* metrics, bool owned)
+      : metrics_(metrics), owned_(owned)
+  {
+  }
+
+  ~PyMetrics()
+  {
+    if (owned_ && metrics_) {
+      // Only log error in destructor.
+      LogIfError(TRITONSERVER_MetricsDelete(metrics_));
+    }
+  }
+
+  std::string Formatted(TRITONSERVER_MetricFormat format)
+  {
+    const char* base = nullptr;
+    size_t byte_size = 0;
+    ThrowIfError(
+        TRITONSERVER_MetricsFormatted(metrics_, format, &base, &byte_size));
+    return std::string(base, byte_size);
+  }
+
+ private:
+  struct TRITONSERVER_Metrics* metrics_{nullptr};
+  bool owned_{false};
+};
+
+class PyTrace {
+ public:
+  struct CallbackResource {
+    CallbackResource(py::object uo) : user_object(uo) {}
+    // 'trace' is not initalized until a later point, see Capture()
+    // for reasoning.
+    py::object trace;
+    py::object user_object;
+    // The trace API will use the same 'trace_userp' for all traces associated
+    // with the request, and becasue there is no guarantee that the root trace
+    // must be released last, need to track all trace seen / released to
+    // determine whether this CallbackResource may be released.
+    std::set<uintptr_t> seen_traces;
+  };
+  using TimestampActivityFn = std::function<void(
+      py::object, TRITONSERVER_InferenceTraceActivity, uint64_t, py::object)>;
+  using TensorActivityFn = std::function<void(
+      py::object, TRITONSERVER_InferenceTraceActivity, std::string,
+      TRITONSERVER_DataType, size_t, size_t, py::array_t<int64_t>,
+      TRITONSERVER_MemoryType, int64_t, py::object)>;
+  // [FIXME] mean different things in Python binding..
+  using ReleaseFn = std::function<void(py::object, py::object)>;
+
+  DISALLOW_COPY_AND_ASSIGN(PyTrace);
+
+  // Use internally when interacting with C APIs that takes ownership
+  // TRITONSERVER_InferenceTrace* Release()
+  // {
+  //   owned_ = false;
+  //   return trace_;
+  // }
+
+  PyTrace(
+      TRITONSERVER_InferenceTraceLevel level, uint64_t parent_id,
+      TimestampActivityFn timestamp, ReleaseFn release, py::object user_object)
+      : owned_(true), timestamp_fn_(timestamp), release_fn_(release),
+        callback_resource_(new CallbackResource(user_object))
+  {
+    ThrowIfError(TRITONSERVER_InferenceTraceNew(
+        &trace_, level, parent_id, PyTritonTraceTimestampActivityFn,
+        PyTritonTraceRelease, callback_resource_.get()));
+  }
+
+  PyTrace(
+      TRITONSERVER_InferenceTraceLevel level, uint64_t parent_id,
+      TimestampActivityFn timestamp, TensorActivityFn tensor, ReleaseFn release,
+      py::object user_object)
+      : owned_(true), timestamp_fn_(timestamp), tensor_fn_(tensor),
+        release_fn_(release),
+        callback_resource_(new CallbackResource(user_object))
+  {
+    ThrowIfError(TRITONSERVER_InferenceTraceTensorNew(
+        &trace_, level, parent_id, PyTritonTraceTimestampActivityFn,
+        PyTritonTraceTensorActivityFn, PyTritonTraceRelease,
+        callback_resource_.get()));
+  }
+
+  PyTrace(
+      struct TRITONSERVER_InferenceTrace* t,
+      const bool owned /* [FIXME] check if needed*/)
+      : trace_(t), owned_(owned)
+  {
+  }
+
+  ~PyTrace()
+  {
+    if (owned_ && trace_) {
+      TRITONSERVER_InferenceTraceDelete(trace_);
+    }
+  }
+  // Capture the py::object representation ('trace') of 'this' into
+  // CallbackResource, by doing so the 'trace' Python object will be kept
+  // alive due to non-zero reference count even if Python user drops all
+  // reference on the Python side.
+  // This function will be called in the binding equivalent of
+  // 'TRITONSERVER_ServerInferAsync' to follow the behavior that the API
+  // unconditionally takes ownership of 'trace' and only releases through
+  // release callback, which implies the user may drop all references and
+  // expect the same object to be passed into release callback.
+  // Note that the capture must be separated from object construction to comply
+  // with regular Python object lifecycle until 'TRITONSERVER_ServerInferAsync'.
+  void Capture(py::object trace)
+  {
+    if (callback_resource_) {
+      callback_resource_->trace = trace;
+    }
+  }
+  void InternalRelease()
+  {
+    if (callback_resource_) {
+      callback_resource_.reset();
+    }
+  }
+
+  uint64_t Id()
+  {
+    uint64_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceTraceId(trace_, &val));
+    return val;
+  }
+
+  uint64_t ParentId()
+  {
+    uint64_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceTraceParentId(trace_, &val));
+    return val;
+  }
+
+  std::string ModelName()
+  {
+    const char* val = nullptr;
+    ThrowIfError(TRITONSERVER_InferenceTraceModelName(trace_, &val));
+    return val;
+  }
+
+  int64_t ModelVersion()
+  {
+    int64_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceTraceModelVersion(trace_, &val));
+    return val;
+  }
+
+  std::string RequestId()
+  {
+    const char* val = nullptr;
+    ThrowIfError(TRITONSERVER_InferenceTraceRequestId(trace_, &val));
+    return val;
+  }
+
+  // Below implements the Triton callbacks, note that when registering the
+  // callbacks in Triton, an wrapped 'CallbackResource' must be used to bridge
+  // the gap between the Python API and C API.
+  static void PyTritonTraceTimestampActivityFn(
+      struct TRITONSERVER_InferenceTrace* trace,
+      TRITONSERVER_InferenceTraceActivity activity, uint64_t timestamp_ns,
+      void* userp)
+  {
+    // Note that 'trace' associated with the activity is not necessary the
+    // root trace captured in Callback Resource, so need to always wrap 'trace'
+    // in PyTrace for the Python callabck to interact with the correct trace.
+    PyTrace pt(trace, false /* owned */);
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    cr->seen_traces.insert(reinterpret_cast<uintptr_t>(trace));
+    cr->trace.cast<PyTrace*>()->timestamp_fn_(
+        py::cast(pt, py::return_value_policy::reference), activity,
+        timestamp_ns, cr->user_object);
+  }
+
+  static void PyTritonTraceTensorActivityFn(
+      struct TRITONSERVER_InferenceTrace* trace,
+      TRITONSERVER_InferenceTraceActivity activity, const char* name,
+      TRITONSERVER_DataType datatype, const void* base, size_t byte_size,
+      const int64_t* shape, uint64_t dim_count,
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id, void* userp)
+  {
+    // See 'PyTritonTraceTimestampActivityFn' for 'pt' explanation.
+    PyTrace pt(trace, false /* owned */);
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    cr->seen_traces.insert(reinterpret_cast<uintptr_t>(trace));
+    cr->trace.cast<PyTrace*>()->tensor_fn_(
+        py::cast(pt, py::return_value_policy::reference), activity, name,
+        datatype, reinterpret_cast<size_t>(base), byte_size,
+        py::array_t<int64_t>({dim_count}, {}, shape), memory_type,
+        memory_type_id, cr->user_object);
+  }
+
+  static void PyTritonTraceRelease(
+      struct TRITONSERVER_InferenceTrace* trace, void* userp)
+  {
+    // See 'PyTritonTraceTimestampActivityFn' for 'pt' explanation.
+    PyTrace pt(trace, true /* owned */);
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    cr->trace.cast<PyTrace*>()->release_fn_(
+        py::cast(pt, py::return_value_policy::reference), cr->user_object);
+    cr->seen_traces.erase(reinterpret_cast<uintptr_t>(trace));
+    if (cr->seen_traces.empty()) {
+      auto py_trace = cr->trace;
+      py_trace.cast<PyTrace*>()->InternalRelease();
+    }
+  }
+
+  //  private:
+  TRITONSERVER_InferenceTrace* trace_{nullptr};
+  // [FIXME] may need to transfer ownership
+  bool owned_{false};
+
+  TimestampActivityFn timestamp_fn_{nullptr};
+  TensorActivityFn tensor_fn_{nullptr};
+  ReleaseFn release_fn_{nullptr};
+  std::unique_ptr<CallbackResource> callback_resource_{nullptr};
+};
+
+
+class PyInferenceRequest {
+ public:
+  // [WIP] PyServer ...
+  PyInferenceRequest(
+      TRITONSERVER_Server* server, const char* model_name,
+      const int64_t model_version)
+      : owned_(true)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestNew(
+        &request_, server, model_name, model_version));
+  }
+
+  ~PyInferenceRequest()
+  {
+    if (owned_ && request_) {
+      TRITONSERVER_InferenceRequestDelete(request_);
+    }
+  }
+
+  struct CallbackResource {
+    CallbackResource(py::object r, py::object uo) : request(r), user_object(uo)
+    {
+    }
+    py::object request;
+    py::object user_object;
+  }
+
+  using ReleaseFn = std::function<void(py::object, uint32_t, py::object)>;
+
+  void SetReleaseCallback(ReleaseFn release)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetReleaseCallback(request_, ))
+  }
+
+  static TRITONSERVER_Error* PyTritonRequestReleaseCallback(
+      struct TRITONSERVER_InferenceRequest* request, const uint32_t flags,
+      void* userp)
+  {
+    auto cr = reinterpret_cast<CallbackResource*>(userp);
+    cr->request.insert(reinterpret_cast<uintptr_t>(trace));
+    cr->request.cast<PyInferenceRequest*>()->release_fn_(
+        cr->request, flags, cr->user_object);
+    delete cr;
+  }
+
+  // Trivial setters / getters
+  void SetId(const std::string& id)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetId(request_, id.c_str()));
+  }
+  std::string Id()
+  {
+    const char* val = nullptr;
+    ThrowIfError(TRITONSERVER_InferenceRequestId(request_, &val));
+    return val;
+  }
+
+  void SetFlag(uint32_t flags)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetFlags(request_, flags));
+  }
+
+  uint32_t Flag()
+  {
+    uint32_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceRequestFlags(request_, &val));
+    return val;
+  }
+
+  void SetCorrelationId(uint64_t correlation_id)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetCorrelationId(
+        request_, correlation_id));
+  }
+  uint64_t CorrelationId()
+  {
+    uint32_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceRequestCorrelationId(request_, &val));
+    return val;
+  }
+  void SetCorrelationIdString(const std::string& correlation_id)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetCorrelationIdString(
+        request_, correlation_id.c_str()));
+  }
+  std::string CorrelationIdString()
+  {
+    const char* val = nullptr;
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestCorrelationIdString(request_, &val));
+    return val;
+  }
+
+  void SetPriority(uint32_t priority)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetPriority(request_, priority));
+  }
+  void SetPriorityUint64(uint64_t priority)
+  {
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestSetPriorityUInt64(request_, priority));
+  }
+  uint32_t Priority()
+  {
+    uint32_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceRequestPriority(request_, &val));
+    return val;
+  }
+  uint64_t PriorityUint64()
+  {
+    uint64_t val = 0;
+    ThrowIfError(TRITONSERVER_InferenceRequestPriorityUInt64(request_, &val));
+    return val;
+  }
+
+
+  void SetTimeoutMicroseconds(uint64_t timeout_us)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetTimeoutMicroseconds(
+        request_, timeout_us));
+  }
+  uint64_t TimeoutMicroseconds()
+  {
+    uint64_t val = 0;
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestTimeoutMicroseconds(request_, &val));
+    return val;
+  }
+
+  void AddInput(
+      const std::string& name, TRITONSERVER_DataType data_type,
+      std::vector<int64_t> shape)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestAddInput(
+        request_, name.c_str(), data_type, shape.data(), shape.size()));
+  }
+  void AddRawInput(const std::string& name)
+  {
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestAddRawInput(request_, name.c_str()));
+  }
+  void RemoveInput(const std::string& name)
+  {
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestRemoveInput(request_, name.c_str()));
+  }
+  void RemoveAllInputs()
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestRemoveAllInputs(request_));
+  }
+  void AppendInputData(
+      const std::string& name, size_t base, size_t byte_size,
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestAppendInputData(
+        request_, name.c_str(), reinterpret_cast<const char*>(base), byte_size,
+        memory_type, memory_type_id));
+  }
+  void AppendInputDataWithHostPolicy(
+      const std::string name, size_t base, size_t byte_size,
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      const std::string& host_policy_name)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestAppendInputDataWithHostPolicy(
+        request_, name.c_str(), reinterpret_cast<const char*>(base), byte_size,
+        memory_type, memory_type_id, host_policy_name.c_str()));
+  }
+  void AppendInputDataWithBufferAttributes(
+      const std::string& name, size_t base,
+      PyBufferAttributes* buffer_attributes)
+  {
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestAppendInputDataWithBufferAttributes(
+            request_, name.c_str(), reinterpret_cast<const char*>(base),
+            buffer_attributes->Ptr()));
+  }
+  void RemoveAllInputData(const std::string& name)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestRemoveAllInputData(
+        request_, name.c_str()));
+  }
+
+  void AddRequestedOutput(const std::string& name)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestAddRequestedOutput(
+        request_, name.c_str()));
+  }
+  void RemoveRequestedOutput(const std::string& name)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestRemoveRequestedOutput(
+        request_, name.c_str()));
+  }
+  void RemoveAllRequestedOutputs()
+  {
+    ThrowIfError(
+        TRITONSERVER_InferenceRequestRemoveAllRequestedOutputs(request_));
+  }
+
+  void SetStringParameter(const std::string& key, const std::string& value)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetStringParameter(
+        request_, key.c_str(), value.c_str()));
+  }
+  void SetIntParameter(const std::string& key, int64_t value)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetIntParameter(
+        request_, key.c_str(), value));
+  }
+  void SetBoolParameter(const std::string& key, bool value)
+  {
+    ThrowIfError(TRITONSERVER_InferenceRequestSetBoolParameter(
+        request_, key.c_str(), value));
+  }
+
+ private:
+  TRITONSERVER_InferenceRequest* request_{nullptr};
+  bool owned_{false};
+};
+
+// [WIP] NOTE: 'response_allocator_userp' in
+// TRITONSERVER_InferenceRequestSetResponseCallback is not keeping alive
+// internally as there is no clear exit point on when the reference can be
+// dropped, in constrast to 'response_userp' where the exit point is clear
+// to be the ResponseComplete invocation with FINAL flag.
+
+// [FIXME] testing field
+// ========================================================
+class Allocator {
+ public:
+  // WAR: PyBind optional_cast deduction seems to be wrong in the case of
+  // std::tuple<std::optional<CustomType>, ...> which requires non-const copy
+  // constructor to be provided for CustomType. Copy constructor should be
+  // avoided in the wrapper class and thus py::object is specified as return
+  // type. And all QueryFn usage will assume the actual return type is
+  //   std::tuple<
+  //     std::optional<PyError>, TRITONSERVER_MemoryType, int64_t>
+  using QueryFn = std::function<py::object(
+      std::string, TRITONSERVER_MemoryType, int64_t, size_t*)>;
+
+  DISALLOW_COPY_AND_ASSIGN(Allocator);
+
+  Allocator(QueryFn func) : func_(func) {}
+  QueryFn func_{nullptr};
+};
+// [FIXME] end of testing field
+// ========================================================
+
+// [FIXME] module name?
+PYBIND11_MODULE(triton_bindings, m)
+{
+  m.doc() = "Python bindings for Triton Inference Server";
+  // [FIXME] testing field
+  // ========================================================
+  auto mt = m.def_submodule("testing", "For testing purpose");
+  // ========================================================
+
+  // [FIXME] if dynamic linking, should have version check here as well to
+  // make sure the binding is compatible with the Triton library loaded
+  m.def("api_version", []() {
+    uint32_t major = 0, minor = 0;
+    ThrowIfError(TRITONSERVER_ApiVersion(&major, &minor));
+    return py::make_tuple(major, minor);
+  });
+
+  // TRITONSERVER_Error... converted to 'TritonError' exception
+  // Implement exception inheritance in PyBind:
+  // https://github.com/jagerman/pybind11/blob/master/tests/test_exceptions.cpp#L149-L152
+  auto te = pybind11::register_exception<TritonError>(m, "TritonError");
+  pybind11::register_exception<Unknown>(m, "Unknown", te.ptr());
+  pybind11::register_exception<Internal>(m, "Internal", te.ptr());
+  pybind11::register_exception<NotFound>(m, "NotFound", te.ptr());
+  pybind11::register_exception<InvalidArgument>(m, "InvalidArgument", te.ptr());
+  pybind11::register_exception<Unavailable>(m, "Unavailable", te.ptr());
+  pybind11::register_exception<Unsupported>(m, "Unsupported", te.ptr());
+  pybind11::register_exception<AlreadyExists>(m, "AlreadyExists", te.ptr());
+
+  // TRITONSERVER_DataType
+  py::enum_<TRITONSERVER_DataType>(m, "TRITONSERVER_DataType")
+      .value("INVALID", TRITONSERVER_TYPE_INVALID)
+      .value("BOOL", TRITONSERVER_TYPE_BOOL)
+      .value("UINT8", TRITONSERVER_TYPE_UINT8)
+      .value("UINT16", TRITONSERVER_TYPE_UINT16)
+      .value("UINT32", TRITONSERVER_TYPE_UINT32)
+      .value("UINT64", TRITONSERVER_TYPE_UINT64)
+      .value("INT8", TRITONSERVER_TYPE_INT8)
+      .value("INT16", TRITONSERVER_TYPE_INT16)
+      .value("INT32", TRITONSERVER_TYPE_INT32)
+      .value("INT64", TRITONSERVER_TYPE_INT64)
+      .value("FP16", TRITONSERVER_TYPE_FP16)
+      .value("FP32", TRITONSERVER_TYPE_FP32)
+      .value("FP64", TRITONSERVER_TYPE_FP64)
+      .value("BYTES", TRITONSERVER_TYPE_BYTES)
+      .value("BF16", TRITONSERVER_TYPE_BF16);
+  // helper functions
+  m.def("TRITONSERVER_DataTypeString", [](TRITONSERVER_DataType datatype) {
+    return TRITONSERVER_DataTypeString(datatype);
+  });
+  m.def("TRITONSERVER_StringToDataType", [](const char* dtype) {
+    return TRITONSERVER_StringToDataType(dtype);
+  });
+  m.def("TRITONSERVER_DataTypeByteSize", [](TRITONSERVER_DataType datatype) {
+    return TRITONSERVER_DataTypeByteSize(datatype);
+  });
+
+  // TRITONSERVER_MemoryType
+  py::enum_<TRITONSERVER_MemoryType>(m, "TRITONSERVER_MemoryType")
+      .value("CPU", TRITONSERVER_MEMORY_CPU)
+      .value("CPU_PINNED", TRITONSERVER_MEMORY_CPU_PINNED)
+      .value("GPU", TRITONSERVER_MEMORY_GPU);
+  // helper functions
+  m.def("TRITONSERVER_MemoryTypeString", [](TRITONSERVER_MemoryType memtype) {
+    return TRITONSERVER_MemoryTypeString(memtype);
+  });
+
+  // TRITONSERVER_ParameterType
+  py::enum_<TRITONSERVER_ParameterType>(m, "TRITONSERVER_ParameterType")
+      .value("STRING", TRITONSERVER_PARAMETER_STRING)
+      .value("INT", TRITONSERVER_PARAMETER_INT)
+      .value("BOOL", TRITONSERVER_PARAMETER_BOOL)
+      .value("BYTES", TRITONSERVER_PARAMETER_BYTES);
+  // helper functions
+  m.def(
+      "TRITONSERVER_ParameterTypeString",
+      [](TRITONSERVER_ParameterType paramtype) {
+        return TRITONSERVER_ParameterTypeString(paramtype);
+      });
+  // TRITONSERVER_Parameter
+  py::class_<PyParameter>(m, "TRITONSERVER_Parameter")
+      .def(py::init<const char*, TRITONSERVER_ParameterType, const void*>())
+      .def(py::init([](const char* name, py::bytes bytes) {
+        // [FIXME] does not own 'bytes' in the same way as C API, but can also
+        // hold 'bytes' to make sure it will not be invalidated while in use.
+        // i.e. safe to perform
+        //   a = triton_bindings.TRITONSERVER_Parameter("abc", b'abc')
+        //   # 'a' still points to valid buffer at this line.
+        // Note that even holding 'bytes', it is the user's responsibility not
+        // to modify 'bytes' while the parameter is in use.
+        py::buffer_info info(py::buffer(bytes).request());
+        return std::make_unique<PyParameter>(name, info.ptr, info.size);
+      }));
+
+  // TRITONSERVER_InstanceGroupKind
+  py::enum_<TRITONSERVER_InstanceGroupKind>(m, "TRITONSERVER_InstanceGroupKind")
+      .value("AUTO", TRITONSERVER_INSTANCEGROUPKIND_AUTO)
+      .value("CPU", TRITONSERVER_INSTANCEGROUPKIND_CPU)
+      .value("GPU", TRITONSERVER_INSTANCEGROUPKIND_GPU)
+      .value("MODEL", TRITONSERVER_INSTANCEGROUPKIND_MODEL);
+  m.def(
+      "TRITONSERVER_InstanceGroupKindString",
+      [](TRITONSERVER_InstanceGroupKind kind) {
+        return TRITONSERVER_InstanceGroupKindString(kind);
+      });
+
+  // TRITONSERVER_Log
+  py::enum_<TRITONSERVER_LogLevel>(m, "TRITONSERVER_LogLevel")
+      .value("INFO", TRITONSERVER_LOG_INFO)
+      .value("WARN", TRITONSERVER_LOG_WARN)
+      .value("ERROR", TRITONSERVER_LOG_ERROR)
+      .value("VERBOSE", TRITONSERVER_LOG_VERBOSE);
+
+  py::enum_<TRITONSERVER_LogFormat>(m, "TRITONSERVER_LogFormat")
+      .value("DEFAULT", TRITONSERVER_LOG_DEFAULT)
+      .value("ISO8601", TRITONSERVER_LOG_ISO8601);
+
+  m.def("TRITONSERVER_LogIsEnabled", [](TRITONSERVER_LogLevel level) {
+    return TRITONSERVER_LogIsEnabled(level);
+  });
+  m.def(
+      "TRITONSERVER_LogMessage",
+      [](TRITONSERVER_LogLevel level, const char* filename, const int line,
+         const char* msg) {
+        ThrowIfError(TRITONSERVER_LogMessage(level, filename, line, msg));
+      });
+
+  py::class_<PyBufferAttributes>(m, "TRITONSERVER_BufferAttributes")
+      .def(py::init<>())
+      .def_property(
+          "memory_type_id", &PyBufferAttributes::MemoryTypeId,
+          &PyBufferAttributes::SetMemoryTypeId)
+      .def_property(
+          "memory_type", &PyBufferAttributes::MemoryType,
+          &PyBufferAttributes::SetMemoryType)
+      .def_property(
+          "cuda_ipc_handle", &PyBufferAttributes::CudaIpcHandle,
+          &PyBufferAttributes::SetCudaIpcHandle)
+      .def_property(
+          "byte_size", &PyBufferAttributes::ByteSize,
+          &PyBufferAttributes::SetByteSize);
+
+  py::class_<PyResponseAllocator>(m, "TRITONSERVER_ResponseAllocator")
+      .def(
+          py::init<
+              PyResponseAllocator::AllocFn, PyResponseAllocator::ReleaseFn,
+              PyResponseAllocator::StartFn>(),
+          py::arg("alloc_function"), py::arg("release_function"),
+          py::arg("start_function").none(true))
+      .def(
+          "set_buffer_attributes_function",
+          &PyResponseAllocator::SetBufferAttributesFunction,
+          py::arg("buffer_attributes_function"))
+      .def(
+          "set_query_function", &PyResponseAllocator::SetQueryFunction,
+          py::arg("query_function"))
+      // ========================================================
+      .def(
+          "invoke_allocator",
+          [](py::object alloc, py::object user_object) {
+            py::print("abc");
+            void* buffer = nullptr;
+            void* buffer_userp = nullptr;
+            TRITONSERVER_MemoryType actual_memory_type =
+                TRITONSERVER_MEMORY_CPU;
+            int64_t actual_memory_type_id = 0;
+            auto callback_resource =
+                new PyResponseAllocator::CallbackResource(alloc, user_object);
+            ThrowIfError(PyResponseAllocator::PyTritonAllocFn(
+                alloc.cast<PyResponseAllocator*>()->allocator_, "abc", 10,
+                TRITONSERVER_MEMORY_CPU_PINNED, 1, callback_resource, &buffer,
+                &buffer_userp, &actual_memory_type, &actual_memory_type_id));
+            py::handle bu = static_cast<PyResponseAllocator::CallbackResource*>(
+                                buffer_userp)
+                                ->user_object;
+            return py::make_tuple(
+                reinterpret_cast<size_t>(buffer), bu, actual_memory_type,
+                actual_memory_type_id);
+          })
+      .def(
+          "invoke_query",
+          [](py::object alloc, py::object user_object) {
+            void* buffer = nullptr;
+            void* buffer_userp = nullptr;
+            TRITONSERVER_MemoryType actual_memory_type =
+                TRITONSERVER_MEMORY_CPU;
+            int64_t actual_memory_type_id = 0;
+            auto callback_resource =
+                new PyResponseAllocator::CallbackResource(alloc, user_object);
+            ThrowIfError(PyResponseAllocator::PyTritonAllocFn(
+                alloc.cast<PyResponseAllocator*>()->allocator_, "abc", 10,
+                TRITONSERVER_MEMORY_CPU_PINNED, 1, callback_resource, &buffer,
+                &buffer_userp, &actual_memory_type, &actual_memory_type_id));
+            py::handle bu = static_cast<PyResponseAllocator::CallbackResource*>(
+                                buffer_userp)
+                                ->user_object;
+            return py::make_tuple(
+                reinterpret_cast<size_t>(buffer), bu, actual_memory_type,
+                actual_memory_type_id);
+          })
+      // ========================================================
+      ;
+
+  // TRITONSERVER_Message
+  py::class_<PyMessage>(m, "TRITONSERVER_Message")
+      .def(py::init<const std::string&>())
+      .def("serialize_to_json", &PyMessage::SerializeToJson);
+
+  // TRITONSERVER_Metrics
+  py::enum_<TRITONSERVER_MetricFormat>(m, "TRITONSERVER_MetricFormat")
+      .value("PROMETHEUS", TRITONSERVER_METRIC_PROMETHEUS);
+  py::class_<PyMetrics>(m, "TRITONSERVER_Metrics")
+      .def("formatted", &PyMetrics::Formatted);
+
+  // TRITONSERVER_InferenceTrace
+  py::enum_<TRITONSERVER_InferenceTraceLevel>(
+      m, "TRITONSERVER_InferenceTraceLevel")
+      .value("DISABLED", TRITONSERVER_TRACE_LEVEL_DISABLED)
+      .value("MIN", TRITONSERVER_TRACE_LEVEL_MIN)
+      .value("MAX", TRITONSERVER_TRACE_LEVEL_MAX)
+      .value("TIMESTAMPS", TRITONSERVER_TRACE_LEVEL_TIMESTAMPS)
+      .value("TENSORS", TRITONSERVER_TRACE_LEVEL_TENSORS)
+      .export_values();
+  m.def(
+      "TRITONSERVER_InferenceTraceLevelString",
+      &TRITONSERVER_InferenceTraceLevelString);
+  py::enum_<TRITONSERVER_InferenceTraceActivity>(
+      m, "TRITONSERVER_InferenceTraceActivity")
+      .value("REQUEST_START", TRITONSERVER_TRACE_REQUEST_START)
+      .value("QUEUE_START", TRITONSERVER_TRACE_QUEUE_START)
+      .value("COMPUTE_START", TRITONSERVER_TRACE_COMPUTE_START)
+      .value("COMPUTE_INPUT_END", TRITONSERVER_TRACE_COMPUTE_INPUT_END)
+      .value("COMPUTE_OUTPUT_START", TRITONSERVER_TRACE_COMPUTE_OUTPUT_START)
+      .value("COMPUTE_END", TRITONSERVER_TRACE_COMPUTE_END)
+      .value("REQUEST_END", TRITONSERVER_TRACE_REQUEST_END)
+      .value("TENSOR_QUEUE_INPUT", TRITONSERVER_TRACE_TENSOR_QUEUE_INPUT)
+      .value("TENSOR_BACKEND_INPUT", TRITONSERVER_TRACE_TENSOR_BACKEND_INPUT)
+      .value("TENSOR_BACKEND_OUTPUT", TRITONSERVER_TRACE_TENSOR_BACKEND_OUTPUT)
+      .export_values();
+  m.def(
+      "TRITONSERVER_InferenceTraceActivityString",
+      &TRITONSERVER_InferenceTraceActivityString);
+  py::class_<PyTrace, std::shared_ptr<PyTrace>>(
+      m, "TRITONSERVER_InferenceTrace")
+      .def(
+          py::init<
+              TRITONSERVER_InferenceTraceLevel, uint64_t,
+              PyTrace::TimestampActivityFn, PyTrace::TensorActivityFn,
+              PyTrace::ReleaseFn, py::object>(),
+          py::arg("level"), py::arg("parent_id"), py::arg("activity_function"),
+          py::arg("tensor_activity_function"), py::arg("release_function"),
+          py::arg("trace_userp"))
+      .def(
+          py::init<
+              TRITONSERVER_InferenceTraceLevel, uint64_t,
+              PyTrace::TimestampActivityFn, PyTrace::ReleaseFn, py::object>(),
+          py::arg("level"), py::arg("parent_id"), py::arg("activity_function"),
+          py::arg("release_function"), py::arg("trace_userp"))
+      .def_property_readonly("id", &PyTrace::Id)
+      .def_property_readonly("parent_id", &PyTrace::ParentId)
+      .def_property_readonly("model_name", &PyTrace::ModelName)
+      .def_property_readonly("model_version", &PyTrace::ModelVersion)
+      .def_property_readonly("request_id", &PyTrace::RequestId)
+      // ========================================================
+      .def(
+          "capture",
+          [](py::object trace) { trace.cast<PyTrace*>()->Capture(trace); })
+      .def("release", &PyTrace::InternalRelease)
+      // ========================================================
+      ;
+}
+
+}}}  // namespace triton::core::python

--- a/python/test/test_binding.py
+++ b/python/test/test_binding.py
@@ -1,0 +1,336 @@
+import unittest
+import json
+import os
+
+import triton_bindings
+
+
+class BindingTest(unittest.TestCase):
+
+    def test_exceptions(self):
+        ex_list = [
+            triton_bindings.Unknown, triton_bindings.Internal,
+            triton_bindings.NotFound, triton_bindings.InvalidArgument,
+            triton_bindings.Unavailable, triton_bindings.Unsupported,
+            triton_bindings.AlreadyExists
+        ]
+        for ex_type in ex_list:
+            try:
+                raise ex_type("Error message")
+            # 'TritonError' should catch all
+            except triton_bindings.TritonError as te:
+                self.assertTrue(isinstance(te, ex_type))
+                self.assertEqual(str(te), "Error message")
+
+    def test_data_type(self):
+        t_list = [
+            (triton_bindings.TRITONSERVER_DataType.INVALID, "<invalid>", 0),
+            (triton_bindings.TRITONSERVER_DataType.BOOL, "BOOL", 1),
+            (triton_bindings.TRITONSERVER_DataType.UINT8, "UINT8", 1),
+            (triton_bindings.TRITONSERVER_DataType.UINT16, "UINT16", 2),
+            (triton_bindings.TRITONSERVER_DataType.UINT32, "UINT32", 4),
+            (triton_bindings.TRITONSERVER_DataType.UINT64, "UINT64", 8),
+            (triton_bindings.TRITONSERVER_DataType.INT8, "INT8", 1),
+            (triton_bindings.TRITONSERVER_DataType.INT16, "INT16", 2),
+            (triton_bindings.TRITONSERVER_DataType.INT32, "INT32", 4),
+            (triton_bindings.TRITONSERVER_DataType.INT64, "INT64", 8),
+            (triton_bindings.TRITONSERVER_DataType.FP16, "FP16", 2),
+            (triton_bindings.TRITONSERVER_DataType.FP32, "FP32", 4),
+            (triton_bindings.TRITONSERVER_DataType.FP64, "FP64", 8),
+            (triton_bindings.TRITONSERVER_DataType.BYTES, "BYTES", 0),
+            (triton_bindings.TRITONSERVER_DataType.BF16, "BF16", 2),
+        ]
+
+        for t, t_str, t_size in t_list:
+            self.assertEqual(triton_bindings.TRITONSERVER_DataTypeString(t),
+                             t_str)
+            self.assertEqual(
+                triton_bindings.TRITONSERVER_StringToDataType(t_str), t)
+            self.assertEqual(triton_bindings.TRITONSERVER_DataTypeByteSize(t),
+                             t_size)
+
+    def test_memory_type(self):
+        t_list = [
+            (triton_bindings.TRITONSERVER_MemoryType.CPU, "CPU"),
+            (triton_bindings.TRITONSERVER_MemoryType.CPU_PINNED, "CPU_PINNED"),
+            (triton_bindings.TRITONSERVER_MemoryType.GPU, "GPU"),
+        ]
+        for t, t_str in t_list:
+            self.assertEqual(triton_bindings.TRITONSERVER_MemoryTypeString(t),
+                             t_str)
+
+    def test_parameter_type(self):
+        t_list = [
+            (triton_bindings.TRITONSERVER_ParameterType.STRING, "STRING"),
+            (triton_bindings.TRITONSERVER_ParameterType.INT, "INT"),
+            (triton_bindings.TRITONSERVER_ParameterType.BOOL, "BOOL"),
+            (triton_bindings.TRITONSERVER_ParameterType.BYTES, "BYTES"),
+        ]
+        for t, t_str in t_list:
+            self.assertEqual(
+                triton_bindings.TRITONSERVER_ParameterTypeString(t), t_str)
+
+    def test_parameter(self):
+        # C API doesn't provide additional API for parameter, can only test
+        # New/Delete unless we mock the implementation to expose more info.
+        str_param = triton_bindings.TRITONSERVER_Parameter(
+            "str_key", "str_value")
+        int_param = triton_bindings.TRITONSERVER_Parameter("int_key", 123)
+        bool_param = triton_bindings.TRITONSERVER_Parameter("bool_key", True)
+        # bytes parameter doesn't own the buffer
+        b = bytes("abc", 'utf-8')
+        bytes_param = triton_bindings.TRITONSERVER_Parameter("bytes_key", b)
+        del str_param
+        del int_param
+        del bool_param
+        del bytes_param
+        import gc
+        gc.collect()
+
+    def test_instance_kind(self):
+        t_list = [
+            (triton_bindings.TRITONSERVER_InstanceGroupKind.AUTO, "AUTO"),
+            (triton_bindings.TRITONSERVER_InstanceGroupKind.CPU, "CPU"),
+            (triton_bindings.TRITONSERVER_InstanceGroupKind.GPU, "GPU"),
+            (triton_bindings.TRITONSERVER_InstanceGroupKind.MODEL, "MODEL"),
+        ]
+        for t, t_str in t_list:
+            self.assertEqual(
+                triton_bindings.TRITONSERVER_InstanceGroupKindString(t), t_str)
+
+    def test_log(self):
+        # This test depends on 'TRITONSERVER_ServerOptions' operates properly
+        # to modify log settings.
+
+        # Direct Triton to log message into a file so that the log may be
+        # retrieved on the Python side. Otherwise the log will be default
+        # on stderr and Python utils can not redirect the pipe on Triton side.
+        log_file = "triton_binding_test_log_output.txt"
+        default_format_regex = r'[0-9][0-9][0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9][0-9][0-9][0-9]'
+        iso8601_format_regex = r'[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z'
+        try:
+            options = triton_bindings.TRITONSERVER_ServerOptions()
+            # Enable subset of log levels
+            options.set_log_file(log_file)
+            options.set_log_info(True)
+            options.set_log_warn(False)
+            options.set_log_error(True)
+            options.set_log_verbose(0)
+            options.set_log_format(
+                triton_bindings.TRITONSERVER_LogFormat.DEFAULT)
+            for ll, enabled in [
+                (triton_bindings.TRITONSERVER_LogLevel.INFO, True),
+                (triton_bindings.TRITONSERVER_LogLevel.WARN, False),
+                (triton_bindings.TRITONSERVER_LogLevel.ERROR, True),
+                (triton_bindings.TRITONSERVER_LogLevel.VERBOSE, False),
+            ]:
+                self.assertEqual(triton_bindings.TRITONSERVER_LogIsEnabled(ll),
+                                 enabled)
+            # Write message to each of the log level
+            triton_bindings.TRITONSERVER_LogMessage(
+                triton_bindings.TRITONSERVER_LogLevel.INFO, "filename", 123,
+                "info_message")
+            triton_bindings.TRITONSERVER_LogMessage(
+                triton_bindings.TRITONSERVER_LogLevel.WARN, "filename", 456,
+                "warn_message")
+            triton_bindings.TRITONSERVER_LogMessage(
+                triton_bindings.TRITONSERVER_LogLevel.ERROR, "filename", 789,
+                "error_message")
+            triton_bindings.TRITONSERVER_LogMessage(
+                triton_bindings.TRITONSERVER_LogLevel.VERBOSE, "filename", 147,
+                "verbose_message")
+            with open(log_file, "r") as f:
+                log = f.read()
+                # Check level
+                self.assertRegex(log, r'filename:123.*info_message')
+                self.assertNotRegex(log, r'filename:456.*warn_message')
+                self.assertRegex(log, r'filename:789.*error_message')
+                self.assertNotRegex(log, r'filename:147.*verbose_message')
+                # Check format "MMDD hh:mm:ss.ssssss".
+                self.assertRegex(log, default_format_regex)
+                # sanity check that there is no log with other format "YYYY-MM-DDThh:mm:ssZ L"
+                self.assertNotRegex(log, iso8601_format_regex)
+            # Test different format
+            options.set_log_format(
+                triton_bindings.TRITONSERVER_LogFormat.ISO8601)
+            triton_bindings.TRITONSERVER_LogMessage(
+                triton_bindings.TRITONSERVER_LogLevel.INFO, "fn", 258,
+                "info_message")
+            with open(log_file, "r") as f:
+                log = f.read()
+                self.assertRegex(log, r'fn:258.*info_message')
+                self.assertRegex(log, iso8601_format_regex)
+        finally:
+            # Must make sure the log settings are reset as the logger is unique
+            # within the process
+            options.set_log_file("")
+            options.set_log_info(False)
+            options.set_log_warn(False)
+            options.set_log_error(False)
+            options.set_log_verbose(0)
+            options.set_log_format(
+                triton_bindings.TRITONSERVER_LogFormat.DEFAULT)
+            os.remove(log_file)
+
+    def test_buffer_attributes(self):
+        expected_memory_type = triton_bindings.TRITONSERVER_MemoryType.CPU_PINNED
+        expected_memory_type_id = 4
+        expected_byte_size = 1024
+        buffer_attributes = triton_bindings.TRITONSERVER_BufferAttributes()
+        buffer_attributes.memory_type_id = expected_memory_type_id
+        self.assertEqual(buffer_attributes.memory_type_id,
+                         expected_memory_type_id)
+        buffer_attributes.memory_type = expected_memory_type
+        self.assertEqual(buffer_attributes.memory_type, expected_memory_type)
+        buffer_attributes.byte_size = expected_byte_size
+        self.assertEqual(buffer_attributes.byte_size, expected_byte_size)
+        # cuda_ipc_handle is supposed to be cudaIpcMemHandle_t, must initialize buffer
+        # of that size to avoid segfault. The handle getter/setter is different from other
+        # attributes that different pointers may be returned from the getter, but the byte
+        # content pointed by the pointer should be the same
+        from array import array
+        import ctypes
+        handle_byte_size = 64
+        mock_handle = array("b", [i for i in range(handle_byte_size)])
+        buffer_attributes.cuda_ipc_handle = mock_handle.buffer_info()[0]
+        res_arr = (ctypes.c_char * handle_byte_size).from_address(
+            buffer_attributes.cuda_ipc_handle)
+        for i in range(handle_byte_size):
+            self.assertEqual(int.from_bytes(res_arr[i], "big"), mock_handle[i])
+
+    def test_allocator(self):
+
+        def alloc_fn(allocator, tensor_name, byte_size, memory_type,
+                     memory_type_id, user_object):
+            return (123, None, triton_bindings.TRITONSERVER_MemoryType.GPU, 1)
+
+        def release_fn(allocator, buffer, buffer_user_object, byte_size,
+                       memory_type, memory_type_id):
+            pass
+
+        def start_fn(allocator, user_object):
+            pass
+
+        def query_fn(allocator, user_object, tensor_name, byte_size,
+                     memory_type, memory_type_id):
+            return (triton_bindings.TRITONSERVER_MemoryType.GPU, 1)
+
+        def buffer_fn(allocator, tensor_name, buffer_attribute, user_object,
+                      buffer_user_object):
+            return buffer_attribute
+
+        # allocator without start_fn
+        allocator = triton_bindings.TRITONSERVER_ResponseAllocator(
+            alloc_fn, release_fn)
+        del allocator
+        import gc
+        gc.collect()
+
+        # allocator with start_fn
+        allocator = triton_bindings.TRITONSERVER_ResponseAllocator(
+            alloc_fn, release_fn, start_fn)
+        allocator.set_buffer_attributes_function(buffer_fn)
+        allocator.set_query_function(query_fn)
+
+    def test_options(self):
+        options = triton_bindings.TRITONSERVER_ServerOptions()
+
+        # Generic
+        options.set_server_id("server_id")
+        options.set_min_supported_compute_capability(7.0)
+        options.set_exit_on_error(False)
+        options.set_strict_readiness(False)
+        options.set_exit_timeout(30)
+
+        # Models
+        options.set_model_repository_path("model_repo_0")
+        options.set_model_repository_path("model_repo_1")
+        for m in [
+                triton_bindings.TRITONSERVER_ModelControlMode.NONE,
+                triton_bindings.TRITONSERVER_ModelControlMode.POLL,
+                triton_bindings.TRITONSERVER_ModelControlMode.EXPLICIT
+        ]:
+            options.set_model_control_mode(m)
+        options.set_startup_model("*")
+        options.set_strict_model_config(True)
+        options.set_model_load_thread_count(2)
+        options.set_model_namespacing(True)
+        # Only support Kind GPU for now
+        options.set_model_load_device_limit(
+            triton_bindings.TRITONSERVER_InstanceGroupKind.GPU, 0, 0.5)
+        for k in [
+                triton_bindings.TRITONSERVER_InstanceGroupKind.AUTO,
+                triton_bindings.TRITONSERVER_InstanceGroupKind.CPU,
+                triton_bindings.TRITONSERVER_InstanceGroupKind.MODEL
+        ]:
+            with self.assertRaises(triton_bindings.TritonError) as context:
+                options.set_model_load_device_limit(k, 0, 0)
+            self.assertTrue("not supported" in str(context.exception))
+
+        # Backend
+        options.set_backend_directory("backend_dir_0")
+        options.set_backend_directory("backend_dir_1")
+        options.set_backend_config("backend_name", "setting", "value")
+
+        # Rate limiter
+        for r in [
+                triton_bindings.TRITONSERVER_RateLimitMode.OFF,
+                triton_bindings.TRITONSERVER_RateLimitMode.EXEC_COUNT
+        ]:
+            options.set_rate_limiter_mode(r)
+        options.add_rate_limiter_resource("shared_resource", 4, -1)
+        options.add_rate_limiter_resource("device_resource", 1, 0)
+        # memory pools
+        options.set_pinned_memory_pool_byte_size(1024)
+        options.set_cuda_memory_pool_byte_size(0, 2048)
+        # cache
+        options.set_response_cache_byte_size(4096)
+        options.set_cache_config(
+            "cache_name",
+            json.dumps({
+                "config_0": "value_0",
+                "config_1": "value_1"
+            }))
+        options.set_cache_directory("cache_dir_0")
+        options.set_cache_directory("cache_dir_1")
+        # Log
+        try:
+            options.set_log_file("some_file")
+            options.set_log_info(True)
+            options.set_log_warn(True)
+            options.set_log_error(True)
+            options.set_log_verbose(2)
+            for f in [
+                    triton_bindings.TRITONSERVER_LogFormat.DEFAULT,
+                    triton_bindings.TRITONSERVER_LogFormat.ISO8601
+            ]:
+                options.set_log_format(f)
+        finally:
+            # Must make sure the log settings are reset as the logger is unique
+            # within the process
+            options.set_log_file("")
+            options.set_log_info(False)
+            options.set_log_warn(False)
+            options.set_log_error(False)
+            options.set_log_verbose(0)
+            options.set_log_format(
+                triton_bindings.TRITONSERVER_LogFormat.DEFAULT)
+
+        # Metrics
+        options.set_gpu_metrics(True)
+        options.set_cpu_metrics(True)
+        options.set_metrics_interval(5)
+        options.set_metrics_config("metrics_group", "setting", "value")
+
+        # Misc..
+        with self.assertRaises(triton_bindings.TritonError) as context:
+            options.set_host_policy("policy_name", "setting", "value")
+        self.assertTrue(
+            "Unsupported host policy setting" in str(context.exception))
+        options.set_repo_agent_directory("repo_agent_dir_0")
+        options.set_repo_agent_directory("repo_agent_dir_1")
+        options.set_buffer_manager_thread_count(4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/test/test_binding.py
+++ b/python/test/test_binding.py
@@ -1,11 +1,227 @@
 import unittest
 import json
 import os
+import shutil
+import numpy
+import gc
+import queue
 
 import triton_bindings
 
 
+# Callback functions used in inference pipeline
+# 'user_object' is a per-request counter of how many times the
+# callback is invoked
+def g_alloc_fn(allocator, tensor_name, byte_size, memory_type, memory_type_id,
+               user_object):
+    if "alloc" not in user_object:
+        user_object["alloc"] = 0
+    user_object["alloc"] += 1
+    buffer = numpy.empty(byte_size, numpy.byte)
+    return (buffer.ctypes.data, buffer,
+            triton_bindings.TRITONSERVER_MemoryType.CPU, 0)
+
+
+def g_release_fn(allocator, buffer, buffer_user_object, byte_size, memory_type,
+                 memory_type_id):
+    # No-op, buffer ('buffer_user_object') will be garbage collected
+    # only sanity check that the objects are expected
+    if (not isinstance(buffer_user_object, numpy.ndarray)) or (
+            buffer_user_object.ctypes.data != buffer):
+        raise Exception("Misaligned parameters in allocator release callback")
+    pass
+
+
+def g_start_fn(allocator, user_object):
+    if "start" not in user_object:
+        user_object["start"] = 0
+    user_object["start"] += 1
+    pass
+
+
+def g_query_fn(allocator, user_object, tensor_name, byte_size, memory_type,
+               memory_type_id):
+    if "query" not in user_object:
+        user_object["query"] = 0
+    user_object["query"] += 1
+    return (triton_bindings.TRITONSERVER_MemoryType.CPU, 0)
+
+
+def g_buffer_fn(allocator, tensor_name, buffer_attribute, user_object,
+                buffer_user_object):
+    if "buffer" not in user_object:
+        user_object["buffer"] = 0
+    user_object["buffer"] += 1
+    buffer_attribute.memory_type = triton_bindings.TRITONSERVER_MemoryType.CPU
+    buffer_attribute.memory_type_id = 0
+    buffer_attribute.byte_size = buffer_user_object.size
+    return buffer_attribute
+
+
+def g_timestamp_fn(trace, activity, timestamp_ns, user_object):
+    # not owning trace, so must read property out
+    trace_log = {
+        "id": trace.id,
+        "parent_id": trace.parent_id,
+        "model_name": trace.model_name,
+        "model_version": trace.model_version,
+        "request_id": trace.request_id,
+        "activity": activity,
+        "timestamp": timestamp_ns
+    }
+    user_object[trace.id] = trace_log
+
+
+def g_tensor_fn(trace, activity, tensor_name, data_type, buffer, byte_size,
+                shape, memory_type, memory_type_id, user_object):
+    # not owning trace, so must read property out
+    trace_log = {
+        "id": trace.id,
+        "parent_id": trace.parent_id,
+        "model_name": trace.model_name,
+        "model_version": trace.model_version,
+        "request_id": trace.request_id,
+        "activity": activity,
+        "tensor": {
+            "name": tensor_name,
+            "data_type": data_type,
+            # skip 'buffer'
+            "byte_size": byte_size,
+            "shape": shape,
+            "memory_type": memory_type,
+            "memory_type_id": memory_type_id
+        }
+    }
+    user_object[trace.id] = trace_log
+
+
+def g_trace_release_fn(trace, user_object):
+    # sanity check that 'trace' has been tracked, the object
+    # will be released on garbage collection
+    if trace.id not in user_object:
+        raise Exception("Releasing unseen trace")
+
+
+def g_response_fn(response, flags, user_object):
+    user_object.put((flags, response))
+
+
+def g_request_fn(request, flags, user_object):
+    if flags != 1:
+        raise Exception("Unexpected request release flag")
+    # counter of "inflight" requests
+    user_object -= 1
+    if user_object != 0:
+        raise Exception(
+            "Expect request release callback to be invoked only once")
+
+
+# Python model file string to fastly deploy test model, depends on
+# 'TRITONSERVER_Server' operates properly to load model with content passed
+# through the load API.
+g_python_addsub = b'''
+import json
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    @staticmethod
+    def auto_complete_config(auto_complete_model_config):
+        input0 = {"name": "INPUT0", "data_type": "TYPE_FP32", "dims": [4]}
+        input1 = {"name": "INPUT1", "data_type": "TYPE_FP32", "dims": [4]}
+        output0 = {"name": "OUTPUT0", "data_type": "TYPE_FP32", "dims": [4]}
+        output1 = {"name": "OUTPUT1", "data_type": "TYPE_FP32", "dims": [4]}
+
+        auto_complete_model_config.set_max_batch_size(0)
+        auto_complete_model_config.add_input(input0)
+        auto_complete_model_config.add_input(input1)
+        auto_complete_model_config.add_output(output0)
+        auto_complete_model_config.add_output(output1)
+
+        # [WARNING] Specify specific dynamic batching field by knowing
+        # the implementation detail
+        auto_complete_model_config.set_dynamic_batching()
+        auto_complete_model_config._model_config["dynamic_batching"]["priority_levels"] = 20
+        auto_complete_model_config._model_config["dynamic_batching"]["default_priority_level"] = 10
+
+        return auto_complete_model_config
+
+    def initialize(self, args):
+        self.model_config = model_config = json.loads(args["model_config"])
+
+        output0_config = pb_utils.get_output_config_by_name(model_config, "OUTPUT0")
+        output1_config = pb_utils.get_output_config_by_name(model_config, "OUTPUT1")
+
+        self.output0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config["data_type"]
+        )
+        self.output1_dtype = pb_utils.triton_string_to_numpy(
+            output1_config["data_type"]
+        )
+
+    def execute(self, requests):
+        """This function is called on inference request."""
+
+        output0_dtype = self.output0_dtype
+        output1_dtype = self.output1_dtype
+
+        responses = []
+        for request in requests:
+            in_0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            in_1 = pb_utils.get_input_tensor_by_name(request, "INPUT1")
+            out_0, out_1 = (
+                in_0.as_numpy() + in_1.as_numpy(),
+                in_0.as_numpy() - in_1.as_numpy(),
+            )
+
+            out_tensor_0 = pb_utils.Tensor("OUTPUT0", out_0.astype(output0_dtype))
+            out_tensor_1 = pb_utils.Tensor("OUTPUT1", out_1.astype(output1_dtype))
+            responses.append(pb_utils.InferenceResponse([out_tensor_0, out_tensor_1]))
+        return responses
+'''
+
+
+# ======================================= Test cases ===========================
 class BindingTest(unittest.TestCase):
+
+    def setUp(self):
+        self._test_model_repo = os.path.join(os.getcwd(), "binding_test_repo")
+        os.makedirs(self._test_model_repo)
+        self._model_name = "addsub"
+        self._version = "1"
+        self._file_name = "model.py"
+
+    def tearDown(self):
+        gc.collect()
+        # clear model repository that may be created for testing.
+        if os.path.exists(self._test_model_repo):
+            shutil.rmtree(self._test_model_repo)
+
+    # helper functions
+    def _to_pyobject(self, triton_message):
+        return json.loads(triton_message.serialize_to_json())
+
+    # prepare a model repository with "addsub" model and create a Triton
+    # instance with POLL mode.
+    def _start_polling_server(self):
+        # prepare model repository
+        os.makedirs(
+            os.path.join(self._test_model_repo, self._model_name,
+                         self._version))
+        with open(
+                os.path.join(self._test_model_repo, self._model_name,
+                             self._version, self._file_name), 'wb') as f:
+            f.write(g_python_addsub)
+
+        options = triton_bindings.TRITONSERVER_ServerOptions()
+        options.set_model_repository_path(self._test_model_repo)
+        options.set_model_control_mode(
+            triton_bindings.TRITONSERVER_ModelControlMode.POLL)
+        # enable "auto-complete" to skip providing config.pbtxt
+        options.set_strict_model_config(False)
+        options.set_server_id("testing_server")
+        return triton_bindings.TRITONSERVER_Server(options)
 
     def test_exceptions(self):
         ex_list = [
@@ -15,12 +231,10 @@ class BindingTest(unittest.TestCase):
             triton_bindings.AlreadyExists
         ]
         for ex_type in ex_list:
-            try:
+            with self.assertRaises(triton_bindings.TritonError) as ctx:
                 raise ex_type("Error message")
-            # 'TritonError' should catch all
-            except triton_bindings.TritonError as te:
-                self.assertTrue(isinstance(te, ex_type))
-                self.assertEqual(str(te), "Error message")
+            self.assertTrue(isinstance(ctx.exception, ex_type))
+            self.assertEqual(str(ctx.exception), "Error message")
 
     def test_data_type(self):
         t_list = [
@@ -64,7 +278,8 @@ class BindingTest(unittest.TestCase):
             (triton_bindings.TRITONSERVER_ParameterType.STRING, "STRING"),
             (triton_bindings.TRITONSERVER_ParameterType.INT, "INT"),
             (triton_bindings.TRITONSERVER_ParameterType.BOOL, "BOOL"),
-            (triton_bindings.TRITONSERVER_ParameterType.BYTES, "BYTES"),
+            # [FIXME] proper string "BYTES" until rebasing the server change
+            (triton_bindings.TRITONSERVER_ParameterType.BYTES, "<invalid>"),
         ]
         for t, t_str in t_list:
             self.assertEqual(
@@ -84,7 +299,6 @@ class BindingTest(unittest.TestCase):
         del int_param
         del bool_param
         del bytes_param
-        import gc
         gc.collect()
 
     def test_instance_kind(self):
@@ -223,7 +437,6 @@ class BindingTest(unittest.TestCase):
         allocator = triton_bindings.TRITONSERVER_ResponseAllocator(
             alloc_fn, release_fn)
         del allocator
-        import gc
         gc.collect()
 
         # allocator with start_fn
@@ -231,6 +444,98 @@ class BindingTest(unittest.TestCase):
             alloc_fn, release_fn, start_fn)
         allocator.set_buffer_attributes_function(buffer_fn)
         allocator.set_query_function(query_fn)
+
+    def test_message(self):
+        expected_dict = {
+            "key_0": [1, 2, "3"],
+            "key_1": {
+                "nested_key": "nested_value"
+            }
+        }
+        message = triton_bindings.TRITONSERVER_Message(
+            json.dumps(expected_dict))
+        self.assertEqual(expected_dict, json.loads(message.serialize_to_json()))
+
+    def test_metrics(self):
+        # This test depends on 'TRITONSERVER_Server' operates properly
+        # to access metrics.
+
+        # Create server in EXPLICIT mode so we don't need to ensure
+        # a model repository is proper repository
+        options = triton_bindings.TRITONSERVER_ServerOptions()
+        options.set_model_repository_path(self._test_model_repo)
+        options.set_model_control_mode(
+            triton_bindings.TRITONSERVER_ModelControlMode.EXPLICIT)
+        server = triton_bindings.TRITONSERVER_Server(options)
+        metrics = server.metrics()
+        # Check one of the metrics is reported
+        self.assertTrue("nv_cpu_memory_used_bytes" in metrics.formatted(
+            triton_bindings.TRITONSERVER_MetricFormat.PROMETHEUS))
+
+    def test_trace_enum(self):
+        t_list = [
+            (triton_bindings.TRITONSERVER_InferenceTraceLevel.DISABLED,
+             "DISABLED"),
+            (triton_bindings.TRITONSERVER_InferenceTraceLevel.MIN, "MIN"),
+            (triton_bindings.TRITONSERVER_InferenceTraceLevel.MAX, "MAX"),
+            (triton_bindings.TRITONSERVER_InferenceTraceLevel.TIMESTAMPS,
+             "TIMESTAMPS"),
+            (triton_bindings.TRITONSERVER_InferenceTraceLevel.TENSORS,
+             "TENSORS"),
+        ]
+        for t, t_str in t_list:
+            self.assertEqual(
+                triton_bindings.TRITONSERVER_InferenceTraceLevelString(t),
+                t_str)
+        # bit-wise operation
+        level = int(
+            triton_bindings.TRITONSERVER_InferenceTraceLevel.TIMESTAMPS) | int(
+                triton_bindings.TRITONSERVER_InferenceTraceLevel.TENSORS)
+        self.assertNotEqual(
+            level &
+            int(triton_bindings.TRITONSERVER_InferenceTraceLevel.TIMESTAMPS), 0)
+        self.assertNotEqual(
+            level &
+            int(triton_bindings.TRITONSERVER_InferenceTraceLevel.TENSORS), 0)
+
+        t_list = [
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.REQUEST_START,
+             "REQUEST_START"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.QUEUE_START,
+             "QUEUE_START"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.COMPUTE_START,
+             "COMPUTE_START"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.
+             COMPUTE_INPUT_END, "COMPUTE_INPUT_END"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.
+             COMPUTE_OUTPUT_START, "COMPUTE_OUTPUT_START"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.COMPUTE_END,
+             "COMPUTE_END"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.REQUEST_END,
+             "REQUEST_END"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.
+             TENSOR_QUEUE_INPUT, "TENSOR_QUEUE_INPUT"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.
+             TENSOR_BACKEND_INPUT, "TENSOR_BACKEND_INPUT"),
+            (triton_bindings.TRITONSERVER_InferenceTraceActivity.
+             TENSOR_BACKEND_OUTPUT, "TENSOR_BACKEND_OUTPUT"),
+        ]
+        for t, t_str in t_list:
+            self.assertEqual(
+                triton_bindings.TRITONSERVER_InferenceTraceActivityString(t),
+                t_str)
+
+    def test_trace(self):
+        raise Exception("Not implemented")
+        # This test depends on 'TRITONSERVER_Server' operates properly to capture
+        # the trace
+        level = int(
+            triton_bindings.TRITONSERVER_InferenceTraceLevel.TIMESTAMPS) | int(
+                triton_bindings.TRITONSERVER_InferenceTraceLevel.TENSORS)
+        trace_dict = {}
+        trace = triton_bindings.TRITONSERVER_InferenceTrace(
+            level, 123, g_timestamp_fn, g_tensor_fn, g_trace_release_fn,
+            trace_dict)
 
     def test_options(self):
         options = triton_bindings.TRITONSERVER_ServerOptions()
@@ -330,6 +635,235 @@ class BindingTest(unittest.TestCase):
         options.set_repo_agent_directory("repo_agent_dir_0")
         options.set_repo_agent_directory("repo_agent_dir_1")
         options.set_buffer_manager_thread_count(4)
+
+    def test_server(self):
+        server = self._start_polling_server()
+        # is_live
+        self.assertTrue(server.is_live())
+        # is_ready
+        self.assertTrue(server.is_ready())
+        # model_is_ready
+        self.assertTrue(server.model_is_ready(self._model_name, -1))
+        # model_batch_properties
+        expected_batch_properties = (int(
+            triton_bindings.TRITONSERVER_ModelBatchFlag.UNKNOWN), 0)
+        self.assertEqual(server.model_batch_properties(self._model_name, -1),
+                         expected_batch_properties)
+        # model_transaction_properties
+        expected_transaction_policy = (int(
+            triton_bindings.TRITONSERVER_ModelTxnPropertyFlag.ONE_TO_ONE), 0)
+        self.assertEqual(
+            server.model_transaction_properties(self._model_name, -1),
+            expected_transaction_policy)
+        # metadata
+        server_meta_data = self._to_pyobject(server.metadata())
+        self.assertTrue("name" in server_meta_data)
+        self.assertEqual(server_meta_data["name"], "testing_server")
+        # model_metadata
+        model_meta_data = self._to_pyobject(
+            server.model_metadata(self._model_name, -1))
+        self.assertTrue("name" in model_meta_data)
+        self.assertEqual(model_meta_data["name"], self._model_name)
+        # model_statistics
+        model_statistics = self._to_pyobject(
+            server.model_statistics(self._model_name, -1))
+        self.assertTrue("model_stats" in model_statistics)
+        # model_config
+        model_config = self._to_pyobject(
+            server.model_config(self._model_name, -1, 1))
+        self.assertTrue("input" in model_config)
+        # model_index
+        model_index = self._to_pyobject(server.model_index(0))
+        self.assertEqual(model_index[0]["name"], self._model_name)
+        # metrics (see test_metrics)
+        # infer_async (see test_infer_async)
+
+    def test_request(self):
+        # This test depends on 'TRITONSERVER_Server' operates properly to initialize
+        # the request
+        server = self._start_polling_server()
+
+        with self.assertRaises(triton_bindings.NotFound) as ctx:
+            _ = triton_bindings.TRITONSERVER_InferenceRequest(
+                server, "not_existing_model", -1)
+        self.assertTrue("unknown model" in str(ctx.exception))
+
+        expected_request_id = "request"
+        expected_flags = int(
+            triton_bindings.TRITONSERVER_RequestFlag.SEQUENCE_START) | int(
+                triton_bindings.TRITONSERVER_RequestFlag.SEQUENCE_END)
+        expected_correlation_id = 2
+        expected_correlation_id_string = "123"
+        expected_priority = 19
+        # larger value than model max priority level,
+        # will be set to default (10, see 'g_python_addsub' for config detail)
+        expected_priority_uint64 = 67
+        expected_timeout_microseconds = 222
+
+        request = triton_bindings.TRITONSERVER_InferenceRequest(
+            server, "addsub", -1)
+
+        # request metadata
+        request.id = expected_request_id
+        self.assertEqual(request.id, expected_request_id)
+        request.flags = expected_flags
+        self.assertEqual(request.flags, expected_flags)
+        request.correlation_id = expected_correlation_id
+        self.assertEqual(request.correlation_id, expected_correlation_id)
+        request.correlation_id_string = expected_correlation_id_string
+        self.assertEqual(request.correlation_id_string,
+                         expected_correlation_id_string)
+        # Expect error from retrieving correlation id in a wrong type,
+        # wrap in lambda function to avoid early evaluation that raises
+        # exception before assert
+        self.assertRaises(triton_bindings.TritonError,
+                          lambda: request.correlation_id)
+        request.priority = expected_priority
+        self.assertEqual(request.priority, expected_priority)
+        request.priority_uint64 = expected_priority_uint64
+        self.assertEqual(request.priority_uint64, 10)
+        request.timeout_microseconds = expected_timeout_microseconds
+        self.assertEqual(request.timeout_microseconds,
+                         expected_timeout_microseconds)
+
+        request.set_string_parameter("str_key", "str_val")
+        request.set_int_parameter("int_key", 567)
+        request.set_bool_parameter("bool_key", False)
+
+        # I/O
+        input = numpy.ones([2, 3], dtype=numpy.float32)
+        buffer = input.ctypes.data
+        ba = triton_bindings.TRITONSERVER_BufferAttributes()
+        ba.memory_type = triton_bindings.TRITONSERVER_MemoryType.CPU
+        ba.memory_type_id = 0
+        ba.byte_size = input.itemsize * input.size
+
+        request.add_input("INPUT0", triton_bindings.TRITONSERVER_DataType.FP32,
+                          input.shape)
+        self.assertRaises(triton_bindings.TritonError, request.remove_input,
+                          "INPUT2")
+        # raw input assumes single input
+        self.assertRaises(triton_bindings.TritonError, request.add_raw_input,
+                          "INPUT1")
+        request.remove_input("INPUT0")
+        request.add_raw_input("INPUT1")
+        request.remove_all_inputs()
+        # all inputs are removed, all 'append' functions should raise exceptions
+        aid_args = [
+            "INPUT0", buffer, ba.byte_size, ba.memory_type, ba.memory_type_id
+        ]
+        self.assertRaises(triton_bindings.TritonError,
+                          request.append_input_data, *aid_args)
+        self.assertRaises(triton_bindings.TritonError,
+                          request.append_input_data_with_host_policy, *aid_args,
+                          "host_policy_name")
+        self.assertRaises(triton_bindings.TritonError,
+                          request.append_input_data_with_buffer_attributes,
+                          "INPUT0", buffer, ba)
+        self.assertRaises(triton_bindings.TritonError,
+                          request.remove_all_input_data, "INPUT0")
+        # Add back input
+        request.add_input("INPUT0", triton_bindings.TRITONSERVER_DataType.FP32,
+                          input.shape)
+        request.append_input_data(*aid_args)
+        request.remove_all_input_data("INPUT0")
+
+        request.add_requested_output("OUTPUT0")
+        request.remove_requested_output("OUTPUT1")
+        request.remove_all_requested_outputs()
+
+    def test_infer_async(self):
+        # start server
+        server = self._start_polling_server()
+
+        # prepare for infer
+        allocator = triton_bindings.TRITONSERVER_ResponseAllocator(
+            g_alloc_fn, g_release_fn, g_start_fn)
+        allocator.set_buffer_attributes_function(g_buffer_fn)
+        allocator.set_query_function(g_query_fn)
+
+        request_counter = 1
+        response_queue = queue.Queue()
+        allocator_counter = {}
+        request = triton_bindings.TRITONSERVER_InferenceRequest(
+            server, self._model_name, -1)
+        request.set_release_callback(g_request_fn, request_counter)
+        request.set_response_callback(allocator, allocator_counter,
+                                      g_response_fn, response_queue)
+        request.id = "req_0"
+
+        input = numpy.ones([4], dtype=numpy.float32)
+        input_buffer = input.ctypes.data
+        ba = triton_bindings.TRITONSERVER_BufferAttributes()
+        ba.memory_type = triton_bindings.TRITONSERVER_MemoryType.CPU
+        ba.memory_type_id = 0
+        ba.byte_size = input.itemsize * input.size
+
+        request.add_input("INPUT0", triton_bindings.TRITONSERVER_DataType.FP32,
+                          input.shape)
+        request.add_input("INPUT1", triton_bindings.TRITONSERVER_DataType.FP32,
+                          input.shape)
+        request.append_input_data_with_buffer_attributes(
+            "INPUT0", input_buffer, ba)
+        request.append_input_data_with_buffer_attributes(
+            "INPUT1", input_buffer, ba)
+
+        # non-blocking, wait on response complete
+        server.infer_async(request)
+
+        # Expect every response to be returned in 10 seconds
+        flags, res = response_queue.get(block=True, timeout=10)
+        self.assertEqual(
+            flags, int(triton_bindings.TRITONSERVER_ResponseCompleteFlag.FINAL))
+        # expect no error
+        res.throw_if_response_error()
+        # version will be actual model version
+        self.assertEqual(res.model, (self._model_name, 1))
+        self.assertEqual(res.id, request.id)
+        self.assertEqual(res.parameter_count, 0)
+        # out of range access
+        self.assertRaises(triton_bindings.TritonError, res.parameter(0))
+
+        # read output tensor
+        self.assertEqual(res.output_count, 2)
+        for (out, expected_name,
+             expected_data) in [(res.output(0), "OUTPUT0", input + input),
+                                (res.output(1), "OUTPUT1", input - input)]:
+            name, data_type, shape, out_buffer, byte_size, memory_type, memory_type_id, numpy_buffer = out
+            self.assertEqual(name, expected_name)
+            self.assertEqual(data_type,
+                             triton_bindings.TRITONSERVER_DataType.FP32)
+            self.assertEqual(shape, expected_data.shape)
+            self.assertEqual(out_buffer, numpy_buffer.ctypes.data)
+            # buffer attribute used for input doesn't necessarily to
+            # match output buffer attributes, this is just knowing the detail.
+            self.assertEqual(byte_size, ba.byte_size)
+            self.assertEqual(memory_type, ba.memory_type)
+            self.assertEqual(memory_type_id, ba.memory_type_id)
+            self.assertTrue(
+                numpy.allclose(
+                    numpy_buffer.view(dtype=expected_data.dtype).reshape(shape),
+                    expected_data))
+
+        # [WIP] label
+
+    def test_server_explicit(self):
+        raise Exception("Not implemented")
+        # explict : load with params
+        # options = triton_bindings.TRITONSERVER_ServerOptions()
+        # options.set_model_repository_path("/tmp")
+        # options.set_model_control_mode(triton_bindings.TRITONSERVER_ModelControlMode.EXPLICIT)
+        # options.set_strict_model_config(False)
+        # server = triton_bindings.TRITONSERVER_Server(options)
+        # load_file_params = [
+        #     triton_bindings.TRITONSERVER_Parameter("config", r'{}'),
+        #     triton_bindings.TRITONSERVER_Parameter(
+        #         "file:" + os.path.join(version, file_name), g_python_addsub)
+        # ]
+        # server.load_model_with_parameters("addsub", load_file_params)
+
+    def test_custom_metric(self):
+        raise Exception("Not implemented")
 
 
 if __name__ == "__main__":

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -606,6 +606,8 @@ TRITONSERVER_ParameterTypeString(TRITONSERVER_ParameterType paramtype)
       return "INT";
     case TRITONSERVER_PARAMETER_BOOL:
       return "BOOL";
+    case TRITONSERVER_PARAMETER_BYTES:
+      return "BYTES";
     default:
       break;
   }


### PR DESCRIPTION
This PR provides the low level binding for Python user to interact with Triton library within the same process, however, this binding is not intended for Python user to use directly but to enable the development of the [Python wrapper](https://github.com/triton-inference-server/core/pull/238). Python user should use the wrapper mentioned because it encapsualtes many concepts that are not intuitive to Python user but inevitably leaked into the binding.

Most part of the binding is straight forward mapping of the C API, however, the `PyResponseAllocator`, `PyTrace`, `PyInferenceRequest` and `PyInferenceResponse` requires extra attention because they are objects that involves callbacks and ownership transfer. Also, below is the snippet from `.cc` file to help reviewers navigate things that are different from the C equivalent of the binding.

```C++
// This binding is merely used to map Triton C API into Python equivalent,
// and therefore, the naming will be the same as the one used in corresponding
// sections. However, there are a few exceptions to better transit to Python:
// Structs:
//  * Triton structs are encapsulated in a thin wrapper to isolate raw pointer
//    operations which is not supported in pure Python. A thin 'PyWrapper' base
//    class is defined with common utilities
//  * Trival getters and setters are grouped to be a Python class property.
//    However, this creates asymmetry that some APIs are called like function
//    while some like member variables. So I am open to expose getter / setter
//    if it may be more intuitive.
//  * The wrapper is only served as communication between Python and C, it will
//    be unwrapped when control reaches C API and the C struct will be wrapped
//    when control reaches Python side. Python binding user should respect the
//    "ownership" and lifetime of the wrapper in the same way as described in
//    the C API. Python binding user must not assume the same C struct will
//    always be referred through the same wrapper object.
// Enums:
//  * In C API, the enum values are prefixed by the enum name. The Python
//    equivalent is an enum class and thus the prefix is removed to avoid
//    duplication, i.e. Python user may specify a value by
//    'TRITONSERVER_ResponseCompleteFlag.FINAL'.
// Functions / Callbacks:
//  * Output parameters are converted to return value. APIs that return an error
//    will be thrown as an exception. The same applies to callbacks.
//  ** Note that in the C API, the inference response may carry an error object
//     that represent an inference failure. The equivalent Python API will raise
//     the corresponding exception if the response contains error object.
//  * The function parameters and return values are exposed in Python style,
//    for example, object pointer becomes py::object, C array and length
//    condenses into Python array.
```