### PR TITLE
fix: Improve error message when validating IO config

### DIFF
--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -303,7 +303,7 @@ ValidateIOShape(
   }
 
   std::string message_prefix_with_name =
-      message_prefix + std::string(" '" + io.name() + "' ");
+      message_prefix + std::string("'" + io.name() + "' ");
 
   if (io.data_type() == inference::DataType::TYPE_INVALID) {
     return Status(

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -303,7 +303,7 @@ ValidateIOShape(
   }
 
   std::string message_prefix_with_name =
-      message_prefix + ::string(" '" + io.name() + "' ");
+      message_prefix + std::string(" '" + io.name() + "' ");
 
   if (io.data_type() == inference::DataType::TYPE_INVALID) {
     return Status(

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -302,16 +302,19 @@ ValidateIOShape(
         Status::Code::INVALID_ARG, message_prefix + "must specify 'name'");
   }
 
-  std::string message_prefix_with_name = message_prefix + ::string(" '" + io.name() + "' ");
+  std::string message_prefix_with_name =
+      message_prefix + ::string(" '" + io.name() + "' ");
 
   if (io.data_type() == inference::DataType::TYPE_INVALID) {
     return Status(
-        Status::Code::INVALID_ARG, message_prefix_with_name + "must specify 'data_type'");
+        Status::Code::INVALID_ARG,
+        message_prefix_with_name + "must specify 'data_type'");
   }
 
   if (io.dims_size() == 0) {
     return Status(
-        Status::Code::INVALID_ARG, message_prefix_with_name + "must specify 'dims'");
+        Status::Code::INVALID_ARG,
+        message_prefix_with_name + "must specify 'dims'");
   }
 
   // If the configuration is non-batching, then no input or output
@@ -343,7 +346,8 @@ ValidateIOShape(
       if ((dim < 1) && (dim != triton::common::WILDCARD_DIM)) {
         return Status(
             Status::Code::INVALID_ARG,
-            message_prefix_with_name + "reshape dimensions must be integer >= 1, or " +
+            message_prefix_with_name +
+                "reshape dimensions must be integer >= 1, or " +
                 std::to_string(triton::common::WILDCARD_DIM) +
                 " to indicate a variable-size dimension");
       }
@@ -404,7 +408,8 @@ ValidateIOShape(
         if (dim_element_cnts[idx] != reshape_element_cnts[idx]) {
           return Status(
               Status::Code::INVALID_ARG,
-              message_prefix_with_name + "has different size for dims and reshape");
+              message_prefix_with_name +
+                  "has different size for dims and reshape");
         }
       }
     }

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -302,14 +302,16 @@ ValidateIOShape(
         Status::Code::INVALID_ARG, message_prefix + "must specify 'name'");
   }
 
+  std::string message_prefix_with_name = message_prefix + ::string(" '" + io.name() + "' ");
+
   if (io.data_type() == inference::DataType::TYPE_INVALID) {
     return Status(
-        Status::Code::INVALID_ARG, "model output must specify 'data_type'");
+        Status::Code::INVALID_ARG, message_prefix_with_name + "must specify 'data_type'");
   }
 
   if (io.dims_size() == 0) {
     return Status(
-        Status::Code::INVALID_ARG, message_prefix + "must specify 'dims'");
+        Status::Code::INVALID_ARG, message_prefix_with_name + "must specify 'dims'");
   }
 
   // If the configuration is non-batching, then no input or output
@@ -319,7 +321,7 @@ ValidateIOShape(
       (max_batch_size == 0)) {
     return Status(
         Status::Code::INVALID_ARG,
-        message_prefix +
+        message_prefix_with_name +
             "cannot have empty reshape for non-batching model as scalar "
             "tensors are not supported");
   }
@@ -329,7 +331,7 @@ ValidateIOShape(
     if ((dim < 1) && (dim != triton::common::WILDCARD_DIM)) {
       return Status(
           Status::Code::INVALID_ARG,
-          message_prefix + "dimension must be integer >= 1, or " +
+          message_prefix_with_name + "dimension must be integer >= 1, or " +
               std::to_string(triton::common::WILDCARD_DIM) +
               " to indicate a variable-size dimension");
     }
@@ -341,7 +343,7 @@ ValidateIOShape(
       if ((dim < 1) && (dim != triton::common::WILDCARD_DIM)) {
         return Status(
             Status::Code::INVALID_ARG,
-            message_prefix + "reshape dimensions must be integer >= 1, or " +
+            message_prefix_with_name + "reshape dimensions must be integer >= 1, or " +
                 std::to_string(triton::common::WILDCARD_DIM) +
                 " to indicate a variable-size dimension");
       }
@@ -359,7 +361,7 @@ ValidateIOShape(
         ((reshape_size != 0) || (dims_size != 1))) {
       return Status(
           Status::Code::INVALID_ARG,
-          message_prefix + "has different size for dims and reshape");
+          message_prefix_with_name + "has different size for dims and reshape");
     }
 
     // shape contains variable-size dimension, in this case we compare if
@@ -394,7 +396,7 @@ ValidateIOShape(
       if (dim_element_cnts.size() != reshape_element_cnts.size()) {
         return Status(
             Status::Code::INVALID_ARG,
-            message_prefix +
+            message_prefix_with_name +
                 "has different number of variable-size dimensions for dims "
                 "and reshape");
       }
@@ -402,7 +404,7 @@ ValidateIOShape(
         if (dim_element_cnts[idx] != reshape_element_cnts[idx]) {
           return Status(
               Status::Code::INVALID_ARG,
-              message_prefix + "has different size for dims and reshape");
+              message_prefix_with_name + "has different size for dims and reshape");
         }
       }
     }


### PR DESCRIPTION
Some of the user models can have large number of model inputs/ouptuts. Without this change the model tensor name is not a part of the error message. This change improves the error logging of the server offering better debugging ability to the user.

There is also a fix included which correctly prints a model input as an input instead of as an output.

The testing is updated to expect this new behavior here:  https://github.com/triton-inference-server/server/pull/7340

For the following model configuration:

```
name: "missing_datatype"
max_batch_size: 4
platform: "tensorflow_savedmodel"
input [
  {
    name: "input"
    dims: [ 2, -1 ]
  }
]
output [
  {
    name: "output"
    data_type: TYPE_FP32
    dims: [ 1 ]
  }
]

```

### Before

`E0611 19:35:52.422993 138 model_repository_manager.cc:1371] "Poll failed for model directory 'missing_datatype': model output must specify 'data_type' for missing_datatype"`

### After
`
E0611 19:31:47.991606 9486 model_repository_manager.cc:1371] "Poll failed for model directory 'missing_datatype': model input 'input' must specify 'data_type' for missing_datatype"`