### PR TITLE
Check for python-based backend in backend map

### DIFF
--- a/src/backend_manager.cc
+++ b/src/backend_manager.cc
@@ -364,7 +364,7 @@ TritonBackendManager::CreateBackend(
 
   (*backend)->SetPythonBasedBackendFlag(is_python_based_backend);
   if (is_python_based_backend) {
-    backend_map_.insert({std::string(dir + "/model.py"), *backend});
+    backend_map_.insert({python_based_backend_path, *backend});
   } else {
     backend_map_.insert({libpath, *backend});
   }

--- a/src/backend_manager.cc
+++ b/src/backend_manager.cc
@@ -349,10 +349,9 @@ TritonBackendManager::CreateBackend(
     // If backend already exists, re-use it.
     if (itr != backend_map_.end()) {
       *backend = itr->second;
-      // Python backend based backends use the same shared library as python
-      // backend. If libpath to libtriton_python.so is already found, need to
-      // check if backends' names match. If not, we create a new python backend
-      // based backend.
+      // Python based backends use the same shared library as python backend.
+      // If libpath to libtriton_python.so is already found, we need to check
+      // if backend names match. If not, we create a new python based backend.
       if ((*backend)->Name() == name) {
         return Status::Success;
       }


### PR DESCRIPTION
Proof of concept to fix loading multiple models from the same python-based backend (ex: vllm).

Without this change or a similar one, we are creating 2 separate backend/backendState objects which breaks the atomic counter used to create shm_region_prefix names in python backend, rather than re-using the 1st backend object when trying to create/load the 2nd backend object.

**Feel free to take over or implement this in a different way @dyastremsky @oandreeva-nv** 

NOTE:
- Another WAR for this issue is to serialize model loading with `tritonserver --model-load-thread-count 1`, though I think this will cause the models to share a shm region rather than each having their own (without this PR fix) which may be an issue
- ~~I think [this check](https://github.com/triton-inference-server/core/blob/3d6d7021c14bb15d9109e45600ee7ecf2c837ddb/src/backend_manager.cc#L352) is redundant or unused if we are [inserting the python_based_backend_path into the map rather than the libpath  ](https://github.com/triton-inference-server/core/blob/3d6d7021c14bb15d9109e45600ee7ecf2c837ddb/src/backend_manager.cc#L362). IIUC, this check would only be used if we were instead always inserting `libpath` (the python shared lib path) for multiple python-based-backends (ex: vllm and pytorch), and then we get a hit on finding libpath, but want to load separate entries for vllm or pytorch~~
    - edit pointed out by @oandreeva-nv - I think this check is useful for the case that python backend is loaded before vllm backend. Without it, I think it would hit on finding libtriton_python but fail the name check in order to load vllm separately.

Testing:
- ~~We should also add a sanity test in vllm backend CI test to try loading multiple models at same time to test this @dyastremsky @pskiran1~~ 
- Added test here: https://github.com/triton-inference-server/vllm_backend/pull/11