### PR TITLE
Use current time when overwriting model configuration.

### DIFF
--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -1414,7 +1414,11 @@ ModelRepositoryManager::InitializeModelInfo(
       // When override happens, set 'mtime_nsec_' to minimum value so that
       // the next load without override will trigger re-load to undo
       // the override while the local files may still be unchanged.
-      linfo->mtime_nsec_ = std::make_pair(0, 0);
+      auto time_since_epoch =
+          std::chrono::system_clock::now().time_since_epoch();
+      linfo->mtime_nsec_.first =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch)
+              .count();
       unmodified = false;
 
       const std::string& override_config = override_parameter->ValueString();


### PR DESCRIPTION
This change changes the way `model_repository_manager` tracks when a model's configuration was last updated. Instead of setting the tracked mtime to zero, the current system time is used. This means that in order to reload the local configuration file, a user will need to "touch" the config.pbtxt file such that its mtime is greater than the mtime recorded when overwriting the model's configuration values and then reload the model.

[MR w/ test code](https://github.com/triton-inference-server/server/pull/6727)
