### PR TITLE
Fix state dimension selection when initial state is specified

### DIFF
--- a/src/sequence_batch_scheduler/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler/sequence_batch_scheduler.cc
@@ -367,6 +367,14 @@ SequenceBatchScheduler::GenerateInitialStateData(
             std::to_string(initial_state.dims().size()) +
             " != " + std::to_string(state.dims().size()));
   }
+  const auto& initial_state_pair = initial_state_.emplace(
+      std::piecewise_construct, std::forward_as_tuple(state.input_name()),
+      std::forward_as_tuple(initial_state.name()));
+  auto& initial_state_data = initial_state_pair.first->second;
+
+  if (max_batch_size_ > 0) {
+    initial_state_data.shape_.emplace_back(1);
+  }
 
   // Check the dimensions to make sure it doesn't have variable-sized dims and
   // matches the state description.
@@ -390,12 +398,8 @@ SequenceBatchScheduler::GenerateInitialStateData(
                 " != " + std::to_string(*state_dim));
       }
     }
+    initial_state_data.shape_.emplace_back(*initial_state_dim);
   }
-
-  const auto& initial_state_pair = initial_state_.emplace(
-      std::piecewise_construct, std::forward_as_tuple(state.input_name()),
-      std::forward_as_tuple(initial_state.name()));
-  auto& initial_state_data = initial_state_pair.first->second;
 
   // Calculate total memory byte size
   auto element_count = triton::common::GetElementCount(initial_state.dims());

--- a/src/sequence_state.h
+++ b/src/sequence_state.h
@@ -134,6 +134,7 @@ class SequenceStates {
     }
 
     std::string state_init_name_;
+    std::vector<int64_t> shape_{};
     std::shared_ptr<MutableMemory> data_;
   };
 


### PR DESCRIPTION
When the state dimensions had variable dimensions, the initial state was not configured using the shape of the initial state and would just use 1 for variable dimensions which was not correct. e.g.

initial state: [1, 32, 2, 1]
model config: [1, 32, -1, 1]

The shape of the state was [1, 32, 1, 1] instead of [1, 32, 2, 1].