### PR TITLE
Add cancellation into response statistics

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -95,7 +95,7 @@ struct TRITONBACKEND_Batcher;
 ///   }
 ///
 #define TRITONBACKEND_API_VERSION_MAJOR 1
-#define TRITONBACKEND_API_VERSION_MINOR 20
+#define TRITONBACKEND_API_VERSION_MINOR 19
 
 /// Get the TRITONBACKEND API version supported by Triton. This value
 /// can be compared against the TRITONBACKEND_API_VERSION_MAJOR and

--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -95,7 +95,7 @@ struct TRITONBACKEND_Batcher;
 ///   }
 ///
 #define TRITONBACKEND_API_VERSION_MAJOR 1
-#define TRITONBACKEND_API_VERSION_MINOR 19
+#define TRITONBACKEND_API_VERSION_MINOR 20
 
 /// Get the TRITONBACKEND API version supported by Triton. This value
 /// can be compared against the TRITONBACKEND_API_VERSION_MAJOR and

--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -1103,6 +1103,10 @@ TRITONBACKEND_ModelInstanceReportResponseStatistics(
       RETURN_TRITONSERVER_ERROR_IF_ERROR(
           sa->UpdateResponseEmpty(key, rs->response_start, rs->response_end));
     }
+  } else if (
+      TRITONSERVER_ErrorCode(rs->error) == TRITONSERVER_ERROR_CANCELLED) {
+    RETURN_TRITONSERVER_ERROR_IF_ERROR(
+        sa->UpdateResponseCancel(key, rs->response_start, rs->response_end));
   } else {
     RETURN_TRITONSERVER_ERROR_IF_ERROR(sa->UpdateResponseFail(
         key, rs->response_start, rs->compute_output_start, rs->response_end));

--- a/src/infer_stats.h
+++ b/src/infer_stats.h
@@ -84,7 +84,7 @@ class InferenceStatsAggregator {
           compute_output_count(0), compute_output_duration_ns(0),
           success_count(0), success_duration_ns(0), fail_count(0),
           fail_duration_ns(0), empty_response_count(0),
-          empty_response_duration_ns(0)
+          empty_response_duration_ns(0), cancel_count(0), cancel_duration_ns(0)
     {
     }
     uint64_t compute_infer_count;
@@ -97,6 +97,8 @@ class InferenceStatsAggregator {
     uint64_t fail_duration_ns;
     uint64_t empty_response_count;
     uint64_t empty_response_duration_ns;
+    uint64_t cancel_count;
+    uint64_t cancel_duration_ns;
   };
 
   struct InferBatchStats {
@@ -178,6 +180,11 @@ class InferenceStatsAggregator {
 
   // Add durations to response stats for an empty response.
   Status UpdateResponseEmpty(
+      const std::string& key, const uint64_t response_start_ns,
+      const uint64_t response_end_ns);
+
+  // Add durations to response stats for a cancellation response.
+  Status UpdateResponseCancel(
       const std::string& key, const uint64_t response_start_ns,
       const uint64_t response_end_ns);
 

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2959,6 +2959,9 @@ TRITONSERVER_ServerModelStatistics(
             metadata, res_stat, "empty_response",
             res_pair.second.empty_response_count,
             res_pair.second.empty_response_duration_ns);
+        SetDurationStat(
+            metadata, res_stat, "cancel", res_pair.second.cancel_count,
+            res_pair.second.cancel_duration_ns);
         RETURN_IF_STATUS_ERROR(
             response_stats.Add(res_pair.first.c_str(), std::move(res_stat)));
       }


### PR DESCRIPTION
Related PRs:
- https://github.com/triton-inference-server/server/pull/6904
- https://github.com/triton-inference-server/common/pull/113
- https://github.com/triton-inference-server/square_backend/pull/17

Enable support for reporting cancellation statistics into response statistics.

Example statistics endpoint output to client:
```
{
  'model_stats': [{
    'name': 'square_int32_slow',
    ...
    'inference_stats': {
      ...
      'response_stats': {
        '0': {
          'compute_infer': {'count': 2, 'ns': 2400268649},
          'compute_output': {'count': 2, 'ns': 1600386958},
          'success': {'count': 2, 'ns': 4000655607},
          'fail': {'count': 0, 'ns': 0},
          'empty_response': {'count': 0, 'ns': 0},
          'cancel': {'count': 0, 'ns': 0}
        },
        '1': {
          'compute_infer': {'count': 2, 'ns': 2400184742},
          'compute_output': {'count': 2, 'ns': 1600335061},
          'success': {'count': 2, 'ns': 4000519803},
          'fail': {'count': 0, 'ns': 0},
          'empty_response': {'count': 0, 'ns': 0},
          'cancel': {'count': 0, 'ns': 0}
        },
        '2': {
          'compute_infer': {'count': 1, 'ns': 1200115835},
          'compute_output': {'count': 1, 'ns': 800189928},
          'success': {'count': 1, 'ns': 2000305763},
          'fail': {'count': 0, 'ns': 0},
          'empty_response': {'count': 0, 'ns': 0},
          'cancel': {'count': 1, 'ns': 400070803}
        },
        '3': {
          'compute_infer': {'count': 1, 'ns': 1200071211},
          'compute_output': {'count': 1, 'ns': 800177699},
          'success': {'count': 1, 'ns': 2000248910},
          'fail': {'count': 0, 'ns': 0},
          'empty_response': {'count': 0, 'ns': 0},
          'cancel': {'count': 0, 'ns': 0}
        }
      }
    ...
    }
  }]
}
```