### PR TITLE
Add version info to prometheus metrics

### DIFF
--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -195,11 +195,6 @@ Metrics::Metrics()
           prometheus::BuildGauge()
             .Name("triton_version_information")
             .Help("Triton API & Server Versions")
-            /*.Labels({
-                //{std::string("api_major_version"), std::to_string(TRITONBACKEND_API_VERSION_MAJOR)},
-                {std::string("api_minor_version"),    std::to_string(TRITONBACKEND_API_VERSION_MINOR)},
-                {std::string("server_major_version"), std::to_string(TRITONSERVER_API_VERSION_MAJOR)},
-                {std::string("server_minor_version"), std::to_string(TRITONSERVER_API_VERSION_MINOR)}})*/
             .Register(*registry_)),
 
 #ifdef TRITON_ENABLE_METRICS_GPU

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -190,6 +190,18 @@ Metrics::Metrics()
                     "microseconds.")
               .Register(*registry_)),
 
+      // Versions
+      version_info_family_(
+          prometheus::BuildGauge()
+            .Name("triton_version_information")
+            .Help("Triton API & Server Versions")
+            /*.Labels({
+                //{std::string("api_major_version"), std::to_string(TRITONBACKEND_API_VERSION_MAJOR)},
+                {std::string("api_minor_version"),    std::to_string(TRITONBACKEND_API_VERSION_MINOR)},
+                {std::string("server_major_version"), std::to_string(TRITONSERVER_API_VERSION_MAJOR)},
+                {std::string("server_minor_version"), std::to_string(TRITONSERVER_API_VERSION_MINOR)}})*/
+            .Register(*registry_)),
+
 #ifdef TRITON_ENABLE_METRICS_GPU
       gpu_utilization_family_(prometheus::BuildGauge()
                                   .Name("nv_gpu_utilization")
@@ -238,6 +250,11 @@ Metrics::Metrics()
       cpu_metrics_enabled_(false), pinned_memory_metrics_enabled_(false),
       metrics_interval_ms_(2000)
 {
+    version_info_family_.Add({
+            {std::string("api_major_version"), std::to_string(TRITONBACKEND_API_VERSION_MAJOR)},        
+            {std::string("api_minor_version"), std::to_string(TRITONBACKEND_API_VERSION_MINOR)},
+            {std::string("server_major_version"), std::to_string(TRITONSERVER_API_VERSION_MAJOR)},
+            {std::string("server_minor_version"), std::to_string(TRITONSERVER_API_VERSION_MINOR)}});
 }
 
 static prometheus::detail::LabelHasher label_hasher_;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -324,6 +324,9 @@ class Metrics {
   prometheus::Family<prometheus::Summary>& cache_hit_summary_us_model_family_;
   prometheus::Family<prometheus::Summary>& cache_miss_summary_us_model_family_;
 
+  // Version
+  prometheus::Family<prometheus::Gauge>& version_info_family_;
+
 #ifdef TRITON_ENABLE_METRICS_GPU
   prometheus::Family<prometheus::Gauge>& gpu_utilization_family_;
   prometheus::Family<prometheus::Gauge>& gpu_memory_total_family_;


### PR DESCRIPTION
Addresses https://github.com/triton-inference-server/server/issues/6320

Example metric output: 
`$ curl -s --request GET "http://localhost:8002/metrics" | grep api
triton_version_information{api_major_version="1",api_minor_version="16",server_major_version="1",server_minor_version="24"} 0`