### PR TITLE
Multiple Model Configurations (#348)

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 30
+#define TRITONSERVER_API_VERSION_MINOR 31
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the
@@ -1827,6 +1827,16 @@ TRITONSERVER_ServerOptionsSetStartupModel(
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
 TRITONSERVER_ServerOptionsSetStrictModelConfig(
     struct TRITONSERVER_ServerOptions* options, bool strict);
+
+/// Set the custom model configuration name to load for all models.
+/// Fall back to default config file if empty.
+///
+/// \param options The server options object.
+/// \param config_name The name of the config file to load for all models.
+/// \return a TRITONSERVER_Error indicating success or failure.
+TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
+TRITONSERVER_ServerOptionsSetModelConfigName(
+    struct TRITONSERVER_ServerOptions* options, const char* model_config_name);
 
 /// Set the rate limit mode in a server options.
 ///

--- a/src/constants.h
+++ b/src/constants.h
@@ -71,6 +71,8 @@ constexpr char kAutoMixedPrecisionExecutionAccelerator[] =
     "auto_mixed_precision";
 
 constexpr char kModelConfigPbTxt[] = "config.pbtxt";
+constexpr char kPbTxtExtension[] = ".pbtxt";
+constexpr char kModelConfigFolder[] = "configs";
 
 constexpr char kMetricsLabelModelNamespace[] = "namespace";
 constexpr char kMetricsLabelModelName[] = "model";

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -92,7 +92,10 @@ VersionsToLoad(
   RETURN_IF_ERROR(GetDirectorySubdirs(model_path, &subdirs));
   std::set<int64_t, std::greater<int64_t>> existing_versions;
   for (const auto& subdir : subdirs) {
-    if (subdir == kWarmupDataFolder || subdir == kInitialStateFolder) {
+    static const std::vector skip_dirs{
+        kWarmupDataFolder, kInitialStateFolder, kModelConfigFolder};
+    if (std::find(skip_dirs.begin(), skip_dirs.end(), subdir) !=
+        skip_dirs.end()) {
       continue;
     }
     if ((subdir.length() > 1) && (subdir.front() == '0')) {

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -79,10 +79,10 @@ class ModelRepositoryManager {
     ModelInfo(
         const std::pair<int64_t, int64_t>& mtime_nsec,
         const std::pair<int64_t, int64_t>& prev_mtime_ns,
-        const std::string& model_path)
+        const std::string& model_path, const std::string& model_config_path)
         : mtime_nsec_(mtime_nsec), prev_mtime_ns_(prev_mtime_ns),
           explicitly_load_(true), model_path_(model_path),
-          is_config_provided_(false)
+          model_config_path_(model_config_path), is_config_provided_(false)
     {
     }
     ModelInfo()
@@ -97,6 +97,7 @@ class ModelRepositoryManager {
     bool explicitly_load_;
     inference::ModelConfig model_config_;
     std::string model_path_;
+    std::string model_config_path_;
     // Temporary location to hold agent model list before creating the model
     // the ownership must transfer to ModelLifeCycle to ensure
     // the agent model life cycle is handled properly.
@@ -391,6 +392,8 @@ class ModelRepositoryManager {
   /// and the models in the model repository will not be loaded at startup.
   /// Otherwise, LoadUnloadModel() is not allowed and the models will be loaded.
   /// Cannot be set to true if polling_enabled is true.
+  /// \param model_config_name Custom model config name to load for all models.
+  /// Fall back to default config file if empty.
   /// \param life_cycle_options The options to configure ModelLifeCycle.
   /// \param model_repository_manager Return the model repository manager.
   /// \return The error status.
@@ -398,8 +401,8 @@ class ModelRepositoryManager {
       InferenceServer* server, const std::string& server_version,
       const std::set<std::string>& repository_paths,
       const std::set<std::string>& startup_models,
-      const bool strict_model_config, const bool polling_enabled,
-      const bool model_control_enabled,
+      const bool strict_model_config, const std::string& model_config_name,
+      const bool polling_enabled, const bool model_control_enabled,
       const ModelLifeCycleOptions& life_cycle_options,
       const bool enable_model_namespacing,
       std::unique_ptr<ModelRepositoryManager>* model_repository_manager);
@@ -410,7 +413,8 @@ class ModelRepositoryManager {
   Status PollAndUpdate();
 
   /// Load or unload a specified model.
-  /// \param models The models and the parameters to be loaded or unloaded
+  /// \param models The models and the parameters to be loaded or unloaded.
+  /// Expect the number of models to be exactly one.
   /// \param type The type action to be performed. If the action is LOAD and
   /// the model has been loaded, the model will be re-loaded.
   /// \return error status. Return "NOT_FOUND" if it tries to load
@@ -509,8 +513,9 @@ class ModelRepositoryManager {
 
   ModelRepositoryManager(
       const std::set<std::string>& repository_paths, const bool autofill,
-      const bool polling_enabled, const bool model_control_enabled,
-      const double min_compute_capability, const bool enable_model_namespacing,
+      const std::string& model_config_name, const bool polling_enabled,
+      const bool model_control_enabled, const double min_compute_capability,
+      const bool enable_model_namespacing,
       std::unique_ptr<ModelLifeCycle> life_cycle);
 
   /// The internal function that are called in Create() and PollAndUpdate().
@@ -614,6 +619,7 @@ class ModelRepositoryManager {
       const std::vector<const InferenceParameter*>& model_params);
 
   const bool autofill_;
+  const std::string model_config_name_;
   const bool polling_enabled_;
   const bool model_control_enabled_;
   const double min_compute_capability_;

--- a/src/server.cc
+++ b/src/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -261,8 +261,8 @@ InferenceServer::Init()
       host_policy_map_, model_load_thread_count_, model_load_retry_count_);
   status = ModelRepositoryManager::Create(
       this, version_, model_repository_paths_, startup_models_,
-      strict_model_config_, polling_enabled, model_control_enabled,
-      life_cycle_options, enable_model_namespacing_,
+      strict_model_config_, model_config_name_, polling_enabled,
+      model_control_enabled, life_cycle_options, enable_model_namespacing_,
       &model_repository_manager_);
   if (!status.IsOk()) {
     if (model_repository_manager_ == nullptr) {

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -177,6 +177,13 @@ class InferenceServer {
   bool StrictModelConfigEnabled() const { return strict_model_config_; }
   void SetStrictModelConfigEnabled(bool e) { strict_model_config_ = e; }
 
+  // Get / set custom model configuration file name.
+  std::string ModelConfigName() const { return model_config_name_; }
+  void SetModelConfigName(const std::string& name)
+  {
+    model_config_name_ = name;
+  }
+
   // Get / set rate limiter mode.
   RateLimitMode RateLimiterMode() const { return rate_limit_mode_; }
   void SetRateLimiterMode(RateLimitMode m) { rate_limit_mode_ = m; }
@@ -333,6 +340,7 @@ class InferenceServer {
   ModelControlMode model_control_mode_;
   bool strict_model_config_;
   bool strict_readiness_;
+  std::string model_config_name_;
   uint32_t exit_timeout_secs_;
   uint32_t buffer_manager_thread_count_;
   uint32_t model_load_thread_count_;

--- a/src/tritonserver_stub.cc
+++ b/src/tritonserver_stub.cc
@@ -378,6 +378,10 @@ TRITONSERVER_ServerOptionsSetStrictModelConfig()
 {
 }
 TRITONAPI_DECLSPEC void
+TRITONSERVER_ServerOptionsSetModelConfigName()
+{
+}
+TRITONAPI_DECLSPEC void
 TRITONSERVER_ServerOptionsSetRateLimiterMode()
 {
 }


### PR DESCRIPTION
Add `--mode-config-name` option when starting Triton server. Allow users to create multiple configurations and select a custom configuration other than the default `model/config.pbtxt`.