### PR TITLE
HTTP live connections on server shutdown

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -2258,7 +2258,9 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerStop(
     struct TRITONSERVER_Server* server);
 
-/// Set the exit timeout on the server object.
+/// Set the exit timeout on the server object. This value overrides the 
+/// value initially set through server options and provides a mechanism to 
+/// update the exit timeout while the serving is running.
 ///
 /// \param server The inference server object.
 /// \param timeout The exit timeout, in seconds.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 29
+#define TRITONSERVER_API_VERSION_MINOR 30
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -2239,14 +2239,13 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerStop(
     struct TRITONSERVER_Server* server);
 
-/// Set the exit timeout on the server object, and then stop the server object.
-/// A server can't be restarted once it is stopped.
+/// Set the exit timeout on the server object.
 ///
 /// \param server The inference server object.
 /// \param timeout The exit timeout, in seconds.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
-TRITONSERVER_ServerStopWithTimeout(
+TRITONSERVER_ServerSetExitTimeout(
     struct TRITONSERVER_Server* server, unsigned int timeout);
 
 /// Register a new model repository. Not available in polling mode.

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 28
+#define TRITONSERVER_API_VERSION_MINOR 29
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the
@@ -2238,6 +2238,16 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerStop(
     struct TRITONSERVER_Server* server);
+
+/// Set the exit timeout on the server object, and then stop the server object.
+/// A server can't be restarted once it is stopped.
+///
+/// \param server The inference server object.
+/// \param timeout The exit timeout, in seconds.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
+TRITONSERVER_ServerStopWithTimeout(
+    struct TRITONSERVER_Server* server, unsigned int timeout);
 
 /// Register a new model repository. Not available in polling mode.
 ///

--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -2258,9 +2258,9 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerDelete(
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerStop(
     struct TRITONSERVER_Server* server);
 
-/// Set the exit timeout on the server object. This value overrides the 
-/// value initially set through server options and provides a mechanism to 
-/// update the exit timeout while the serving is running.
+/// Set the exit timeout on the server object. This value overrides the value
+/// initially set through server options and provides a mechanism to update the
+/// exit timeout while the serving is running.
 ///
 /// \param server The inference server object.
 /// \param timeout The exit timeout, in seconds.

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2543,13 +2543,12 @@ TRITONSERVER_ServerStop(TRITONSERVER_Server* server)
 }
 
 TRITONAPI_DECLSPEC TRITONSERVER_Error*
-TRITONSERVER_ServerStopWithTimeout(
+TRITONSERVER_ServerSetExitTimeout(
     TRITONSERVER_Server* server, unsigned int timeout)
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
   if (lserver != nullptr) {
     lserver->SetExitTimeoutSeconds(timeout);
-    RETURN_IF_STATUS_ERROR(lserver->Stop());
   }
   return nullptr;  // Success
 }

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2542,6 +2542,18 @@ TRITONSERVER_ServerStop(TRITONSERVER_Server* server)
   return nullptr;  // Success
 }
 
+TRITONAPI_DECLSPEC TRITONSERVER_Error*
+TRITONSERVER_ServerStopWithTimeout(
+    TRITONSERVER_Server* server, unsigned int timeout)
+{
+  tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
+  if (lserver != nullptr) {
+    lserver->SetExitTimeoutSeconds(timeout);
+    RETURN_IF_STATUS_ERROR(lserver->Stop());
+  }
+  return nullptr;  // Success
+}
+
 TRITONSERVER_DECLSPEC TRITONSERVER_Error*
 TRITONSERVER_ServerRegisterModelRepository(
     TRITONSERVER_Server* server, const char* repository_path,

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -551,6 +551,10 @@ TRITONSERVER_ServerStop()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerStopWithTimeout()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerPollModelRepository()
 {
 }

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -551,7 +551,7 @@ TRITONSERVER_ServerStop()
 {
 }
 TRITONAPI_DECLSPEC void
-TRITONSERVER_ServerStopWithTimeout()
+TRITONSERVER_ServerSetExitTimeout()
 {
 }
 TRITONAPI_DECLSPEC void


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6986

Add a new C-API to update the server exit timeout value and then stop the server.