### PR TITLE
Fix state transitions for re-running requests

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -150,13 +150,13 @@ InferenceRequest::SetState(InferenceRequest::State new_state)
   // Define state transitions
   switch (state_) {
     case InferenceRequest::State::INITIALIZED: {
-      if (new_state != InferenceRequest::State::STARTED) {
+      if (new_state != InferenceRequest::State::PENDING) {
         return generate_error();
       }
       IncrementPendingRequestCount();
       break;
     }
-    case InferenceRequest::State::STARTED: {
+    case InferenceRequest::State::PENDING: {
       if (new_state != InferenceRequest::State::EXECUTING) {
         return generate_error();
       }
@@ -170,7 +170,7 @@ InferenceRequest::SetState(InferenceRequest::State new_state)
       break;
     }
     case InferenceRequest::State::RELEASED: {
-      if (new_state != InferenceRequest::State::STARTED) {
+      if (new_state != InferenceRequest::State::PENDING) {
         // Only transition currently supported after release is to start again
         // when re-using request objects for multiple inferences.
         return generate_error();
@@ -384,7 +384,7 @@ InferenceRequest::OutputBufferProperties(
 Status
 InferenceRequest::Run(std::unique_ptr<InferenceRequest>& request)
 {
-  RETURN_IF_ERROR(request->SetState(InferenceRequest::State::STARTED));
+  RETURN_IF_ERROR(request->SetState(InferenceRequest::State::PENDING));
   return request->model_raw_->Enqueue(request);
 }
 
@@ -1588,8 +1588,8 @@ operator<<(std::ostream& out, const InferenceRequest::State& state)
       out << "INITIALIZED";
       break;
     }
-    case InferenceRequest::State::STARTED: {
-      out << "STARTED";
+    case InferenceRequest::State::PENDING: {
+      out << "PENDING";
       break;
     }
     case InferenceRequest::State::EXECUTING: {

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -291,7 +291,6 @@ class InferenceRequest {
       const int64_t requested_model_version);
 
   InferenceRequest(Model* model, const int64_t requested_model_version);
-  ~InferenceRequest();
 
   const std::string& ModelName() const;
   int64_t RequestedModelVersion() const { return requested_model_version_; }

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -63,7 +63,7 @@ class InferenceRequest {
     INITIALIZED,
 
     // The request has been enqueued, but is not yet executing.
-    STARTED,
+    PENDING,
 
     // The request has been picked up by a backend model instance for execution,
     // but hasn't been released yet.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -799,9 +799,6 @@ class InferenceRequest {
   // Whether this is a null request used for direct sequence batch padding or
   // not.
   bool null_request_;
-  // Catch-all to correctly decrement pending count if needed on destruction
-  // if request doesn't follow normal execution path (error, unused, ensembles)
-  bool decrement_pending_count_;
 };
 
 std::ostream& operator<<(std::ostream& out, const InferenceRequest& request);

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -66,8 +66,6 @@ InferenceRequest::InferenceRequest(
   response_factory_.reset(new InferenceResponseFactory());
 }
 
-InferenceRequest::~InferenceRequest() {}
-
 InferenceRequest::Input::Input(
     const std::string& name, const inference::DataType datatype,
     const int64_t* shape, const uint64_t dim_count)


### PR DESCRIPTION
Fixes L0_simple_lib--base, and allows requests to be re-used for multiple inferences. 

Adds a sanity check that pending count isn't incremented multiple times without getting decremented in some edge case where a request is PENDING, fails to get to the PENDING state, and ends up in PENDING state again (re-used).

General logic:
1. When a request is created, it is in INITIALIZED state
2. When a request is run, it is set to PENDING state
3. If a request makes it to the backend, it should be in EXECUTING state
    - At this point, the backend takes ownership of the request, and is responsible to call RequestRelease() on it, moving request into RELEASED state
4. If any error occurs before getting to backend, it should hit InferenceRequest::RespondIfError and be set to RELEASED state.
5. If somehow a request didn't make it to backend (EXECUTING state), but also didn't get RELEASED, then it should still be in PENDING state. If the request is to be re-used for another inference, it should call PrepareForInference() which should set state back to INITIALIZED at the start of the cycle. 

If a request were to be transitioned from RELEASED to PENDING/EXECUTING directly, this should indicate a logical error as the request should only execute via InferAsync entrypoint, which calls PrepareForInference ([re]sets to INITIALIZED state) then InferenceRequest::Run (sets to PENDING state).