### PR TITLE
updated to add models loaded dynamically

### DIFF
--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -1028,8 +1028,8 @@ Status
 ModelRepositoryManager::RepositoryIndex(
     const bool ready_only, std::vector<ModelIndex>* index)
 {
-  std::set<ModelIdentifier> seen_models;
-  std::set<ModelIdentifier> duplicate_models;
+  std::unordered_set<ModelIdentifier> seen_models;
+  std::unordered_set<ModelIdentifier> duplicate_models;
   for (const auto& repository_path : repository_paths_) {
     const std::string model_namespace =
         (enable_model_namespacing_ ? repository_path : "");
@@ -1056,6 +1056,18 @@ ModelRepositoryManager::RepositoryIndex(
       }
 
       seen_models.insert(model_id);
+    }
+  }
+
+  // Any loaded models which are
+  // not present in the local model repository
+  // are added to the index directly
+  
+  for (const auto& mapping_it : global_map_) {
+    for (const auto& model_id : mapping_it.second) {
+      if (seen_models.count(model_id) == 0) {
+	seen_models.insert(model_id);
+      }
     }
   }
 


### PR DESCRIPTION
Related to: https://github.com/triton-inference-server/server/issues/7066

Looking for feedback on the goal for the API - whether models loaded in this way should be included in the model index - or if wanted to limit how model index is used.



