### PR TITLE
Dynamic batch scheduler request cancellation

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -57,15 +57,12 @@ IsStaleState(Payload::State payload_state)
 
 void
 FinishSkippedRequests(
-    std::shared_ptr<
-        std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>&& requests,
+    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>&& requests,
     const Status& response_status)
 {
-  if (requests != nullptr) {
-    for (auto& queue : *requests) {
-      for (auto& request : queue) {
-        InferenceRequest::RespondIfError(request, response_status, true);
-      }
+  for (auto& queue : requests) {
+    for (auto& request : queue) {
+      InferenceRequest::RespondIfError(request, response_status, true);
     }
   }
 }
@@ -329,7 +326,7 @@ DynamicBatchScheduler::BatcherThread(const int nice)
   while (!scheduler_thread_exit_.load()) {
     NVTX_RANGE(nvtx_, "DynamicBatcher " + model_name_);
 
-    std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>
+    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
         rejected_requests, cancelled_requests;
     uint64_t wait_microseconds = 0;
 

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -104,6 +104,7 @@ class DynamicBatchScheduler : public Scheduler {
   void NewPayload();
   uint64_t GetDynamicBatch();
   void DelegateResponse(std::unique_ptr<InferenceRequest>& request);
+  void CancelRequest(std::unique_ptr<InferenceRequest>&& request);
   void CacheLookUp(
       std::unique_ptr<InferenceRequest>& request,
       std::unique_ptr<InferenceResponse>& cached_response);

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -104,7 +104,6 @@ class DynamicBatchScheduler : public Scheduler {
   void NewPayload();
   uint64_t GetDynamicBatch();
   void DelegateResponse(std::unique_ptr<InferenceRequest>& request);
-  void CancelRequest(std::unique_ptr<InferenceRequest>&& request);
   void CacheLookUp(
       std::unique_ptr<InferenceRequest>& request,
       std::unique_ptr<InferenceResponse>& cached_response);

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -688,6 +688,7 @@ class InferenceRequest {
   {
     secondary_stats_aggregator_ = secondary_stats_aggregator;
   }
+#endif  // TRITON_ENABLE_STATS
 
   Status Cancel()
   {
@@ -722,8 +723,6 @@ class InferenceRequest {
     }
     return is_cancelled;
   }
-
-#endif  // TRITON_ENABLE_STATS
 
  private:
   DISALLOW_COPY_AND_ASSIGN(InferenceRequest);

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -38,6 +38,7 @@
 #include "response_allocator.h"
 #include "sequence_state.h"
 #include "status.h"
+#include "triton/common/logging.h"
 #include "triton/common/model_config.h"
 #include "tritonserver_apis.h"
 
@@ -710,6 +711,16 @@ class InferenceRequest {
     }
     *is_cancelled = response_factory_->IsCancelled();
     return Status::Success;
+  }
+
+  bool IsCancelled()
+  {
+    bool is_cancelled = false;
+    Status status = IsCancelled(&is_cancelled);
+    if (!status.IsOk()) {
+      LOG_ERROR << status.Message();
+    }
+    return is_cancelled;
   }
 
 #endif  // TRITON_ENABLE_STATS

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -360,22 +360,20 @@ PriorityQueue::Dequeue(std::unique_ptr<InferenceRequest>* request)
 
 void
 PriorityQueue::ReleaseSkippedRequests(
-    std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>*
+    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>*
         rejected_requests,
-    std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>*
+    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>*
         cancelled_requests)
 {
-  auto reject_req = std::make_shared<
-      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>(
+  std::vector<std::deque<std::unique_ptr<InferenceRequest>>> reject_req(
       queues_.size());
-  auto cancel_req = std::make_shared<
-      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>(
+  std::vector<std::deque<std::unique_ptr<InferenceRequest>>> cancel_req(
       queues_.size());
 
   size_t idx = 0;
   for (auto it = queues_.begin(); it != queues_.end();) {
-    it->second.ReleaseRejectedQueue(&((*reject_req)[idx]));
-    it->second.ReleaseCancelledQueue(&((*cancel_req)[idx]));
+    it->second.ReleaseRejectedQueue(&reject_req[idx]);
+    it->second.ReleaseCancelledQueue(&cancel_req[idx]);
     idx++;
     if (it->second.ReadyForErasure()) {
       // Invalidate the pending batch cursor if it points to

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -86,10 +86,9 @@ class PriorityQueue {
 
   // Retrieve the requests that are either rejected or cancelled.
   void ReleaseSkippedRequests(
-      std::shared_ptr<std::vector<
-          std::deque<std::unique_ptr<InferenceRequest>>>>* rejected_requests,
-      std::shared_ptr<
-          std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>*
+      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>*
+          rejected_requests,
+      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>*
           cancelled_requests);
 
   // Return the number of requests in the queue, rejected requests are


### PR DESCRIPTION
The requests queued on the dynamic batch scheduler can be cancelled, if the cancellation is received before the request is added into a payload.