### PR TITLE
Share allocation between input and output state

### DIFF
--- a/src/sequence_state.cc
+++ b/src/sequence_state.cc
@@ -237,11 +237,8 @@ SequenceStates::OutputState(
 
     if (output_state_r->Data()->TotalByteSize() ==
         input_state_r->Data()->TotalByteSize()) {
-      std::shared_ptr<Memory> temp_memory = input_state_r->Data();
       RETURN_IF_ERROR(input_state_r->RemoveAllData());
       RETURN_IF_ERROR(input_state_r->SetData(output_state_r->Data()));
-      RETURN_IF_ERROR(output_state_r->RemoveAllData());
-      RETURN_IF_ERROR(output_state_r->SetData(temp_memory));
     } else {
       // If the size of output state is different from the input state, allocate
       // a new memory for the input state with the same size as output state.


### PR DESCRIPTION
Originally discussed [here](https://github.com/triton-inference-server/server/issues/6215). Currently Triton will manage two CUDA memory allocations for each state: one for input and a corresponding output state. If the input and output states are of the size then after each batch is executed we:
1. Set the output allocation as the new input (containing the newly computed state values for the next batch)
2. Set the previous input allocation as the new output (to avoid re-allocating each time we need to write a new output)

This PR proposes to remove step 2. and always write and read states from the **same** shared allocation. This cuts in half the amount of memory required for each state, which can be multiple gigabytes in the case of large Transformer architectures.

When adding logging to `InferenceRequest::LoadInputStates()` we see the following allocation pattern across consecutive inference requests

**Master**
```
InputState address: 0x1511d06de240   <-- first allocation is in CPU pinned memory
InputState address: 0x1510e0a50800   <-- CUDA allocation 1 
InputState address: 0x1510e1818600   <-- CUDA allocation 2 
InputState address: 0x1510e0a50800   <-- CUDA allocation 1 
InputState address: 0x1510e1818600   <-- CUDA allocation 2 
```

**This PR**
```
InputState address: 0x14d7d26de240   <-- first allocation is in CPU pinned memory
InputState address: 0x14d6e3158600   <-- CUDA allocation 1 
InputState address: 0x14d6e3158600   <-- CUDA allocation 1 
InputState address: 0x14d6e3158600   <-- CUDA allocation 1 
InputState address: 0x14d6e3158600   <-- CUDA allocation 1 
```


