### PR TITLE
Fix the pending_request_count to release the failed requests

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -393,7 +393,13 @@ Status
 InferenceRequest::Run(std::unique_ptr<InferenceRequest>& request)
 {
   RETURN_IF_ERROR(request->SetState(InferenceRequest::State::PENDING));
-  return request->model_raw_->Enqueue(request);
+  auto status = request->model_raw_->Enqueue(request);
+  if (!status.IsOk()) {
+    LOG_STATUS_ERROR(
+      request->SetState(InferenceRequest::State::RELEASED),
+      "Failed to set released state");
+  }
+  return status;
 }
 
 void

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -396,8 +396,8 @@ InferenceRequest::Run(std::unique_ptr<InferenceRequest>& request)
   auto status = request->model_raw_->Enqueue(request);
   if (!status.IsOk()) {
     LOG_STATUS_ERROR(
-      request->SetState(InferenceRequest::State::RELEASED),
-      "Failed to set released state");
+        request->SetState(InferenceRequest::State::RELEASED),
+        "Failed to set released state");
   }
   return status;
 }

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -157,9 +157,11 @@ InferenceRequest::SetState(InferenceRequest::State new_state)
     }
     case InferenceRequest::State::PENDING: {
       // Request may move from pending to either execution when scheduled to
-      // backend, or released early due to some error.
+      // backend, released early due to some error or failure was encountered
+      // when calling enqueue.
       if (new_state == InferenceRequest::State::EXECUTING ||
-          new_state == InferenceRequest::State::RELEASED) {
+          new_state == InferenceRequest::State::RELEASED ||
+          new_state == InferenceRequest::State::FAILED_ENQUEUE) {
         DecrementPendingRequestCount();
       } else {
         // Unexpected state transition
@@ -177,6 +179,15 @@ InferenceRequest::SetState(InferenceRequest::State new_state)
       if (new_state != InferenceRequest::State::INITIALIZED) {
         // Only transition currently supported after release is to start over
         // again, such as re-using request objects for multiple inferences.
+        return generate_error();
+      }
+      break;
+    }
+    case InferenceRequest::State::FAILED_ENQUEUE: {
+      if (new_state != InferenceRequest::State::INITIALIZED) {
+        // Only transition currently supported after failed to enqueue is to
+        // start over again, such as re-using request objects for multiple
+        // inferences.
         return generate_error();
       }
       break;
@@ -396,8 +407,8 @@ InferenceRequest::Run(std::unique_ptr<InferenceRequest>& request)
   auto status = request->model_raw_->Enqueue(request);
   if (!status.IsOk()) {
     LOG_STATUS_ERROR(
-        request->SetState(InferenceRequest::State::RELEASED),
-        "Failed to set released state");
+        request->SetState(InferenceRequest::State::FAILED_ENQUEUE),
+        "Failed to set failed_enqueue state");
   }
   return status;
 }

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -65,8 +65,11 @@ class InferenceRequest {
     // The request has been initialized, but not yet enqueued.
     INITIALIZED,
 
-    // The request has been enqueued, but is not yet executing.
+    // The request is pending execution.
     PENDING,
+
+    // The request failed to enqueue.
+    FAILED_ENQUEUE,
 
     // The request has been picked up by a backend model instance for execution,
     // but hasn't been released yet.


### PR DESCRIPTION
### Before

After sending a 136 requests that will fail in Enqueue:

```
curl -s localhost:8002/metrics | grep pending
# HELP nv_inference_pending_request_count Instantaneous number of pending requests awaiting execution per-model.
# TYPE nv_inference_pending_request_count gauge
nv_inference_pending_request_count{model="test_model",version="1"} 136
```

### After fix

After sending a 136 requests that will fail in Enqueue:

```
curl -s localhost:8002/metrics | grep pending
# HELP nv_inference_pending_request_count Instantaneous number of pending requests awaiting execution per-model.
# TYPE nv_inference_pending_request_count gauge
nv_inference_pending_request_count{model="test_model",version="1"} 0
```

I couldn't find any tests for nv_inference_pending_request_count metrics. Need to add testing of these features to avoid regression. Will open another ticket to enhance the testing.

