### PR TITLE
updating expected test failure until 2.47.0 release (r 24.06 release)

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -346,7 +346,7 @@ class ServerTests(unittest.TestCase):
         self.assertTrue(server.ready())
 
     @pytest.mark.xfail(
-        tritonserver.__version__ <= "2.43.0",
+        tritonserver.__version__ <= "2.46.0",
         reason="Known issue on stop: Exit timeout expired. Exiting immediately",
         raises=tritonserver.InternalError,
     )


### PR DESCRIPTION
failure for stop case is not currently blocking release - will remove once issue is scheduled for fix.