### PR TITLE
Ensemble scheduler request cancellation

### DIFF
--- a/src/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler.cc
@@ -1264,6 +1264,11 @@ EnsembleContext::ScheduleSteps(
       }
     }
     if (should_schedule) {
+      // If the ensemble request is cancelled, propagate the cancellation to the
+      // next request step.
+      if (context->request_tracker_->Request()->IsCancelled()) {
+        step->request_->Cancel();
+      }
       // On a successful call to InferAsync(), the step will be released by
       // the response callback. When the response callback is invoked, the
       // step must not own (and release) the request as the request should be

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -688,6 +688,7 @@ class InferenceRequest {
   {
     secondary_stats_aggregator_ = secondary_stats_aggregator;
   }
+#endif  // TRITON_ENABLE_STATS
 
   Status Cancel()
   {
@@ -722,8 +723,6 @@ class InferenceRequest {
     }
     return is_cancelled;
   }
-
-#endif  // TRITON_ENABLE_STATS
 
  private:
   DISALLOW_COPY_AND_ASSIGN(InferenceRequest);

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -38,6 +38,7 @@
 #include "response_allocator.h"
 #include "sequence_state.h"
 #include "status.h"
+#include "triton/common/logging.h"
 #include "triton/common/model_config.h"
 #include "tritonserver_apis.h"
 
@@ -710,6 +711,16 @@ class InferenceRequest {
     }
     *is_cancelled = response_factory_->IsCancelled();
     return Status::Success;
+  }
+
+  bool IsCancelled()
+  {
+    bool is_cancelled = false;
+    Status status = IsCancelled(&is_cancelled);
+    if (!status.IsOk()) {
+      LOG_ERROR << status.Message();
+    }
+    return is_cancelled;
   }
 
 #endif  // TRITON_ENABLE_STATS


### PR DESCRIPTION
In between each ensemble steps, the parent request is checked for cancellation. If the parent request is cancelled, the cancellation is propagated to the next child request step. The scheduler of the individual request can then pick up the cancellation request, cancel the request and propagate the cancellation status back to parent.