### PR TITLE
nnshah1 suggestion

### DIFF
--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -115,13 +115,11 @@ class LocalizeRepoAgent : public TritonRepoAgent {
               // Resolve any relative paths or symlinks, and enforce that target
               // directory stays within model directory for security.
               // DLIS-5149: Can use std::filesystem over boost in C++17.
-
               const std::string file_path =
                   boost::filesystem::weakly_canonical(
                       JoinPath(
                           {temp_dir, file->Name().substr(file_prefix.size())}))
                       .string();
-
               if (file_path.rfind(temp_dir, 0) != 0) {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
@@ -133,9 +131,7 @@ class LocalizeRepoAgent : public TritonRepoAgent {
 
               // Save model override file to the instructed directory using the
               // temporary model directory as the basepath.
-
               const std::string dir = DirName(file_path);
-
               bool dir_exist = false;
               RETURN_TRITONSERVER_ERROR_IF_ERROR(FileExists(dir, &dir_exist));
               if (dir_exist) {

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -124,7 +124,7 @@ class LocalizeRepoAgent : public TritonRepoAgent {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Invalid file parameter '") + file->Name() +
-                     "' with normalized dir '" + dir +
+                     "' with normalized path '" + file_path +
                      "' must stay within model directory.")
                         .c_str());
               }

--- a/src/model_repository_manager.cc
+++ b/src/model_repository_manager.cc
@@ -111,17 +111,18 @@ class LocalizeRepoAgent : public TritonRepoAgent {
                      "' must have bytes type for its value")
                         .c_str());
               }
-              // Save model override file to the instructed directory using the
-              // temporary model directory as the basepath.
-              const std::string file_path =
-                  JoinPath({temp_dir, file->Name().substr(file_prefix.size())});
+
               // Resolve any relative paths or symlinks, and enforce that target
               // directory stays within model directory for security.
               // DLIS-5149: Can use std::filesystem over boost in C++17.
-              const std::string dir =
-                  boost::filesystem::weakly_canonical(DirName(file_path))
+
+              const std::string file_path =
+                  boost::filesystem::weakly_canonical(
+                      JoinPath(
+                          {temp_dir, file->Name().substr(file_prefix.size())}))
                       .string();
-              if (dir.rfind(temp_dir, 0) != 0) {
+
+              if (file_path.rfind(temp_dir, 0) != 0) {
                 return TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Invalid file parameter '") + file->Name() +
@@ -129,6 +130,11 @@ class LocalizeRepoAgent : public TritonRepoAgent {
                      "' must stay within model directory.")
                         .c_str());
               }
+
+              // Save model override file to the instructed directory using the
+              // temporary model directory as the basepath.
+
+              const std::string dir = DirName(file_path);
 
               bool dir_exist = false;
               RETURN_TRITONSERVER_ERROR_IF_ERROR(FileExists(dir, &dir_exist));


### PR DESCRIPTION
In our conversation I realized that the path we write to is not the one we cananocalize. While not a high priority - I think we want to normalize the file path, check it, and then write to that same file path - just for consistency.

A future consideration: we can add checking to JoinPath(root, leaf) to:

1) return full absolute path
2) optional error if leaf exits the roof 

This would help in any place we use Join to put paths together that may escape their intended location.