### PR TITLE
Promptly respond to timeout requests under reject policy

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -460,38 +460,28 @@ DynamicBatchScheduler::WaitForPayloadSlotAvailable(
   // Enqueue threads above to make progress.
   lock->unlock();
 
-  const auto reject_and_release_timeout_requests = [this]() {
-    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
-        rejected_requests, cancelled_requests;
-    {
-      std::lock_guard<std::mutex> lock(mu_);
-      queue_.RejectTimeoutRequests();
-      queue_.ReleaseSkippedRequests(&rejected_requests, &cancelled_requests);
-    }
-    FinishRejectedCancelledRequests(
-        std::move(rejected_requests), std::move(cancelled_requests));
-  };
   const std::chrono::microseconds wait_timeout(wait_microseconds);
   std::mutex slot_mu;
   std::unique_lock<std::mutex> slot_lock(slot_mu);
   bool slot_available = false;
 
   while (!slot_available) {
-    slot_available = cv_.wait_for(
-        slot_lock, wait_timeout,
-        [this, &wait_timeout, &reject_and_release_timeout_requests]() {
-          auto slot_available_future = std::async(std::launch::async, [this]() {
-            return model_->Server()->GetRateLimiter()->PayloadSlotAvailable(
-                model_, model_instance_, queue_.SupportPrefetching());
-          });
-          while (slot_available_future.wait_for(wait_timeout) !=
-                 std::future_status::ready) {
-            reject_and_release_timeout_requests();
-          }
-          return slot_available_future.get();
-        });
+    slot_available = cv_.wait_for(slot_lock, wait_timeout, [this]() {
+      return model_->Server()->GetRateLimiter()->PayloadSlotAvailable(
+          model_, model_instance_, queue_.SupportPrefetching(),
+          true /* force_non_blocking */);
+    });
     if (!slot_available) {
-      reject_and_release_timeout_requests();
+      // Reject and release timeout requests from queue.
+      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
+          rejected_requests, cancelled_requests;
+      {
+        std::lock_guard<std::mutex> lock(mu_);
+        queue_.RejectTimeoutRequests();
+        queue_.ReleaseSkippedRequests(&rejected_requests, &cancelled_requests);
+      }
+      FinishRejectedCancelledRequests(
+          std::move(rejected_requests), std::move(cancelled_requests));
     }
   }
 

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -461,29 +461,28 @@ DynamicBatchScheduler::WaitForPayloadSlotAvailable(
   lock->unlock();
 
   std::chrono::microseconds wait_timeout(wait_microseconds);
-  std::mutex slot_mu;
-  std::unique_lock<std::mutex> slot_lock(slot_mu);
 
-  cv_.wait(slot_lock, [this, &wait_timeout]() {
-    auto slot_available_future = std::async(std::launch::async, [this]() {
-      return model_->Server()->GetRateLimiter()->PayloadSlotAvailable(
-          model_, model_instance_, queue_.SupportPrefetching());
-    });
-    while (slot_available_future.wait_for(wait_timeout) !=
-           std::future_status::ready) {
-      // Reject and release timed-out requests while waiting.
-      std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
-          rejected_requests, cancelled_requests;
-      {
-        std::lock_guard<std::mutex> lock(mu_);
-        queue_.RejectTimeoutRequests();
-        queue_.ReleaseSkippedRequests(&rejected_requests, &cancelled_requests);
-      }
-      FinishRejectedCancelledRequests(
-          std::move(rejected_requests), std::move(cancelled_requests));
-    }
-    return slot_available_future.get();
+  auto slot_available_future = std::async(std::launch::async, [this]() {
+    return model_->Server()->GetRateLimiter()->PayloadSlotAvailable(
+        model_, model_instance_, queue_.SupportPrefetching());
   });
+  while (slot_available_future.wait_for(wait_timeout) !=
+         std::future_status::ready) {
+    // Reject and release timed-out requests while waiting.
+    std::vector<std::deque<std::unique_ptr<InferenceRequest>>>
+        rejected_requests, cancelled_requests;
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      queue_.RejectTimeoutRequests();
+      queue_.ReleaseSkippedRequests(&rejected_requests, &cancelled_requests);
+    }
+    FinishRejectedCancelledRequests(
+        std::move(rejected_requests), std::move(cancelled_requests));
+  }
+  if (slot_available_future.get() != true) {
+    LOG_ERROR << "Should not print this! PayloadSlotAvailable returned without "
+                 "an available slot.";
+  }
 
   // Recapture the lock.
   lock->lock();

--- a/src/dynamic_batch_scheduler.h
+++ b/src/dynamic_batch_scheduler.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -108,6 +108,15 @@ class DynamicBatchScheduler : public Scheduler {
       std::unique_ptr<InferenceRequest>& request,
       std::unique_ptr<InferenceResponse>& cached_response);
   void FinalizeResponses();
+
+  // Block until a payload slot is available on the rate limiter. The 'lock'
+  // should be acquired when calling this function. The 'lock' will be released
+  // when waiting for payload slot and re-acquired before this function returns.
+  // For queued requests under policy REJECT, they will be rejected if timed-out
+  // while waiting for a slot. The timeout will be checked every
+  // 'wait_microseconds'. The 'wait_microseconds' should be non-zero.
+  void WaitForPayloadSlotAvailable(
+      std::unique_lock<std::mutex>* lock, uint64_t wait_microseconds);
 
   // Custom batching function calls
   // Returns whether custom batching is enabled.

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -241,7 +241,7 @@ size_t
 PriorityQueue::PolicyQueue::RejectTimeoutRequests()
 {
   if (timeout_action_ != inference::ModelQueuePolicy::REJECT) {
-    return false;
+    return 0;
   }
 
   size_t rejected_count = 0;

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -237,6 +237,32 @@ PriorityQueue::PolicyQueue::ApplyPolicy(
   return ((idx - queue_.size()) < delayed_queue_.size());
 }
 
+size_t
+PriorityQueue::PolicyQueue::RejectTimeoutRequests()
+{
+  if (timeout_action_ != inference::ModelQueuePolicy::REJECT) {
+    return false;
+  }
+
+  size_t rejected_count = 0;
+  uint64_t now_nanoseconds =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count();
+  for (size_t idx = 0; idx < queue_.size();) {
+    if (timeout_timestamp_ns_[idx] != 0 &&
+        now_nanoseconds > timeout_timestamp_ns_[idx]) {
+      rejected_count++;
+      rejected_queue_.emplace_back(std::move(queue_[idx]));
+      queue_.erase(queue_.begin() + idx);
+      timeout_timestamp_ns_.erase(timeout_timestamp_ns_.begin() + idx);
+    } else {
+      idx++;
+    }
+  }
+  return rejected_count;
+}
+
 void
 PriorityQueue::PolicyQueue::ReleaseRejectedQueue(
     std::deque<std::unique_ptr<InferenceRequest>>* requests)
@@ -356,6 +382,18 @@ PriorityQueue::Dequeue(std::unique_ptr<InferenceRequest>* request)
     }
   }
   return Status(Status::Code::UNAVAILABLE, "dequeue on empty queue");
+}
+
+void
+PriorityQueue::RejectTimeoutRequests()
+{
+  for (auto it = queues_.begin(); it != queues_.end(); it++) {
+    size_t rejected_count = it->second.RejectTimeoutRequests();
+    size_ -= rejected_count;
+    if (rejected_count > 0 && it->first == pending_cursor_.curr_it_->first) {
+      pending_cursor_.valid_ = false;
+    }
+  }
 }
 
 void

--- a/src/scheduler_utils.cc
+++ b/src/scheduler_utils.cc
@@ -249,7 +249,8 @@ PriorityQueue::PolicyQueue::RejectTimeoutRequests()
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           std::chrono::steady_clock::now().time_since_epoch())
           .count();
-  for (size_t idx = 0; idx < queue_.size();) {
+  size_t idx = 0;
+  while (idx < queue_.size()) {
     if (timeout_timestamp_ns_[idx] != 0 &&
         now_nanoseconds > timeout_timestamp_ns_[idx]) {
       rejected_count++;

--- a/src/scheduler_utils.h
+++ b/src/scheduler_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -83,6 +83,11 @@ class PriorityQueue {
 
   // Dequeue the request at the front of the queue.
   Status Dequeue(std::unique_ptr<InferenceRequest>* request);
+
+  // Reject timed-out requests from 'queues_', if queue policy set to reject.
+  // The cursor will be marked as invalid, if a request from the queue pointed
+  // to by the cursor is rejected.
+  void RejectTimeoutRequests();
 
   // Retrieve the requests that are either rejected or cancelled.
   void ReleaseSkippedRequests(
@@ -202,6 +207,10 @@ class PriorityQueue {
     bool ApplyPolicy(
         size_t idx, size_t* rejected_count, size_t* rejected_batch_size,
         size_t* cancelled_count, size_t* cancelled_batch_size);
+
+    // Move timed-out requests from 'queue_' to 'rejected_queue_', if
+    // 'timeout_action_' is to reject. Return the number of requests rejected.
+    size_t RejectTimeoutRequests();
 
     // Return the rejected requests held by the queue.
     void ReleaseRejectedQueue(


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6938

Currently, the dynamic batch scheduler only rejects timed-out requests when a payload slot is available and a new batch of requests is formed and submitted for inference. The payload slot availability is based on the completion of the previous batched inference request, which can take a long time depending on the model. Thus, the rejection of timed-out requests can be significantly delayed.

This change adds the ability for the dynamic batch scheduler to reject timed-out requests while waiting for the availability of a payload slot.