### PR TITLE
Better error handling for invalid model repository

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -24,11 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import asyncio
 import json
 import os
-import queue
-import time
 import unittest
 
 import numpy
@@ -386,3 +383,7 @@ class InferenceTests(unittest.TestCase):
             numpy.testing.assert_array_equal(fp16_input, fp16_output)
 
         server.stop()
+
+    def test_model_repository_not_specified(self):
+        with self.assertRaises(tritonserver.InvalidArgumentError):
+            tritonserver.Server(model_repository=None)

--- a/python/tritonserver/_api/_server.py
+++ b/python/tritonserver/_api/_server.py
@@ -526,6 +526,8 @@ class Server:
         if options is None:
             options = Options(**kwargs)
         self.options: Options = options
+        if self.options.model_repository is None:
+            raise InvalidArgumentError("Model repository must be specified.")
         self._server = Server._UnstartedServer()
 
     def start(


### PR DESCRIPTION
Before:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/tritonserver/_api/_server.py", line 582, in start
    self.options._create_tritonserver_server_options()
  File "/usr/local/lib/python3.10/dist-packages/tritonserver/_api/_server.py", line 349, in _create_tritonserver_server_options
    options.set_model_repository_path(model_repository_path)
TypeError: set_model_repository_path(): incompatible function arguments. The following argument types are supported:
    1. (self: tritonserver._c.triton_bindings.TRITONSERVER_ServerOptions, arg0: str) -> None

Invoked with: <tritonserver._c.triton_bindings.TRITONSERVER_ServerOptions object at 0x7f78b4583e70>, None
```
After:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/dist-packages/tritonserver/_api/_server.py", line 530, in __init__
    raise InvalidArgumentError("Model repository must be specified.")
tritonserver.InvalidArgumentError: Model repository must be specified.
```