### PR TITLE
Server stop will wait until all loading models to complete before unload all models

### DIFF
--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -957,15 +957,44 @@ ModelRepositoryManager::PollModels(
 Status
 ModelRepositoryManager::UnloadAllModels()
 {
-  Status status;
-  for (const auto& name_info : infos_) {
-    Status unload_status = model_life_cycle_->AsyncUnload(name_info.first);
-    if (!unload_status.IsOk()) {
-      status = Status(
-          unload_status.ErrorCode(),
-          "Failed to gracefully unload models: " + unload_status.Message());
+  std::unique_lock<std::mutex> lock(mu_);
+
+  // Get a set of all models, and make sure non of them are loading/unloading.
+  std::set<ModelIdentifier> all_models;
+  bool all_models_locked = false;
+  while (!all_models_locked) {
+    // Make a copy of the dependency graph.
+    std::unordered_map<std::string, std::set<ModelIdentifier>> global_map(
+        global_map_);
+    DependencyGraph dependency_graph(dependency_graph_, &global_map);
+    // Try to lock all models.
+    all_models = infos_.GetModelIdentifiers();
+    std::shared_ptr<std::condition_variable> retry_notify_cv;
+    auto conflict_model =
+        dependency_graph.LockNodes(all_models, &retry_notify_cv);
+    if (conflict_model) {
+      LOG_VERBOSE(2) << "Unload all models conflict '" << conflict_model->str()
+                     << "'";
+      // A model is loading/unloading. Wait for it to complete.
+      retry_notify_cv->wait(lock);
+      // There could be changes to other models as well. The dependency graph
+      // and models has to be reloaded.
+      continue;
+    }
+    all_models_locked = true;
+  }
+
+  // Unload all models.
+  for (const auto& model_id : all_models) {
+    Status status = model_life_cycle_->AsyncUnload(model_id);
+    if (!status.IsOk()) {
+      // The server is shutting down. There is nothing to do about the error but
+      // to move forward.
+      LOG_ERROR << "Unload all models failed on '" << model_id << "'; "
+                << status.Message();
     }
   }
+
   return Status::Success;
 }
 
@@ -2218,6 +2247,16 @@ ModelRepositoryManager::ModelInfoMap::operator=(const ModelInfoMap& rhs)
   ModelInfoMap tmp(rhs);
   Swap(tmp);
   return *this;
+}
+
+std::set<ModelIdentifier>
+ModelRepositoryManager::ModelInfoMap::GetModelIdentifiers()
+{
+  std::set<ModelIdentifier> model_ids;
+  for (const auto& pair : map_) {
+    model_ids.emplace(pair.first);
+  }
+  return model_ids;
 }
 
 void

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -1832,11 +1832,13 @@ ModelRepositoryManager::DependencyGraph::RemoveNodes(
       }
 
       all_removed_nodes.emplace(model_id);
-      // Exclude removed node from affected nodes to skip some evaluations.
-      all_affected_nodes.erase(model_id);
     }
 
     curr_removal.swap(next_removal);
+  }
+  // Exclude removed nodes from affected nodes.
+  for (const auto& removed_node : all_removed_nodes) {
+    all_affected_nodes.erase(removed_node);
   }
   return {std::move(all_affected_nodes), std::move(all_removed_nodes)};
 }

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -957,27 +957,21 @@ ModelRepositoryManager::PollModels(
 Status
 ModelRepositoryManager::UnloadAllModels()
 {
-  bool polled, no_parallel_conflict;
-  do {
-    // Find all the models to be unloaded.
-    std::unordered_map<std::string, std::vector<const InferenceParameter*>>
-        models;
-    {
-      std::lock_guard<std::mutex> lock(mu_);
-      for (const auto& pair : infos_) {
-        // Only the model name is needed.
-        models[pair.first.name_];
-      }
+  // Find all the models to be unloaded.
+  std::unordered_map<std::string, std::vector<const InferenceParameter*>>
+      models;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    for (const auto& pair : infos_) {
+      // Only the model name is needed.
+      models[pair.first.name_];
     }
-    // Unload all models found. If 'no_parallel_conflict' is false, then at
-    // least one model was loading or unloading, which the function will be a
-    // no-op and block until the loading or unloading is completed.
-    RETURN_IF_ERROR(LoadUnloadModels(
-        models, ActionType::UNLOAD, true /* unload_dependents */, &polled,
-        &no_parallel_conflict));
-  } while (!no_parallel_conflict);
-
-  return Status::Success;
+  }
+  // Unload all models found.
+  bool polled;
+  return LoadUnloadModels(
+      models, ActionType::UNLOAD, true /* unload_dependents */, &polled,
+      nullptr /* no_parallel_conflict */);
 }
 
 Status

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -146,6 +146,9 @@ class ModelRepositoryManager {
       return map_.find(key);
     }
 
+    // Return all keys on the map as a set.
+    std::set<ModelIdentifier> GetModelIdentifiers();
+
     // Write updated model info back to this object after model load/unload.
     void Writeback(
         const ModelInfoMap& updated_model_info,

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -146,9 +146,6 @@ class ModelRepositoryManager {
       return map_.find(key);
     }
 
-    // Return all keys on the map as a set.
-    std::set<ModelIdentifier> GetModelIdentifiers();
-
     // Write updated model info back to this object after model load/unload.
     void Writeback(
         const ModelInfoMap& updated_model_info,
@@ -424,8 +421,9 @@ class ModelRepositoryManager {
           std::string, std::vector<const InferenceParameter*>>& models,
       const ActionType type, const bool unload_dependents);
 
-  /// Unload all models. This function should be called before shutting down
-  /// the model repository manager.
+  /// Unload all models that are tracked by the model repository manager. New
+  /// models may be loaded while this function is unloading. This function
+  /// should be called before shutting down the model repository manager.
   /// \return error status.
   Status UnloadAllModels();
 

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -421,9 +421,11 @@ class ModelRepositoryManager {
           std::string, std::vector<const InferenceParameter*>>& models,
       const ActionType type, const bool unload_dependents);
 
-  /// Unload all models that are tracked by the model repository manager. New
-  /// models may be loaded while this function is unloading. This function
-  /// should be called before shutting down the model repository manager.
+  /// Unload all models that are tracked by the model repository manager. If a
+  /// model is loading or unloading when this function is called, or a model
+  /// failed to unload, an error is returned. New models may be loaded while
+  /// this function is unloading models. This function should be called before
+  /// shutting down the model repository manager.
   /// \return error status.
   Status UnloadAllModels();
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -330,11 +330,11 @@ InferenceServer::Stop(const bool force)
       }
 
       if (inflight_status.size() == 0) {
-        unloading_model = true;
         status = model_repository_manager_->UnloadAllModels();
         if (!status.IsOk()) {
-          LOG_ERROR << status.Message();
+          LOG_WARNING << status.Message();
         } else {
+          unloading_model = true;
           LOG_INFO << "All models are stopped, unloading models";
           continue;
         }


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6837

When the server is stopping and trying to unload all models, the unload all models will wait until all models are no longer in transition (i.e. loading/unloading) before starting the unload.