### PR TITLE
Use already defined constant for Python related names

### DIFF
--- a/src/backend_manager.cc
+++ b/src/backend_manager.cc
@@ -342,7 +342,7 @@ TritonBackendManager::CreateBackend(
 {
   std::lock_guard<std::mutex> lock(mu_);
 
-  const auto python_based_backend_path = dir + "/model.py";
+  const auto python_based_backend_path = JoinPath({dir, kPythonFilename});
   std::vector<std::string> paths = {libpath, python_based_backend_path};
   for (const auto& path : paths) {
     const auto& itr = backend_map_.find(path);
@@ -386,7 +386,7 @@ TritonBackendManager::BackendState(
   for (const auto& backend_pair : backend_map_) {
     auto& libpath = backend_pair.first;
     auto backend = backend_pair.second;
-    if (backend->Name() == "python") {
+    if (backend->Name() == kPythonBackend) {
       has_python_backend = true;
     }
     const char* backend_config;
@@ -401,7 +401,7 @@ TritonBackendManager::BackendState(
   }
 
   if (!has_python_backend && !python_backend_config.empty()) {
-    backend_state_map->insert({"python", python_backend_config});
+    backend_state_map->insert({kPythonBackend, python_backend_config});
   }
 
   *backend_state = std::move(backend_state_map);

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -131,7 +131,7 @@ TritonModel::Create(
     return Status(
         Status::Code::INVALID_ARG,
         "unable to find '" + backend_libname + "' or '" +
-            specialized_backend_name + "/model.py' for model '" +
+            specialized_backend_name + "/" + kPythonFilename + "' for model '" +
             model_config.name() + "', searched: " + version_path + ", " +
             model_path + ", " + global_path);
   }
@@ -146,8 +146,8 @@ TritonModel::Create(
     is_python_based_backend = true;
     // Python backend based backends use configs, specified for python backend
     // in cmdline.
-    RETURN_IF_ERROR(
-        ResolveBackendConfigs(backend_cmdline_config_map, "python", config));
+    RETURN_IF_ERROR(ResolveBackendConfigs(
+        backend_cmdline_config_map, kPythonBackend, config));
   } else {
     RETURN_IF_ERROR(ResolveBackendConfigs(
         backend_cmdline_config_map, backend_name, config));
@@ -356,7 +356,8 @@ TritonModel::ResolveBackendPaths(
   // If not found, then we are processing a python-based backend.
   // We look for libtriton_python.so in python backend directory
   // and model.py in provided custom backend's directory
-  std::string python_backend_dir = JoinPath({global_backend_dir, "python"});
+  std::string python_backend_dir =
+      JoinPath({global_backend_dir, kPythonBackend});
   bool is_dir;
   RETURN_IF_ERROR(IsDirectory(python_backend_dir, &is_dir));
   if (!is_dir) {
@@ -367,21 +368,21 @@ TritonModel::ResolveBackendPaths(
   }
   search_paths.emplace_back(python_backend_dir);
   std::string runtime_model_path =
-      JoinPath({global_backend_dir, backend_name, "model.py"});
+      JoinPath({global_backend_dir, backend_name, kPythonFilename});
   bool exists;
   RETURN_IF_ERROR(FileExists(runtime_model_path, &exists));
   if (!exists) {
     return Status(
         Status::Code::INVALID_ARG,
-        "unable to find '" + backend_libname + "' or '" + backend_name +
-            "/model.py' for model '" + model_name + "', in " +
+        "unable to find '" + backend_libname + "' or '" + backend_name + "/" +
+            kPythonFilename + "' for model '" + model_name + "', in " +
             JoinPath({global_backend_dir, backend_name}));
   }
 
   *python_runtime_modeldir = JoinPath({global_backend_dir, backend_name});
   std::string python_backend_libname;
   RETURN_IF_ERROR(BackendConfigurationBackendLibraryName(
-      "python", &python_backend_libname));
+      kPythonBackend, &python_backend_libname));
 
   RETURN_IF_ERROR(LocateBackendLibrary(
       search_paths, python_backend_libname, backend_libdir, backend_libpath));

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -883,7 +883,7 @@ LocalizePythonBackendExecutionEnvironmentPath(
     const std::string& model_path, inference::ModelConfig* config,
     std::shared_ptr<LocalizedPath>* localized_model_dir)
 {
-  if (config->backend() == "python") {
+  if (config->backend() == kPythonBackend) {
     if (config->parameters().contains("EXECUTION_ENV_PATH")) {
       // Read EXECUTION_ENV_PATH
       std::string exec_env_path =


### PR DESCRIPTION
This PR unifies the core code to switch from using hardcoded "model.py" and "python" to already defined constant variables `kPythonFilename` and `kPythonBackend`.