### PR TITLE
Server stop will wait until all background models are unloaded

### DIFF
--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -259,6 +259,14 @@ ModelLifeCycle::InflightStatus()
   return inflight_status;
 }
 
+size_t
+ModelLifeCycle::BackgroundModelsSize()
+{
+  LOG_VERBOSE(2) << "BackgroundModelsSize()";
+  std::lock_guard<std::mutex> map_lock(map_mtx_);
+  return background_models_.size();
+}
+
 const ModelStateMap
 ModelLifeCycle::ModelStates()
 {

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -221,6 +221,9 @@ class ModelLifeCycle {
   // that don't have in-flight inferences will not be included.
   const std::set<std::tuple<ModelIdentifier, int64_t, size_t>> InflightStatus();
 
+  // Return the number of model(s) in the background.
+  size_t BackgroundModelsSize();
+
  private:
   struct ModelInfo {
     ModelInfo(

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -957,15 +957,44 @@ ModelRepositoryManager::PollModels(
 Status
 ModelRepositoryManager::UnloadAllModels()
 {
-  Status status;
-  for (const auto& name_info : infos_) {
-    Status unload_status = model_life_cycle_->AsyncUnload(name_info.first);
-    if (!unload_status.IsOk()) {
-      status = Status(
-          unload_status.ErrorCode(),
-          "Failed to gracefully unload models: " + unload_status.Message());
+  std::unique_lock<std::mutex> lock(mu_);
+
+  // Get a set of all models, and make sure non of them are loading/unloading.
+  std::set<ModelIdentifier> all_models;
+  bool all_models_locked = false;
+  while (!all_models_locked) {
+    // Make a copy of the dependency graph.
+    std::unordered_map<std::string, std::set<ModelIdentifier>> global_map(
+        global_map_);
+    DependencyGraph dependency_graph(dependency_graph_, &global_map);
+    // Try to lock all models.
+    all_models = infos_.GetModelIdentifiers();
+    std::shared_ptr<std::condition_variable> retry_notify_cv;
+    auto conflict_model =
+        dependency_graph.LockNodes(all_models, &retry_notify_cv);
+    if (conflict_model) {
+      LOG_VERBOSE(2) << "Unload all models conflict '" << conflict_model->str()
+                     << "'";
+      // A model is loading/unloading. Wait for it to complete.
+      retry_notify_cv->wait(lock);
+      // There could be changes to other models as well. The dependency graph
+      // and models has to be reloaded.
+      continue;
+    }
+    all_models_locked = true;
+  }
+
+  // Unload all models.
+  for (const auto& model_id : all_models) {
+    Status status = model_life_cycle_->AsyncUnload(model_id);
+    if (!status.IsOk()) {
+      // The server is shutting down. There is nothing to do about the error but
+      // to move forward.
+      LOG_ERROR << "Unload all models failed on '" << model_id << "'; "
+                << status.Message();
     }
   }
+
   return Status::Success;
 }
 
@@ -2212,6 +2241,16 @@ ModelRepositoryManager::ModelInfoMap::operator=(const ModelInfoMap& rhs)
   ModelInfoMap tmp(rhs);
   Swap(tmp);
   return *this;
+}
+
+std::set<ModelIdentifier>
+ModelRepositoryManager::ModelInfoMap::GetModelIdentifiers()
+{
+  std::set<ModelIdentifier> model_ids;
+  for (const auto& pair : map_) {
+    model_ids.emplace(pair.first);
+  }
+  return model_ids;
 }
 
 void

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -957,44 +957,15 @@ ModelRepositoryManager::PollModels(
 Status
 ModelRepositoryManager::UnloadAllModels()
 {
-  std::unique_lock<std::mutex> lock(mu_);
-
-  // Get a set of all models, and make sure non of them are loading/unloading.
-  std::set<ModelIdentifier> all_models;
-  bool all_models_locked = false;
-  while (!all_models_locked) {
-    // Make a copy of the dependency graph.
-    std::unordered_map<std::string, std::set<ModelIdentifier>> global_map(
-        global_map_);
-    DependencyGraph dependency_graph(dependency_graph_, &global_map);
-    // Try to lock all models.
-    all_models = infos_.GetModelIdentifiers();
-    std::shared_ptr<std::condition_variable> retry_notify_cv;
-    auto conflict_model =
-        dependency_graph.LockNodes(all_models, &retry_notify_cv);
-    if (conflict_model) {
-      LOG_VERBOSE(2) << "Unload all models conflict '" << conflict_model->str()
-                     << "'";
-      // A model is loading/unloading. Wait for it to complete.
-      retry_notify_cv->wait(lock);
-      // There could be changes to other models as well. The dependency graph
-      // and models has to be reloaded.
-      continue;
-    }
-    all_models_locked = true;
-  }
-
-  // Unload all models.
-  for (const auto& model_id : all_models) {
-    Status status = model_life_cycle_->AsyncUnload(model_id);
-    if (!status.IsOk()) {
-      // The server is shutting down. There is nothing to do about the error but
-      // to move forward.
-      LOG_ERROR << "Unload all models failed on '" << model_id << "'; "
-                << status.Message();
+  Status status;
+  for (const auto& name_info : infos_) {
+    Status unload_status = model_life_cycle_->AsyncUnload(name_info.first);
+    if (!unload_status.IsOk()) {
+      status = Status(
+          unload_status.ErrorCode(),
+          "Failed to gracefully unload models: " + unload_status.Message());
     }
   }
-
   return Status::Success;
 }
 
@@ -2241,16 +2212,6 @@ ModelRepositoryManager::ModelInfoMap::operator=(const ModelInfoMap& rhs)
   ModelInfoMap tmp(rhs);
   Swap(tmp);
   return *this;
-}
-
-std::set<ModelIdentifier>
-ModelRepositoryManager::ModelInfoMap::GetModelIdentifiers()
-{
-  std::set<ModelIdentifier> model_ids;
-  for (const auto& pair : map_) {
-    model_ids.emplace(pair.first);
-  }
-  return model_ids;
 }
 
 void

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -981,6 +981,12 @@ ModelRepositoryManager::InflightStatus()
   return model_life_cycle_->InflightStatus();
 }
 
+size_t
+ModelRepositoryManager::BackgroundModelsSize()
+{
+  return model_life_cycle_->BackgroundModelsSize();
+}
+
 const ModelStateMap
 ModelRepositoryManager::LiveModelStates(bool strict_readiness)
 {

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -146,6 +146,9 @@ class ModelRepositoryManager {
       return map_.find(key);
     }
 
+    // Return all keys on the map as a set.
+    std::set<ModelIdentifier> GetModelIdentifiers();
+
     // Write updated model info back to this object after model load/unload.
     void Writeback(
         const ModelInfoMap& updated_model_info,

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -146,9 +146,6 @@ class ModelRepositoryManager {
       return map_.find(key);
     }
 
-    // Return all keys on the map as a set.
-    std::set<ModelIdentifier> GetModelIdentifiers();
-
     // Write updated model info back to this object after model load/unload.
     void Writeback(
         const ModelInfoMap& updated_model_info,

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -438,6 +438,9 @@ class ModelRepositoryManager {
   /// if it doesn't have in-flight inferences.
   const std::set<std::tuple<ModelIdentifier, int64_t, size_t>> InflightStatus();
 
+  /// \return the number of model(s) in the background.
+  size_t BackgroundModelsSize();
+
   /// \param strict_readiness If true, only models that have at least one
   /// ready version will be considered as live. Otherwise, the models that
   /// have loading / unloading versions will also be live.

--- a/src/server.cc
+++ b/src/server.cc
@@ -341,6 +341,7 @@ InferenceServer::Stop(const bool force)
       }
     } else {
       const auto& live_models = model_repository_manager_->LiveModelStates();
+      size_t bg_models_size = model_repository_manager_->BackgroundModelsSize();
 
       LOG_INFO << "Timeout " << exit_timeout_iters << ": Found "
                << live_models.size() << " live models and "
@@ -355,7 +356,8 @@ InferenceServer::Stop(const bool force)
         }
       }
 
-      if ((live_models.size() == 0) && (inflight_request_counter_ == 0)) {
+      if ((live_models.size() == 0) && (bg_models_size == 0) &&
+          (inflight_request_counter_ == 0)) {
         return Status::Success;
       }
     }

--- a/src/server.cc
+++ b/src/server.cc
@@ -342,10 +342,10 @@ InferenceServer::Stop(const bool force)
     } else {
       const auto& live_models = model_repository_manager_->LiveModelStates();
       size_t bg_models_size = model_repository_manager_->BackgroundModelsSize();
+      size_t num_models = live_models.size() + bg_models_size;
 
-      LOG_INFO << "Timeout " << exit_timeout_iters << ": Found "
-               << live_models.size() << " live models and "
-               << inflight_request_counter_
+      LOG_INFO << "Timeout " << exit_timeout_iters << ": Found " << num_models
+               << " live models and " << inflight_request_counter_
                << " in-flight non-inference requests";
       if (LOG_VERBOSE_IS_ON(1)) {
         for (const auto& m : live_models) {
@@ -356,8 +356,7 @@ InferenceServer::Stop(const bool force)
         }
       }
 
-      if ((live_models.size() == 0) && (bg_models_size == 0) &&
-          (inflight_request_counter_ == 0)) {
+      if ((num_models == 0) && (inflight_request_counter_ == 0)) {
         return Status::Success;
       }
     }


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6835

When the server is stopping, it will now check the background for any model(s) that are loading/unloading. If there are models in transition in the background, the server will wait until all transitions have completed before commencing the shutdown.