### PR TITLE
Allow backends to auto-complete model transaction policy

### DIFF
--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -693,7 +693,6 @@ TritonModel::UpdateModelConfig(
       JsonToModelConfig({buffer, byte_size}, config_version, &updated_config));
   auto config = Config();
   config.set_max_batch_size(updated_config.max_batch_size());
-
   auto inputs_config = config.mutable_input();
   *inputs_config = updated_config.input();
   auto outputs_config = config.mutable_output();
@@ -721,6 +720,12 @@ TritonModel::UpdateModelConfig(
          std::string(" when auto-completing."))
             .c_str());
   }  // else do nothing
+
+  // Update model_transaction_policy if needed
+  if (updated_config.has_model_transaction_policy()) {
+    bool is_decoupled = updated_config.model_transaction_policy().decoupled();
+    config.mutable_model_transaction_policy()->set_decoupled(is_decoupled);
+  }
 
   // Need to normalize the model configuration for
   // populating missing fields.

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -681,6 +681,8 @@ GetNormalizedModelConfig(
                  << config->DebugString();
 
   RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability, config));
+  LOG_VERBOSE(1) << "Core side normalized auto-completed config: "
+                 << config->DebugString();
 
   return Status::Success;
 }

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -681,8 +681,6 @@ GetNormalizedModelConfig(
                  << config->DebugString();
 
   RETURN_IF_ERROR(NormalizeModelConfig(min_compute_capability, config));
-  LOG_VERBOSE(1) << "Core side normalized auto-completed config: "
-                 << config->DebugString();
 
   return Status::Success;
 }


### PR DESCRIPTION
To set model transaction policy from Python backend's autocomple function, I need to add this field on core-side config, when `TritonModel::UpdateModelConfig` is called. `TritonModel::UpdateModelConfig` seem to be called only for `auto_complete` tasks.
