### PR TITLE
Dependency graph to track unloading nodes until unload completes

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -767,9 +767,8 @@ ModelRepositoryManager::LoadUnloadModels(
 
   // Check for collision in affected models and try to lock those models.
   std::shared_ptr<std::condition_variable> retry_notify_cv;
-  auto conflict_model = new_dependency_graph.LockNodes(
-      affected_models, dependency_graph_ /* prev_dependency_graph */,
-      &retry_notify_cv);
+  auto conflict_model =
+      new_dependency_graph.LockNodes(affected_models, &retry_notify_cv);
   if (conflict_model) {
     // A collision is found. Since info is only written to local copy, so it is
     // safe to rollback by simply returning the conflict information.
@@ -1972,13 +1971,13 @@ ModelRepositoryManager::DependencyGraph::RemoveNode(
     downstreams.emplace(downstream->model_id_);
   }
 
-  // Drop the node from all reference,
-  // remove from graph at last to complete its lifecycle
+  // Drop the node from all references and only track it on removed nodes
   (*global_map_ptr_)[model_id.name_].erase(model_id);
   for (const auto& model_name : node->missing_upstreams_) {
     auto mit = missing_nodes_.find(model_name);
     mit->second.erase(model_id);
   }
+  removed_nodes_.emplace(std::make_pair(model_id, std::move(node)));
   nodes_.erase(it);
 
   return {std::move(upstreams), std::move(downstreams)};
@@ -2078,6 +2077,11 @@ ModelRepositoryManager::DependencyGraph::DependencyGraph(
     }
     pair.second->downstreams_.swap(new_downstreams);
   }
+  // Copy removed_nodes_
+  for (auto& pair : rhs.removed_nodes_) {
+    removed_nodes_.emplace(
+        pair.first, std::make_unique<DependencyNode>(*pair.second));
+  }
 }
 
 void
@@ -2095,38 +2099,36 @@ ModelRepositoryManager::DependencyGraph::Swap(DependencyGraph& rhs)
   std::swap(global_map_ptr_, rhs.global_map_ptr_);
   nodes_.swap(rhs.nodes_);
   missing_nodes_.swap(rhs.missing_nodes_);
+  removed_nodes_.swap(rhs.removed_nodes_);
+}
+
+ModelRepositoryManager::DependencyNode*
+ModelRepositoryManager::DependencyGraph::GetNode(
+    const ModelIdentifier& model_id) const
+{
+  const auto it = removed_nodes_.find(model_id);
+  if (it != removed_nodes_.end()) {
+    return it->second.get();
+  } else {
+    return FindNode(model_id, false /* allow_fuzzy_matching */);
+  }
+  return nullptr;
 }
 
 std::unique_ptr<ModelIdentifier>
 ModelRepositoryManager::DependencyGraph::LockNodes(
     const std::set<ModelIdentifier>& nodes,
-    const DependencyGraph& prev_dependency_graph,
     std::shared_ptr<std::condition_variable>* retry_notify_cv)
 {
   for (const auto& model_id : nodes) {
-    auto node = FindNode(model_id, false /* allow_fuzzy_matching */);
-    // An affected node can be deleted from this graph, so the presence of the
-    // node must be checked.
-    if (node != nullptr) {
-      // The node is on this graph, check the lock state and then lock.
-      if (node->is_locked_) {
-        if (retry_notify_cv != nullptr) {
-          *retry_notify_cv = node->retry_notify_cv_;
-        }
-        return std::make_unique<ModelIdentifier>(model_id);
+    auto* node = GetNode(model_id);
+    if (node->is_locked_) {
+      if (retry_notify_cv != nullptr) {
+        *retry_notify_cv = node->retry_notify_cv_;
       }
-      node->is_locked_ = true;
-    } else {
-      // The node should be on the previous graph.
-      node = prev_dependency_graph.FindNode(
-          model_id, false /* allow_fuzzy_matching */);
-      if (node != nullptr && node->is_locked_) {
-        if (retry_notify_cv != nullptr) {
-          *retry_notify_cv = node->retry_notify_cv_;
-        }
-        return std::make_unique<ModelIdentifier>(model_id);
-      }
+      return std::make_unique<ModelIdentifier>(model_id);
     }
+    node->is_locked_ = true;
   }
   return std::unique_ptr<ModelIdentifier>(nullptr);
 }
@@ -2136,16 +2138,11 @@ ModelRepositoryManager::DependencyGraph::UnlockNodes(
     const std::set<ModelIdentifier>& nodes)
 {
   for (const auto& model_id : nodes) {
-    auto node = FindNode(model_id, false /* allow_fuzzy_matching */);
-    // An affected node can be deleted from this graph, so the presence of the
-    // node must be checked.
-    // If the node is present, check the lock state and then unlock.
-    if (node != nullptr) {
-      if (!node->is_locked_) {
-        return std::make_unique<ModelIdentifier>(model_id);
-      }
-      node->is_locked_ = false;
+    auto* node = GetNode(model_id);
+    if (!node->is_locked_) {
+      return std::make_unique<ModelIdentifier>(model_id);
     }
+    node->is_locked_ = false;
   }
   return std::unique_ptr<ModelIdentifier>(nullptr);
 }
@@ -2156,20 +2153,17 @@ ModelRepositoryManager::DependencyGraph::Writeback(
     const std::set<ModelIdentifier>& affected_models)
 {
   for (const auto& model_id : affected_models) {
-    // An affected model can be deleted, so the presence of the model must be
-    // checked.
-    auto* updated_node = updated_dependency_graph.FindNode(
-        model_id, false /* allow_fuzzy_matching */);
-    if (updated_node != nullptr) {
-      auto* node = FindNode(model_id, false /* allow_fuzzy_matching */);
-      // Writeback
-      node->status_ = updated_node->status_;
-      node->checked_ = updated_node->checked_;
-      node->loaded_versions_ = updated_node->loaded_versions_;
-      node->is_locked_ = updated_node->is_locked_;
-      // Notify retry(s)
-      node->retry_notify_cv_->notify_all();
-    }
+    auto* node = GetNode(model_id);
+    auto* updated_node = updated_dependency_graph.GetNode(model_id);
+    // Writeback
+    node->status_ = updated_node->status_;
+    node->checked_ = updated_node->checked_;
+    node->loaded_versions_ = updated_node->loaded_versions_;
+    node->is_locked_ = updated_node->is_locked_;
+    // Notify retry(s)
+    node->retry_notify_cv_->notify_all();
+    // Erase removed nodes at last to complete its lifecycle
+    removed_nodes_.erase(model_id);
   }
 }
 

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -265,16 +265,11 @@ class ModelRepositoryManager {
 
     // Set the nodes to lock state. If a node is already locked, then the
     // identifier of the node is returned. Otherwise, nullptr is returned.
-    // The previous dependency graph is for checking if the node is already
-    // locked when it is not found on this dependency graph, as the node could
-    // be deleted on this graph from the previous, and correctly return the
-    // identifier.
-    // The conflict notifier can be provided optionally. If a node is already
+    // The retry notifier can be provided optionally. If a node is already
     // locked, it will be set to a notifier that the calling thread can wait on
     // until notified to retry, to reduce the number of retries.
     std::unique_ptr<ModelIdentifier> LockNodes(
         const std::set<ModelIdentifier>& nodes,
-        const DependencyGraph& prev_dependency_graph,
         std::shared_ptr<std::condition_variable>* retry_notify_cv = nullptr);
 
     // Set the nodes to unlock state. If a node is already unlocked, then the
@@ -306,6 +301,12 @@ class ModelRepositoryManager {
         std::set<ModelIdentifier>* deleted_dependents = nullptr);
 
    private:
+    // Find a node in the dependency graph with the exact matching model
+    // identifier. The disconnected portion of the graph is looked up first, see
+    // 'removed_nodes_'. If not found, then the connected portion of the graph
+    // is looked up, see 'nodes_'. If not found, 'nullptr' is returned.
+    DependencyNode* GetNode(const ModelIdentifier& model_id) const;
+
     // Remove the given set of nodes, return two sets of nodes: The first set
     // contains existing nodes to be re-evaluated, because they depend on
     // the nodes removed; the second set contains all the nodes removed in this
@@ -365,6 +366,11 @@ class ModelRepositoryManager {
     // A list of model names that there are nodes depending on but not present.
     // Note that the key is not ModelIdentifier to allow more flexible matching.
     std::unordered_map<std::string, std::set<ModelIdentifier>> missing_nodes_;
+    // A set of nodes that are disconnected from the graph but not yet
+    // forgotten. Since the nodes are disconnected, their upstream and
+    // downstream pointers are always invalid and must not be used.
+    std::unordered_map<ModelIdentifier, std::unique_ptr<DependencyNode>>
+        removed_nodes_;
   };
 
   ~ModelRepositoryManager();

--- a/src/model_repository_manager.h
+++ b/src/model_repository_manager.h
@@ -174,6 +174,8 @@ class ModelRepositoryManager {
       downstreams_.erase(downstream);
     }
 
+    void Writeback(const DependencyNode& updated_dependency_node);
+
     // Overall status
     Status status_;
 
@@ -304,7 +306,7 @@ class ModelRepositoryManager {
     // Find a node in the dependency graph with the exact matching model
     // identifier. The disconnected portion of the graph is looked up first, see
     // 'removed_nodes_'. If not found, then the connected portion of the graph
-    // is looked up, see 'nodes_'. If not found, 'nullptr' is returned.
+    // is looked up, see 'nodes_'. If not found, an exception is thrown.
     DependencyNode* GetNode(const ModelIdentifier& model_id) const;
 
     // Remove the given set of nodes, return two sets of nodes: The first set


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6436

Previously, the model repository manager stops tracking a model once it is sure that the model will be unloaded. This behavior is problematic with the model lifecycle because it assumes a model cannot be loaded or unloaded concurrently, this guarantee is broken if models are not tracked while they are unloading. For example,
1. A model is unloading by the model lifecycle, while the model repository manager stops tracking it.
2. Without knowing the model is unloading by the model lifecycle, the model repository manager will be happy to load the same model again, while it is unloading by the model lifecycle.
3. The model lifecycle sees the same model has started loading while unloading has not yet completed, it sends an error on the unload process.

After the fix, the model repository manager will track any unloading model until it is unloaded. Thus, the overlapping between unloading and loading the same model on the model lifecycle cannot happen.