### PR TITLE
Forward ensemble request parameters to composing models

### DIFF
--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -955,10 +955,7 @@ EnsembleContext::InitStep(
   irequest->SetFlags(flags);
   irequest->SetPriority(priority_);
   irequest->SetTimeoutMicroseconds(timeout_);
-  // Forward ensemble request parameters to composing models.
-  for (const auto& parameter : parameters_) {
-    irequest->AddParameter(parameter);
-  }
+  irequest->SetParameters(parameters_);
 #ifdef TRITON_ENABLE_STATS
   irequest->SetSecondaryStatsAggregator(
       &request_tracker_->ContextStatsAggregator());

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -241,6 +241,13 @@ InferenceRequest::AddParameter(const char* name, const bool value)
   return Status::Success;
 }
 
+Status
+InferenceRequest::AddParameter(const InferenceParameter& parameter)
+{
+  parameters_.emplace_back(parameter);
+  return Status::Success;
+}
+
 #ifdef TRITON_ENABLE_TRACING
 Status
 InferenceRequest::TraceInputTensors(

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -242,9 +242,11 @@ InferenceRequest::AddParameter(const char* name, const bool value)
 }
 
 Status
-InferenceRequest::AddParameter(const InferenceParameter& parameter)
+InferenceRequest::SetParameters(
+    const std::deque<InferenceParameter>& parameters)
 {
-  parameters_.emplace_back(parameter);
+  // NOTE: For BYTES parameters, this will shallow copy the pointer for now.
+  parameters_ = parameters;
   return Status::Success;
 }
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -362,11 +362,11 @@ class InferenceRequest {
       TRITONSERVER_InferenceTraceActivity activity, const std::string& msg);
 #endif  // TRITON_ENABLE_TRACING
 
-  // Add an parameter to the request.
+  // Add a parameter to the request.
   Status AddParameter(const char* name, const char* value);
   Status AddParameter(const char* name, const int64_t value);
   Status AddParameter(const char* name, const bool value);
-  Status AddParameter(const InferenceParameter& parameter);
+  Status SetParameters(const std::deque<InferenceParameter>& parameters);
   const std::deque<InferenceParameter>& Parameters() const
   {
     return parameters_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -366,6 +366,7 @@ class InferenceRequest {
   Status AddParameter(const char* name, const char* value);
   Status AddParameter(const char* name, const int64_t value);
   Status AddParameter(const char* name, const bool value);
+  Status AddParameter(const InferenceParameter& parameter);
   const std::deque<InferenceParameter>& Parameters() const
   {
     return parameters_;


### PR DESCRIPTION
Improves LLM pipeline UX. Applies to other workflows as well, but use of per-request parameters is particularly common for LLMs.

Previously, when certain model parameters are passed as request parameters to an ensemble (ex: preprocess, LLM, postprocess), the parameters wouldn't be accessible to the composing models. Now they will be forwarded to each step request in the ensemble.

Server: https://github.com/triton-inference-server/server/pull/6284
Core: https://github.com/triton-inference-server/core/pull/261