### PR TITLE
Don't allow file override outside of model directory in model load API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,9 @@ endif() # TRITON_ENABLE_GPU
 # Minimum of 1.78 required for use of boost::span. This can eventually be
 # relaxed and replaced with std::span in C++20.
 #
-find_package(Boost 1.78 REQUIRED)
+# boost::filesystem can be replaced with std::filesystem in C++17.
+#
+find_package(Boost 1.78 REQUIRED COMPONENTS filesystem)
 message(STATUS "Using Boost ${Boost_VERSION}")
 
 #
@@ -458,6 +460,7 @@ target_link_libraries(
     triton-common-table-printer      # from repo-common
     protobuf::libprotobuf
     ${RE2_LIBRARY}
+    Boost::filesystem
 )
 
 if (NOT WIN32)

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -129,11 +129,6 @@ class LocalizeRepoAgent : public TritonRepoAgent {
                         .c_str());
               }
 
-
-              // TODO: Remove
-              std::cout << "[DEBUG] dirname: " << dir << std::endl;
-              std::cout << "[DEBUG] weakly_canonical dirname: " << realdir
-                        << std::endl;
               bool dir_exist = false;
               RETURN_TRITONSERVER_ERROR_IF_ERROR(FileExists(dir, &dir_exist));
               if (dir_exist) {

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -118,9 +118,11 @@ class LocalizeRepoAgent : public TritonRepoAgent {
               // Resolve any relative paths or symlinks, and enforce that target
               // directory stays within model directory for security.
               // DLIS-5149: Can use std::filesystem over boost in C++17.
-              const std::string& real_dir =
+              const std::string& canonical_tmp_dir =
+                  boost::filesystem::weakly_canonical(temp_dir).string();
+              const std::string& canonical_override_dir =
                   boost::filesystem::weakly_canonical(dir).string();
-              if (real_dir.rfind(temp_dir, 0) != 0) {
+              if (canonical_override_dir.rfind(canonical_tmp_dir, 0) != 0) {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Invalid file parameter '") + file->Name() +

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -117,11 +117,10 @@ class LocalizeRepoAgent : public TritonRepoAgent {
               const std::string dir = DirName(file_path);
               // Resolve any relative paths or symlinks, and enforce that target
               // directory stays within model directory for security.
-              // NOTE: realpath doesn't support windows, use boost for cross
-              // platform support. Can use std::filesystem over boost in C++17.
-              const std::string realdir =
+              // DLIS-5149: Can use std::filesystem over boost in C++17.
+              const std::string& real_dir =
                   boost::filesystem::weakly_canonical(dir).string();
-              if (realdir.rfind(temp_dir, 0) != 0) {
+              if (real_dir.rfind(temp_dir, 0) != 0) {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Invalid file parameter '") + file->Name() +

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -111,25 +111,27 @@ class LocalizeRepoAgent : public TritonRepoAgent {
                      "' must have bytes type for its value")
                         .c_str());
               }
-              // Save model override file to the instructed directory using the
-              // temporary model directory as the basepath.
-              const std::string file_path =
-                  JoinPath({temp_dir, file->Name().substr(file_prefix.size())});
+
               // Resolve any relative paths or symlinks, and enforce that target
               // directory stays within model directory for security.
               // DLIS-5149: Can use std::filesystem over boost in C++17.
-              const std::string dir =
-                  boost::filesystem::weakly_canonical(DirName(file_path))
+              const std::string file_path =
+                  boost::filesystem::weakly_canonical(
+                      JoinPath(
+                          {temp_dir, file->Name().substr(file_prefix.size())}))
                       .string();
-              if (dir.rfind(temp_dir, 0) != 0) {
+              if (file_path.rfind(temp_dir, 0) != 0) {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Invalid file parameter '") + file->Name() +
-                     "' with normalized dir '" + dir +
+                     "' with normalized path '" + file_path +
                      "' must stay within model directory.")
                         .c_str());
               }
 
+              // Save model override file to the instructed directory using the
+              // temporary model directory as the basepath.
+              const std::string dir = DirName(file_path);
               bool dir_exist = false;
               RETURN_TRITONSERVER_ERROR_IF_ERROR(FileExists(dir, &dir_exist));
               if (dir_exist) {


### PR DESCRIPTION
Server/test PR: https://github.com/triton-inference-server/server/pull/6516

```
E1107 03:19:14.402174 16541 model_repository_manager.cc:1323] Poll failed for model directory 'new_model': Invalid file parameter 'file:../../root/new_dir/test.txt' with normalized dir '/root/new_dir' must stay within model directory.
E1107 03:19:14.403816 16541 model_repository_manager.cc:1323] Poll failed for model directory 'new_model': Invalid file parameter 'file:../escape_symlink/new_dir/test.txt' with normalized dir '/root/new_dir' must stay within model directory.
E1107 03:19:14.405993 16541 model_repository_manager.cc:1323] Poll failed for model directory 'new_model': Invalid file parameter 'file:../../root/.bashrc' with normalized dir '/root' must stay within model directory.
E1107 03:19:14.408064 16541 model_repository_manager.cc:1323] Poll failed for model directory 'new_model': Invalid file parameter 'file:../escape_symlink/.bashrc' with normalized dir '/root' must stay within model directory.
```



:warning: **boost::filesystem dependency**

NOTE: `boost::filesystem::weakly_canonical` is used to get an "absolute/normalized" path for a path that **may not yet exist**, and **is cross-platform**. This is available in C++17, but to avoid risk of upgrading C++ version right before code freeze, I'd like to temporarily introduce the boost dependency. After code freeze, I would like to push the C++17 upgrade that @oandreeva-nv started through and then replace this usage with built-in `std:filesystem` instead.

Some other notes on alternatives:
- `realpath` (unix-only) does not support paths that don't yet exist, and may require more complex logic to write by hand. 
- [PathCanonicalize](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathcanonicalizea) is a Windows specific version of something similar to `realpath` that may work if there are any windows issues with boost that take too long to resolve.