### PR TITLE
Moving model repo None check to align with other checks

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -376,6 +376,10 @@ class ServerTests(unittest.TestCase):
 
         server.stop()
 
+    def test_model_repository_not_specified(self):
+        with self.assertRaises(tritonserver.InvalidArgumentError):
+            tritonserver.Server(model_repository=None).start()
+
 
 class InferenceTests(unittest.TestCase):
     def setup_method(self, method):
@@ -452,7 +456,3 @@ class InferenceTests(unittest.TestCase):
         ):
             fp16_output = numpy.from_dlpack(response.outputs["fp16_output"])
             numpy.testing.assert_array_equal(fp16_input, fp16_output)
-
-    def test_model_repository_not_specified(self):
-        with self.assertRaises(tritonserver.InvalidArgumentError):
-            tritonserver.Server(model_repository=None)

--- a/python/tritonserver/_api/_server.py
+++ b/python/tritonserver/_api/_server.py
@@ -343,6 +343,8 @@ class Options:
 
         options.set_server_id(self.server_id)
 
+        if self.model_repository is None:
+            raise InvalidArgumentError("Model repository must be specified.")
         if not isinstance(self.model_repository, list):
             self.model_repository = [self.model_repository]
         for model_repository_path in self.model_repository:
@@ -526,8 +528,6 @@ class Server:
         if options is None:
             options = Options(**kwargs)
         self.options: Options = options
-        if self.options.model_repository is None:
-            raise InvalidArgumentError("Model repository must be specified.")
         self._server = Server._UnstartedServer()
 
     def start(


### PR DESCRIPTION
Currently all errors on options are thrown at server.start() - moved the check and exception to align with that and moved test to server section. 