### PR TITLE
Fix request re-use when cancelling a request

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -1023,11 +1023,7 @@ TRITONBACKEND_RequestIsCancelled(
 {
   InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
 
-  auto status = tr->IsCancelled(is_cancelled);
-  if (!status.IsOk()) {
-    return TRITONSERVER_ErrorNew(
-        StatusCodeToTritonCode(status.StatusCode()), status.Message().c_str());
-  }
+  RETURN_TRITONSERVER_ERROR_IF_ERROR(tr->IsCancelled(is_cancelled));
   return nullptr;
 }
 

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -1022,7 +1022,12 @@ TRITONBACKEND_RequestIsCancelled(
     TRITONBACKEND_Request* request, bool* is_cancelled)
 {
   InferenceRequest* tr = reinterpret_cast<InferenceRequest*>(request);
-  *is_cancelled = tr->IsCancelled();
+
+  auto status = tr->IsCancelled(is_cancelled);
+  if (!status.IsOk()) {
+    return TRITONSERVER_ErrorNew(
+        StatusCodeToTritonCode(status.StatusCode()), status.Message().c_str());
+  }
   return nullptr;
 }
 

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -631,6 +631,10 @@ TritonModelInstance::WarmUp()
         request->CaptureQueueStartNs();
         triton_requests.push_back(
             reinterpret_cast<TRITONBACKEND_Request*>(request.get()));
+
+        // For warmup requests we need to manually set ResponseFactory
+        // since they don't run `PrepareForInference`.
+        request->SetResponseFactory();
       }
 
       Execute(triton_requests);

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -623,6 +623,12 @@ TritonModelInstance::WarmUp()
         request->SetResponseCallback(
             &warmup_allocator, nullptr, WarmupResponseComplete,
             &response_complete[i]);
+
+        // For warmup requests we need to manually set ResponseFactory
+        // since they modify the callback after PrepareForInference has
+        // been called.
+        request->SetResponseFactory();
+
         // Capture timestamp before run to avoid incorrect accumulation from
         // sequential warmup runs
 #ifdef TRITON_ENABLE_STATS
@@ -631,11 +637,6 @@ TritonModelInstance::WarmUp()
         request->CaptureQueueStartNs();
         triton_requests.push_back(
             reinterpret_cast<TRITONBACKEND_Request*>(request.get()));
-
-        // For warmup requests we need to manually set ResponseFactory
-        // since they modify the callback after PrepareForInference has
-        // been called.
-        request->SetResponseFactory();
       }
 
       Execute(triton_requests);

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -633,7 +633,8 @@ TritonModelInstance::WarmUp()
             reinterpret_cast<TRITONBACKEND_Request*>(request.get()));
 
         // For warmup requests we need to manually set ResponseFactory
-        // since they don't run `PrepareForInference`.
+        // since they modify the callback after PrepareForInference has
+        // been called.
         request->SetResponseFactory();
       }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -828,9 +828,7 @@ InferenceRequest::PrepareForInference()
   // inference execution.
   inputs_.clear();
   override_inputs_.clear();
-  response_factory_.reset(new InferenceResponseFactory(
-      model_shared_, id_, response_allocator_, alloc_userp_, response_callback_,
-      response_userp_, response_delegator_));
+  SetResponseFactory();
 
   // Renormalize if anything has changed in the inference request in a
   // way that could impact renormalization.

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -599,6 +599,7 @@ InferenceRequest::CopyAsNull(const InferenceRequest& from)
   lrequest->SetResponseCallback(
       &null_allocator, nullptr, NullResponseComplete, nullptr);
   lrequest->SetReleaseCallback(NullRequestComplete, nullptr);
+  lrequest->SetResponseFactory();
 
   // Must normalize inputs here...
   for (auto& pr : lrequest->original_inputs_) {

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -828,7 +828,9 @@ InferenceRequest::PrepareForInference()
   // inference execution.
   inputs_.clear();
   override_inputs_.clear();
-  ResetCancel();
+  response_factory_.reset(new InferenceResponseFactory(
+      model_shared_, id_, response_allocator_, alloc_userp_, response_callback_,
+      response_userp_, response_delegator_));
 
   // Renormalize if anything has changed in the inference request in a
   // way that could impact renormalization.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -497,8 +497,8 @@ class InferenceRequest {
     return Status::Success;
   }
 
-  // Initialize the response factory that is to be used with any
-  // responses produced for this request.
+  // Initialize the response factory arguments that are going to be used with
+  // any responses produced for this request.
   Status SetResponseCallback(
       const ResponseAllocator* allocator, void* alloc_userp,
       TRITONSERVER_InferenceResponseCompleteFn_t response_fn,
@@ -683,9 +683,7 @@ class InferenceRequest {
 
   Status Cancel()
   {
-    if (response_factory_) {
-      response_factory_->Cancel();
-    } else {
+    if (!response_factory_) {
       return Status(
           Status::Code::INTERNAL,
           "It is not possible to cancel an inference request before calling "
@@ -697,14 +695,13 @@ class InferenceRequest {
 
   Status IsCancelled(bool* is_cancelled)
   {
-    if (response_factory_) {
-      *is_cancelled = response_factory_->IsCancelled();
-    } else {
+    if (!response_factory_) {
       return Status(
           Status::Code::INTERNAL,
           "It is not possible to query cancellation status before calling "
           "TRITONSERVER_InferAsync.");
     }
+    *is_cancelled = response_factory_->IsCancelled();
     return Status::Success;
   }
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -551,6 +551,13 @@ class InferenceRequest {
 
   Status LoadInputStates();
 
+  void SetResponseFactory()
+  {
+    response_factory_.reset(new InferenceResponseFactory(
+        model_shared_, id_, response_allocator_, alloc_userp_,
+        response_callback_, response_userp_, response_delegator_));
+  }
+
   const std::shared_ptr<SequenceStates>& GetSequenceStates() const
   {
     return sequence_states_;

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -65,7 +65,6 @@ class InferenceResponseFactory {
   }
 
   void Cancel() { is_cancelled_ = true; }
-  void ResetCancel() { is_cancelled_ = false; }
 
   bool IsCancelled() { return is_cancelled_; }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -592,6 +592,14 @@ set_target_properties(
     INSTALL_RPATH ""
 )
 
+target_include_directories(
+  request_cancellation_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${GTEST_INCLUDE_DIRS}
+)
+
 target_link_libraries(
   request_cancellation_test
   PRIVATE

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1643,7 +1643,7 @@ TRITONSERVER_InferenceRequestIsCancelled(
 {
   tc::InferenceRequest* lrequest =
       reinterpret_cast<tc::InferenceRequest*>(inference_request);
-  *is_cancelled = lrequest->IsCancelled();
+  RETURN_IF_STATUS_ERROR(lrequest->IsCancelled(is_cancelled));
   return nullptr;  // Success
 }
 
@@ -1653,7 +1653,7 @@ TRITONSERVER_InferenceRequestCancel(
 {
   tc::InferenceRequest* lrequest =
       reinterpret_cast<tc::InferenceRequest*>(inference_request);
-  lrequest->Cancel();
+  RETURN_IF_STATUS_ERROR(lrequest->Cancel());
   return nullptr;  // Success
 }
 


### PR DESCRIPTION
When cancelling a request that is being re-used, we need to make sure that a new response factory is created for each inference. Otherwise, in the old code, if the user didn't call `SetResponseReleaseCallback`, cancelling a new request could cancel the old response factory as well which is not desired.