### PR TITLE
Resolve thread contention when waiting for instance slot

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -365,9 +365,9 @@ DynamicBatchScheduler::BatcherThread(const int nice)
           // outer lock to allow Enqueue threads above to make progress.
           lock.unlock();
           // Use slot lock to wait for the slot availability.
-          std::unique_lock<std::mutex> slot_lock(slot_mu_);
+          std::mutex slot_mu;
+          std::unique_lock<std::mutex> slot_lock(slot_mu);
           cv_.wait(slot_lock, wait_for_slots);
-
           // Recapture the outer most lock to keep making progress.
           lock.lock();
         }

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -358,7 +358,20 @@ DynamicBatchScheduler::BatcherThread(const int nice)
         if (payload_saturated_) {
           continue;
         }
-        cv_.wait(lock, wait_for_slots);
+
+        {
+          // The wait_for_slots conditional can be blocking till the slots
+          // are available for execution. Need to explicitly release the
+          // outer lock to allow Enqueue threads above to make progress.
+          lock.unlock();
+          // Use slot lock to wait for the slot availability.
+          std::unique_lock<std::mutex> slot_lock(slot_mu_);
+          cv_.wait(slot_lock, wait_for_slots);
+
+          // Recapture the outer most lock to keep making progress.
+          lock.lock();
+        }
+
         {
           std::lock_guard<std::mutex> exec_lock(
               *(curr_payload_->GetExecMutex()));

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -142,7 +142,6 @@ class DynamicBatchScheduler : public Scheduler {
 
   // Mutex and condvar for signaling scheduler thread
   std::mutex mu_;
-  std::mutex slot_mu_;
   std::condition_variable cv_;
 
   std::shared_ptr<RateLimiter> rate_limiter_;

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -142,6 +142,7 @@ class DynamicBatchScheduler : public Scheduler {
 
   // Mutex and condvar for signaling scheduler thread
   std::mutex mu_;
+  std::mutex slot_mu_;
   std::condition_variable cv_;
 
   std::shared_ptr<RateLimiter> rate_limiter_;


### PR DESCRIPTION
Before this change the mu_ may be held by the batcher thread while waiting for instance consumer to be available. This would cause the handler thread calling Enqueue on the model to block as well cascading the response back to the user. 

Follow-up item is to enhance the stress tests to these special cases. 
