### PR TITLE
Use constant references instead of value copy when traverse map

### DIFF
--- a/src/sequence_batch_scheduler/sequence_batch_scheduler.cc
+++ b/src/sequence_batch_scheduler/sequence_batch_scheduler.cc
@@ -986,7 +986,7 @@ SequenceBatchScheduler::DelayScheduler(
   queue_request_cnts_[model_instance] = cnt;
 
   size_t seen = 0;
-  for (auto c : queue_request_cnts_) {
+  for (const auto& c : queue_request_cnts_) {
     seen += c.second;
   }
 


### PR DESCRIPTION
Fix map traverse bug, though it doesn't seem like a big improvement.