### PR TITLE
Sequence batch scheduler request cancellation

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -431,9 +431,9 @@ DynamicBatchScheduler::BatcherThread(const int nice)
     }
 
     // Finish rejected and cancelled requests if any
-    static Status rejected_status =
+    const static Status rejected_status =
         Status(Status::Code::UNAVAILABLE, "Request timeout expired");
-    static Status cancelled_status = Status(Status::Code::CANCELLED);
+    const static Status cancelled_status = Status(Status::Code::CANCELLED);
     FinishSkippedRequests(std::move(rejected_requests), rejected_status);
     FinishSkippedRequests(std::move(cancelled_requests), cancelled_status);
   }  // end runner loop

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -690,6 +690,7 @@ class InferenceRequest {
   }
 #endif  // TRITON_ENABLE_STATS
 
+  // Mark the request as cancelled.
   Status Cancel()
   {
     if (!response_factory_) {
@@ -702,6 +703,9 @@ class InferenceRequest {
     return Status::Success;
   }
 
+  // Check if the request is marked as cancelled. This does not indicate if the
+  // request is actually cancelled. The request is cancelled if and only if it
+  // is responded with a cancelled status.
   Status IsCancelled(bool* is_cancelled)
   {
     if (!response_factory_) {

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -854,7 +854,9 @@ SequenceBatchScheduler::MarkRequestsCancelled(
   bool notify_clean_up = !requests->empty();
   while (!requests->empty()) {
     auto& cancelled_request = requests->front();
-    cancelled_requests_.emplace_back(std::move(cancelled_request));
+    if (cancelled_request) {
+      cancelled_requests_.emplace_back(std::move(cancelled_request));
+    }
     requests->pop_front();
   }
   if (notify_clean_up) {

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -83,9 +83,15 @@ IsAnyRequestCancelled(std::deque<std::unique_ptr<InferenceRequest>>& requests)
 void
 CancelRequests(std::vector<std::unique_ptr<InferenceRequest>>&& requests)
 {
-  static Status status = Status(Status::Code::CANCELLED);
+  static Status cancelled_status = Status(Status::Code::CANCELLED);
   for (auto& req : requests) {
-    InferenceRequest::RespondIfError(req, status, true);
+    // Mark the request as cancelled before responding.
+    Status status = req->Cancel();
+    if (!status.IsOk()) {
+      LOG_ERROR << status.Message();
+    }
+    // Respond the request as cancelled.
+    InferenceRequest::RespondIfError(req, cancelled_status, true);
   }
 }
 

--- a/src/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler.cc
@@ -83,7 +83,7 @@ IsAnyRequestCancelled(std::deque<std::unique_ptr<InferenceRequest>>& requests)
 void
 CancelRequests(std::vector<std::unique_ptr<InferenceRequest>>&& requests)
 {
-  static Status cancelled_status = Status(Status::Code::CANCELLED);
+  const static Status cancelled_status = Status(Status::Code::CANCELLED);
   for (auto& req : requests) {
     // Mark the request as cancelled before responding.
     Status status = req->Cancel();
@@ -1144,7 +1144,7 @@ SequenceBatchScheduler::ReaperThread(const int nice)
       }
 
       // Reject timeout requests
-      static Status rejected_status = Status(
+      const static Status rejected_status = Status(
           Status::Code::UNAVAILABLE,
           "timeout of the corresponding sequence has been expired");
       for (auto& backlog : expired_backlogs) {

--- a/src/sequence_batch_scheduler.h
+++ b/src/sequence_batch_scheduler.h
@@ -208,6 +208,8 @@ class SequenceBatchScheduler : public Scheduler {
   // Removed objects to be cleaned up
   std::vector<std::shared_ptr<TritonModelInstance>> removed_instances_;
   std::vector<std::unique_ptr<SequenceBatch>> removed_batchers_;
+  std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
+      cancelled_requests_;
 
   // Map from a model instance pointer that is pending to be removed from this
   // scheduler to a pair ["the number of sequence slots remaining for the

--- a/src/sequence_batch_scheduler.h
+++ b/src/sequence_batch_scheduler.h
@@ -160,6 +160,10 @@ class SequenceBatchScheduler : public Scheduler {
   Status CreateBatchers(
       const std::vector<std::shared_ptr<TritonModelInstance>>& instances);
 
+  // Move requests so they will be cancelled by the CleanUpThread.
+  void MarkRequestsCancelled(
+      std::deque<std::unique_ptr<InferenceRequest>>* requests);
+
   // Erase the sequence slot from 'pending_removal_seq_slots_'. The batcher
   // behind the sequence slot will be removed when all sequence slots of the
   // batcher are removed. Return true if the sequence slot is pending removal.
@@ -208,8 +212,7 @@ class SequenceBatchScheduler : public Scheduler {
   // Removed objects to be cleaned up
   std::vector<std::shared_ptr<TritonModelInstance>> removed_instances_;
   std::vector<std::unique_ptr<SequenceBatch>> removed_batchers_;
-  std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
-      cancelled_requests_;
+  std::vector<std::unique_ptr<InferenceRequest>> cancelled_requests_;
 
   // Map from a model instance pointer that is pending to be removed from this
   // scheduler to a pair ["the number of sequence slots remaining for the


### PR DESCRIPTION
There are two cancellation scenarios:
1. If a sequence is queued on the backlog and one or more requests of the sequence is cancelled, then the sequence is cancelled along with all requests queued on the sequence..
2. If a sequence is inferencing (one or more requests are inferencing or completed) and a request of the sequence that has not started inference is cancelled, then the sequence is cancelled along with all requests queued on the sequence.