### PR TITLE
Add response statistics

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1337,16 +1337,16 @@ TRITONBACKEND_ModelInstanceReportMemoryUsage(
 /// TRITONBACKEND_ModelInstanceExecute.
 ///
 ///   TRITONBACKEND_ModelInstanceExecute()
-///     CAPTURE TIMESPACE (exec_start_ns)
+///     CAPTURE TIMESTAMP (exec_start_ns)
 ///     < process input tensors to prepare them for inference
 ///       execution, including copying the tensors to/from GPU if
 ///       necessary>
-///     CAPTURE TIMESPACE (compute_start_ns)
+///     CAPTURE TIMESTAMP (compute_start_ns)
 ///     < perform inference computations to produce outputs >
-///     CAPTURE TIMESPACE (compute_end_ns)
+///     CAPTURE TIMESTAMP (compute_end_ns)
 ///     < allocate output buffers and extract output tensors, including
 ///       copying the tensors to/from GPU if necessary>
-///     CAPTURE TIMESPACE (exec_end_ns)
+///     CAPTURE TIMESTAMP (exec_end_ns)
 ///     return
 ///
 /// Note that these statistics are associated with a valid
@@ -1385,12 +1385,12 @@ TRITONBACKEND_ModelInstanceReportStatistics(
 ///
 ///   TRITONBACKEND_ModelInstanceExecute()
 ///     < start of this response >
-///     CAPTURE TIMESPACE (response_start)
+///     CAPTURE TIMESTAMP (response_start)
 ///     < generate this response >
-///     CAPTURE TIMESPACE (compute_output_start)
+///     CAPTURE TIMESTAMP (compute_output_start)
 ///     < allocate output buffers and extract output tensors, including copying
 ///       the tensors to/from GPU if necessary >
-///     CAPTURE TIMESPACE (response_end)
+///     CAPTURE TIMESTAMP (response_end)
 ///     < end of this response >
 ///     return
 ///

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -94,7 +94,7 @@ struct TRITONBACKEND_Batcher;
 ///   }
 ///
 #define TRITONBACKEND_API_VERSION_MAJOR 1
-#define TRITONBACKEND_API_VERSION_MINOR 18
+#define TRITONBACKEND_API_VERSION_MINOR 19
 
 /// Get the TRITONBACKEND API version supported by Triton. This value
 /// can be compared against the TRITONBACKEND_API_VERSION_MAJOR and

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1389,9 +1389,9 @@ TRITONBACKEND_ModelInstanceReportStatistics(
 /// \param response_end Timestamp for the end of extracting output tensors for
 /// this response.
 /// \param send_flags Flags associated with the response. \see
-/// TRITONBACKEND_ResponseSend \see
+/// TRITONBACKEND_ResponseSend
 /// \param error The TRITONSERVER_Error to send if the response is an error, or
-/// nullptr if the response is successful. \see TRITONBACKEND_ResponseSend \see
+/// nullptr if the response is successful. \see TRITONBACKEND_ResponseSend
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceReportResponseStatistics(

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1358,7 +1358,7 @@ TRITONBACKEND_ModelInstanceReportStatistics(
     const uint64_t compute_start_ns, const uint64_t compute_end_ns,
     const uint64_t exec_end_ns);
 
-/// Create a new decoupled inference response statistics object.
+/// Create a new inference response statistics object.
 ///
 /// \param response_statistics The new response statistics object to be created.
 /// \return a TRITONSERVER_Error indicating success or failure.
@@ -1366,7 +1366,7 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceResponseStatisticsNew(
     TRITONBACKEND_ModelInstanceResponseStatistics** response_statistics);
 
-/// Delete a decoupled inference response statistics object.
+/// Delete an inference response statistics object.
 ///
 /// The caller retains ownership to the objects set on the deleted response
 /// statistics object and must free them separately.
@@ -1377,7 +1377,7 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceResponseStatisticsDelete(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics);
 
-/// Set model instance to a decoupled inference response statistics object.
+/// Set model instance to an inference response statistics object.
 ///
 /// \param response_statistics The response statistics object.
 /// \param model_instance The model instance.
@@ -1387,7 +1387,7 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetModelInstance(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     TRITONBACKEND_ModelInstance* model_instance);
 
-/// Set response factory to a decoupled inference response statistics object.
+/// Set response factory to an inference response statistics object.
 ///
 /// \param response_statistics The response statistics object.
 /// \param response_factory The response factory.
@@ -1397,7 +1397,7 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseFactory(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     TRITONBACKEND_ResponseFactory* response_factory);
 
-/// Set response start time to a decoupled inference response statistics object.
+/// Set response start time to an inference response statistics object.
 ///
 /// All timestamps should be reported in nanonseconds and collected using
 /// std::chrono::steady_clock::now().time_since_epoch() or the equivalent.
@@ -1425,8 +1425,8 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseStart(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     uint64_t response_start);
 
-/// Set compute output start time to a decoupled inference response statistics
-/// object. Set this to 0 for reporting an empty response.
+/// Set compute output start time to an inference response statistics object.
+/// Set this to 0 for reporting an empty response.
 ///
 /// All timestamps should be reported in nanonseconds and collected using
 /// std::chrono::steady_clock::now().time_since_epoch() or the equivalent.
@@ -1454,7 +1454,7 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetComputeOutputStart(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     uint64_t compute_output_start);
 
-/// Set response end time to a decoupled inference response statistics object.
+/// Set response end time to an inference response statistics object.
 ///
 /// All timestamps should be reported in nanonseconds and collected using
 /// std::chrono::steady_clock::now().time_since_epoch() or the equivalent.
@@ -1482,7 +1482,7 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseEnd(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     uint64_t response_end);
 
-/// Set error to a decoupled inference response statistics object.
+/// Set error to an inference response statistics object.
 ///
 /// Use the same error object passed to the TRITONBACKEND_ResponseSend. \see
 /// TRITONBACKEND_ResponseSend.
@@ -1495,7 +1495,7 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetError(
     TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics,
     TRITONSERVER_Error* error);
 
-/// Record statistics for a decoupled inference response.
+/// Record statistics for an inference response.
 ///
 /// The caller retains ownership to the response statistics and must free it
 /// after this function returns.

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -761,8 +761,9 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseOutput(
 /// \param send_flags Flags associated with the response. \see
 /// TRITONSERVER_ResponseCompleteFlag. \see
 /// TRITONSERVER_InferenceResponseCompleteFn_t.
-/// \param error The TRITONSERVER_Error to send if the response is an
-/// error, or nullptr if the response is successful.
+/// \param error The TRITONSERVER_Error to send if the response is an error, or
+/// nullptr if the response is successful. The caller retains ownership to the
+/// error object and must free it with TRITONSERVER_ErrorDelete.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ResponseSend(
     TRITONBACKEND_Response* response, const uint32_t send_flags,
@@ -1392,6 +1393,8 @@ TRITONBACKEND_ModelInstanceReportStatistics(
 /// TRITONBACKEND_ResponseSend
 /// \param error The TRITONSERVER_Error to send if the response is an error, or
 /// nullptr if the response is successful. \see TRITONBACKEND_ResponseSend
+/// The caller retains ownership to the error object and must free it with
+/// TRITONSERVER_ErrorDelete.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceReportResponseStatistics(

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1426,7 +1426,9 @@ TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseStart(
     uint64_t response_start);
 
 /// Set compute output start time to an inference response statistics object.
-/// Set this to 0 for reporting an empty response.
+///
+/// Do NOT set this compute output start time (or set it to 0), if reporting an
+/// empty response.
 ///
 /// All timestamps should be reported in nanonseconds and collected using
 /// std::chrono::steady_clock::now().time_since_epoch() or the equivalent.

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -955,33 +955,33 @@ TRITONBACKEND_ModelInstanceReportStatistics(
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceReportResponseStatistics(
-    TRITONBACKEND_ModelInstance* instance,
-    TRITONBACKEND_ResponseFactory* response_factory,
-    const uint64_t response_start, const uint64_t compute_output_start,
-    const uint64_t response_end, const uint32_t send_flags,
-    TRITONSERVER_Error* error)
+    TRITONBACKEND_ModelInstanceResponseStatistics* response_statistics)
 {
 #ifdef TRITON_ENABLE_STATS
-  TritonModelInstance* ti = reinterpret_cast<TritonModelInstance*>(instance);
+  TRITONBACKEND_ModelInstanceResponseStatistics* rs = response_statistics;
+  TritonModelInstance* ti =
+      reinterpret_cast<TritonModelInstance*>(rs->model_instance);
   std::shared_ptr<InferenceResponseFactory>* rf =
       reinterpret_cast<std::shared_ptr<InferenceResponseFactory>*>(
-          response_factory);
+          rs->response_factory);
   std::string key = std::to_string((*rf)->GetAndIncrementResponseIndex());
 
-  if (error == nullptr) {
-    if (compute_output_start > 0) {
+  if (rs->error == nullptr) {
+    if (rs->compute_output_start > 0) {
       RETURN_TRITONSERVER_ERROR_IF_ERROR(
           ti->Model()->MutableStatsAggregator()->UpdateResponseSuccess(
-              key, response_start, compute_output_start, response_end));
+              key, rs->response_start, rs->compute_output_start,
+              rs->response_end));
     } else {
       RETURN_TRITONSERVER_ERROR_IF_ERROR(
           ti->Model()->MutableStatsAggregator()->UpdateResponseEmpty(
-              key, response_start, response_end));
+              key, rs->response_start, rs->response_end));
     }
   } else {
     RETURN_TRITONSERVER_ERROR_IF_ERROR(
         ti->Model()->MutableStatsAggregator()->UpdateResponseFail(
-            key, response_start, compute_output_start, response_end));
+            key, rs->response_start, rs->compute_output_start,
+            rs->response_end));
   }
 #endif  // TRITON_ENABLE_STATS
 

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -966,7 +966,7 @@ TRITONBACKEND_ModelInstanceReportResponseStatistics(
   std::shared_ptr<InferenceResponseFactory>* rf =
       reinterpret_cast<std::shared_ptr<InferenceResponseFactory>*>(
           response_factory);
-  std::string key = std::to_string((*rf)->ResponseStatsIndex());
+  std::string key = std::to_string((*rf)->GetAndIncrementResponseIndex());
 
   if (error == nullptr) {
     if (compute_output_start > 0) {

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -61,6 +61,10 @@ class InferenceResponseFactory {
         alloc_userp_(alloc_userp), response_fn_(response_fn),
         response_userp_(response_userp), response_delegator_(delegator),
         is_cancelled_(false)
+#ifdef TRITON_ENABLE_STATS
+        ,
+        response_stats_index_(0)
+#endif  // TRITON_ENABLE_STATS
   {
   }
 
@@ -93,6 +97,11 @@ class InferenceResponseFactory {
   }
   void ReleaseTrace() { trace_ = nullptr; }
 #endif  // TRITON_ENABLE_TRACING
+
+#ifdef TRITON_ENABLE_STATS
+  // Return the current response statistics index and increment it.
+  uint64_t ResponseStatsIndex() { return response_stats_index_++; };
+#endif  // TRITON_ENABLE_STATS
 
  private:
   // The model associated with this factory. For normal
@@ -129,6 +138,11 @@ class InferenceResponseFactory {
   // Inference trace associated with this response.
   std::shared_ptr<InferenceTraceProxy> trace_;
 #endif  // TRITON_ENABLE_TRACING
+
+#ifdef TRITON_ENABLE_STATS
+  // Number of response statistics reported.
+  std::atomic<uint64_t> response_stats_index_;
+#endif  // TRITON_ENABLE_STATS
 };
 
 //

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -100,7 +100,7 @@ class InferenceResponseFactory {
 
 #ifdef TRITON_ENABLE_STATS
   // Return the current response statistics index and increment it.
-  uint64_t ResponseStatsIndex() { return response_stats_index_++; };
+  uint64_t GetAndIncrementResponseIndex() { return response_stats_index_++; };
 #endif  // TRITON_ENABLE_STATS
 
  private:

--- a/src/infer_stats.h
+++ b/src/infer_stats.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -78,6 +78,27 @@ class InferenceStatsAggregator {
     uint64_t cache_miss_duration_ns_;
   };
 
+  struct InferResponseStats {
+    InferResponseStats()
+        : compute_infer_count(0), compute_infer_duration_ns(0),
+          compute_output_count(0), compute_output_duration_ns(0),
+          success_count(0), success_duration_ns(0), fail_count(0),
+          fail_duration_ns(0), empty_response_count(0),
+          empty_response_duration_ns(0)
+    {
+    }
+    uint64_t compute_infer_count;
+    uint64_t compute_infer_duration_ns;
+    uint64_t compute_output_count;
+    uint64_t compute_output_duration_ns;
+    uint64_t success_count;
+    uint64_t success_duration_ns;
+    uint64_t fail_count;
+    uint64_t fail_duration_ns;
+    uint64_t empty_response_count;
+    uint64_t empty_response_duration_ns;
+  };
+
   struct InferBatchStats {
     InferBatchStats()
         : count_(0), compute_input_duration_ns_(0),
@@ -100,6 +121,11 @@ class InferenceStatsAggregator {
   uint64_t InferenceCount() const { return inference_count_; }
   uint64_t ExecutionCount() const { return execution_count_; }
   const InferStats& ImmutableInferStats() const { return infer_stats_; }
+  const std::map<std::string, InferResponseStats>& ImmutableInferResponseStats()
+      const
+  {
+    return response_stats_;
+  }
   const std::map<size_t, InferBatchStats>& ImmutableInferBatchStats() const
   {
     return batch_stats_;
@@ -140,6 +166,21 @@ class InferenceStatsAggregator {
       MetricModelReporter* metric_reporter,
       const uint64_t cache_miss_duration_ns);
 
+  // Add durations to response stats for a successful response.
+  Status UpdateResponseSuccess(
+      const std::string& key, const uint64_t response_start_ns,
+      const uint64_t compute_output_start_ns, const uint64_t response_end_ns);
+
+  // Add durations to response stats for a failed response.
+  Status UpdateResponseFail(
+      const std::string& key, const uint64_t response_start_ns,
+      const uint64_t compute_output_start_ns, const uint64_t response_end_ns);
+
+  // Add durations to response stats for an empty response.
+  Status UpdateResponseEmpty(
+      const std::string& key, const uint64_t response_start_ns,
+      const uint64_t response_end_ns);
+
   // Add durations to batch infer stats for a batch execution.
   // 'success_request_count' is the number of success requests in the
   // batch that have infer_stats attached.
@@ -163,6 +204,7 @@ class InferenceStatsAggregator {
   uint64_t inference_count_;
   uint64_t execution_count_;
   InferStats infer_stats_;
+  std::map<std::string, InferResponseStats> response_stats_;
   std::map<size_t, InferBatchStats> batch_stats_;
 #endif  // TRITON_ENABLE_STATS
 };

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -947,6 +947,38 @@ TRITONBACKEND_ModelInstanceReportStatistics()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsNew()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetModelInstance()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseFactory()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseStart()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetComputeOutputStart()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetResponseEnd()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsSetError()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceResponseStatisticsDelete()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONBACKEND_ModelInstanceReportResponseStatistics()
 {
 }

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -944,6 +944,10 @@ TRITONBACKEND_ModelInstanceReportMemoryUsage()
 }
 TRITONAPI_DECLSPEC void
 TRITONBACKEND_ModelInstanceReportStatistics()
+{
+}
+TRITONAPI_DECLSPEC void
+TRITONBACKEND_ModelInstanceReportResponseStatistics()
 {
 }
 TRITONAPI_DECLSPEC void


### PR DESCRIPTION
Related PRs:
- https://github.com/triton-inference-server/server/pull/6869
- https://github.com/triton-inference-server/common/pull/112
- https://github.com/triton-inference-server/square_backend/pull/16

Add response statistics API.

Example statistics endpoint output to client:
```
{
  'model_stats': [{
    'name': 'square_int32',
    ...
    'inference_stats': {
      ...
      'response_stats': {
        '0': {
          'compute_infer': {'count': 3, 'ns': 1200514434},
          'compute_output': {'count': 3, 'ns': 600346215},
          'success': {'count': 2, 'ns': 1200431061},
          'fail': {'count': 1, 'ns': 600429588},
          'empty_response': {'count': 0, 'ns': 0}
        },
        '1': {
          'compute_infer': {'count': 3, 'ns': 1200250644},
          'compute_output': {'count': 3, 'ns': 600358040},
          'success': {'count': 1, 'ns': 600202056},
          'fail': {'count': 2, 'ns': 1200406628},
          'empty_response': {'count': 0, 'ns': 0}
        },
        '2': {
          'compute_infer': {'count': 3, 'ns': 1200252841},
          'compute_output': {'count': 2, 'ns': 400214433},
          'success': {'count': 1, 'ns': 600183751},
          'fail': {'count': 1, 'ns': 600188918},
          'empty_response': {'count': 1, 'ns': 400094605}
        },
        '3': {
          'compute_infer': {'count': 2, 'ns': 800160632},
          'compute_output': {'count': 1, 'ns': 200133237},
          'success': {'count': 0, 'ns': 0},
          'fail': {'count': 1, 'ns': 600214152},
          'empty_response': {'count': 1, 'ns': 400079717}
        },
        '4': {
          'compute_infer': {'count': 1, 'ns': 400086093},
          'compute_output': {'count': 1, 'ns': 200104114},
          'success': {'count': 0, 'ns': 0},
          'fail': {'count': 1, 'ns': 600190207},
          'empty_response': {'count': 0, 'ns': 0}
        },
        '5': {
          'compute_infer': {'count': 1, 'ns': 400089434},
          'compute_output': {'count': 0, 'ns': 0},
          'success': {'count': 0, 'ns': 0},
          'fail': {'count': 0, 'ns': 0},
          'empty_response': {'count': 1, 'ns': 400089434}}
        }
      }
    ...
    }
  }]
}
```