### PR TITLE
fix: Fix various tests caused by cases byte size validation not handled properly

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1203,10 +1203,10 @@ InferenceRequest::Normalize()
               triton::common::GetByteSize(data_type, input_dims);
         }
 
-        bool byte_size_valid =
+        bool byte_size_invalid =
             (byte_size > INT_MAX) ||
             (static_cast<int64_t>(byte_size) != expected_byte_size);
-        if (!skip_byte_size_check && byte_size_valid) {
+        if (!skip_byte_size_check && byte_size_invalid) {
           return Status(
               Status::Code::INVALID_ARG,
               LogRequest() + "input byte size mismatch for input '" + input_id +

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1301,6 +1301,13 @@ InferenceRequest::ValidateBytesInputs(
           &buffer_memory_type, &buffer_memory_id));
       *expected_byte_size += remaining_buffer_size;
 
+      if (buffer_idx > buffer_count) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            LogRequest() +
+                "element strings exceed the end of the last buffer.");
+      }
+
       // FIXME: Skip GPU buffers for now, return an expected_byte_size of -1 as
       // a signal to skip validation.
       if (buffer_memory_type == TRITONSERVER_MEMORY_GPU) {
@@ -1318,7 +1325,7 @@ InferenceRequest::ValidateBytesInputs(
         return Status(
             Status::Code::INVALID_ARG,
             LogRequest() +
-                "Element byte size indicator exceeds the end of the buffer.");
+                "element byte size indicator exceeds the end of the buffer.");
       }
 
       // Start the next element and reset the remaining element size.
@@ -1349,8 +1356,8 @@ InferenceRequest::ValidateBytesInputs(
   if (buffer_idx != buffer_count) {
     return Status(
         Status::Code::INVALID_ARG,
-        LogRequest() + "expected to process " + std::to_string(buffer_count) +
-            " buffers for inference input '" + input_id + "', only processed " +
+        LogRequest() + "expected " + std::to_string(buffer_count) +
+            " buffers for inference input '" + input_id + "', got " +
             std::to_string(buffer_idx));
   }
 
@@ -1359,7 +1366,7 @@ InferenceRequest::ValidateBytesInputs(
     return Status(
         Status::Code::INVALID_ARG,
         LogRequest() + "expected " + std::to_string(element_count) +
-            " strings for inference input '" + input_id + "', got " +
+            " string elements for inference input '" + input_id + "', got " +
             std::to_string(element_idx));
   }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1284,7 +1284,7 @@ InferenceRequest::ValidateBytesInputs(
   size_t remaining_element_size = 0;
 
   size_t buffer_idx = 0;
-  const size_t buffer_count = input.Data()->BufferCount();
+  const size_t buffer_count = input.DataBufferCount();
 
   const char* buffer = nullptr;
   size_t remaining_buffer_size = 0;
@@ -1296,9 +1296,9 @@ InferenceRequest::ValidateBytesInputs(
     // Get the next buffer if not currently processing one.
     if (!remaining_buffer_size) {
       // Reset remaining buffer size and pointers for next buffer.
-      buffer = input.Data()->BufferAt(
-          buffer_idx++, &remaining_buffer_size, &buffer_memory_type,
-          &buffer_memory_id);
+      RETURN_IF_ERROR(input.DataBuffer(
+          buffer_idx++, (const void**)(&buffer), &remaining_buffer_size,
+          &buffer_memory_type, &buffer_memory_id));
       *expected_byte_size += remaining_buffer_size;
 
       // FIXME: Skip GPU buffers for now, return an expected_byte_size of -1 as

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -749,7 +749,6 @@ class InferenceRequest {
 
   Status ValidateBytesInputs(
       const std::string& input_id, const Input& input,
-      int64_t* const expected_byte_size,
       TRITONSERVER_MemoryType* buffer_memory_type) const;
 
   // Helpers for pending request metrics

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -749,7 +749,8 @@ class InferenceRequest {
 
   Status ValidateBytesInputs(
       const std::string& input_id, const Input& input,
-      int64_t* const expected_byte_size) const;
+      int64_t* const expected_byte_size,
+      TRITONSERVER_MemoryType* buffer_memory_type) const;
 
   // Helpers for pending request metrics
   void IncrementPendingRequestCount();


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
- Recent byte size validation checks were failing the L0_http HttpTest.test_byte unit test which sends a raw binary tensor.
- Recent input byte size validation checks are segfaulting for the CUDA Shared Memory case because it assumes it is in CPU memory and dereferences an invalid pointer.
- Currently, L0_trt_shape_tensor and L0_trt_reformat_free tests are failing because TensorRT infer requests should not check byte size.

The raw binary tensor in the failing test case consists of two memory chunks by the time it gets validated:
1. The size of the bytes element
2. The bytes element

This PR makes some generic refactoring to try to handle any series of buffers, where each element is not guaranteed to fit within a single buffer, and each buffer is not guaranteed to contain a single element. Also it skips byte size validation if input memory type is GPU or input platform is TensorRT.

#### Caveats: 

1. GPU buffers are currently skipped, as they may need some special handling to be dereferenced/checked compared to CPU buffers in the existing code. This will likely cause the element count checks to fail as well.
2. TensorRT inputs are currently skipped, as format-free IO tensors require communication with the backend to determine the byte size.
3. A check is made that the 4-byte `byte_size` indicator for a given element is contained within a single buffer, and is not split across buffers. If a byte_size is split across buffers, then an error is returned. This was just easier to implement, open to suggestions if anyone has a slick solution. Technically the buffer APIs should support doing this, but I assume it is unlikely to be done. Example of this currently unsupported case: 
    - `buffer1=[<size1><element1><size2_partial>]`
    - `buffer2=[<size2_partial><element2>...]`
    - `<size2_partial>` is split across buffers, and is currently rejected.

#### Open Items

- [ ] Verify test plan passes in CI
- [ ] Decide what to do about GPU tensors - probably need to handle them
- [ ] Decide what to do about TensorRT, e.g. shape tensors and reformat-free I/O tensors.

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/server/pull/7326

#### Where should the reviewer start?
N/A

#### Test plan:
- L0_http
- L0_input_validation
- L0_infer_cudashm
- L0_sequence_batcher_cudashm
- L0_backend_output_detail
- L0_request_cancellation
- L0_trt_reformat_free
- L0_trt_shape_tensors
- Nightly pipeline

CI Pipeline ID: 15635924

#### Background
None

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
None
