### PR TITLE
fix: Move pinned memory size checks to PinnedMemoryManager and update C API version for new EnablePeerAccess API

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -91,7 +91,7 @@ struct TRITONSERVER_MetricFamily;
 ///   }
 ///
 #define TRITONSERVER_API_VERSION_MAJOR 1
-#define TRITONSERVER_API_VERSION_MINOR 31
+#define TRITONSERVER_API_VERSION_MINOR 32
 
 /// Get the TRITONBACKEND API version supported by the Triton shared
 /// library. This value can be compared against the

--- a/src/pinned_memory_manager.cc
+++ b/src/pinned_memory_manager.cc
@@ -263,7 +263,7 @@ PinnedMemoryManager::Create(const Options& options)
   instance_.reset(new PinnedMemoryManager());
   if (options.host_policy_map_.empty()) {
     void* buffer = nullptr;
-    if (options.pinned_memory_pool_byte_size_ > 0) {
+    // if (options.pinned_memory_pool_byte_size_ > 0) {
 #ifdef TRITON_ENABLE_GPU
       auto err = cudaHostAlloc(
           &buffer, options.pinned_memory_pool_byte_size_,
@@ -290,9 +290,9 @@ PinnedMemoryManager::Create(const Options& options)
             Status::Code::INTERNAL,
             "Failed to add Pinned Memory buffer: " + std::string(ex.what()));
       }
-    } else {
-      LOG_INFO << "Pinned memory pool disabled";
-    }
+    // } else {
+    //   LOG_INFO << "Pinned memory pool disabled";
+    // }
 
   } else {
     // Create only one buffer / manager should be created for one node,
@@ -324,7 +324,7 @@ PinnedMemoryManager::Create(const Options& options)
         continue;
       }
       void* buffer = nullptr;
-      if (options.pinned_memory_pool_byte_size_ > 0) {
+//      if (options.pinned_memory_pool_byte_size_ > 0) {
 #ifdef TRITON_ENABLE_GPU
         auto err = cudaHostAlloc(
             &buffer, options.pinned_memory_pool_byte_size_,
@@ -356,9 +356,9 @@ PinnedMemoryManager::Create(const Options& options)
               "Failed to add Pinned Memory buffer with host policy: " +
                   std::string(ex.what()));
         }
-      } else {
-        LOG_INFO << "Pinned memory pool disabled";
-      }
+//      } else {
+//        LOG_INFO << "Pinned memory pool disabled";
+//      }
       // If no pinned memory is allocated, add an empty entry where all
       // allocation will be on normal system memory
       if (instance_->pinned_memory_buffers_.empty()) {

--- a/src/pinned_memory_manager.cc
+++ b/src/pinned_memory_manager.cc
@@ -264,30 +264,36 @@ PinnedMemoryManager::Create(const Options& options)
   if (options.host_policy_map_.empty()) {
     void* buffer = nullptr;
 #ifdef TRITON_ENABLE_GPU
-    auto err = cudaHostAlloc(
-        &buffer, options.pinned_memory_pool_byte_size_, cudaHostAllocPortable);
-    if (err != cudaSuccess) {
-      buffer = nullptr;
-      LOG_WARNING << "Unable to allocate pinned system memory, pinned memory "
-                     "pool will not be available: "
-                  << std::string(cudaGetErrorString(err));
-    } else if (options.pinned_memory_pool_byte_size_ != 0) {
-      LOG_INFO << "Pinned memory pool is created at '"
-               << PointerToString(buffer) << "' with size "
-               << options.pinned_memory_pool_byte_size_;
-    }
+    if (options.pinned_memory_pool_byte_size_ > 0) {
+      auto err = cudaHostAlloc(
+          &buffer, options.pinned_memory_pool_byte_size_,
+          cudaHostAllocPortable);
+      if (err != cudaSuccess) {
+        buffer = nullptr;
+        LOG_WARNING << "Unable to allocate pinned system memory, pinned memory "
+                       "pool will not be available: "
+                    << std::string(cudaGetErrorString(err));
+      } else if (options.pinned_memory_pool_byte_size_ != 0) {
+        LOG_INFO << "Pinned memory pool is created at '"
+                 << PointerToString(buffer) << "' with size "
+                 << options.pinned_memory_pool_byte_size_;
+      }
 #endif  // TRITON_ENABLE_GPU
-    try {
-      instance_->AddPinnedMemoryBuffer(
-          std::shared_ptr<PinnedMemory>(
-              new PinnedMemory(buffer, options.pinned_memory_pool_byte_size_)),
-          0);
+      try {
+        instance_->AddPinnedMemoryBuffer(
+            std::shared_ptr<PinnedMemory>(new PinnedMemory(
+                buffer, options.pinned_memory_pool_byte_size_)),
+            0);
+      }
+      catch (const std::exception& ex) {
+        return Status(
+            Status::Code::INTERNAL,
+            "Failed to add Pinned Memory buffer: " + std::string(ex.what()));
+      }
+    } else {
+      LOG_INFO << "Pinned memory pool disabled";
     }
-    catch (const std::exception& ex) {
-      return Status(
-          Status::Code::INTERNAL,
-          "Failed to add Pinned Memory buffer: " + std::string(ex.what()));
-    }
+
   } else {
     // Create only one buffer / manager should be created for one node,
     // and all associated devices should request memory from the shared manager
@@ -319,35 +325,42 @@ PinnedMemoryManager::Create(const Options& options)
       }
       void* buffer = nullptr;
 #ifdef TRITON_ENABLE_GPU
-      auto err = cudaHostAlloc(
-          &buffer, options.pinned_memory_pool_byte_size_,
-          cudaHostAllocPortable);
-      if (err != cudaSuccess) {
-        buffer = nullptr;
-        LOG_WARNING << "Unable to allocate pinned system memory, pinned memory "
-                       "pool will not be available: "
-                    << std::string(cudaGetErrorString(err));
-      } else if (options.pinned_memory_pool_byte_size_ != 0) {
-        LOG_INFO << "Pinned memory pool is created at '"
-                 << PointerToString(buffer) << "' with size "
-                 << options.pinned_memory_pool_byte_size_;
-      } else {
-        LOG_INFO << "Pinned memory pool disabled";
-      }
+      if (options.pinned_memory_pool_byte_size_ > 0) {
+        auto err = cudaHostAlloc(
+            &buffer, options.pinned_memory_pool_byte_size_,
+            cudaHostAllocPortable);
+        if (err != cudaSuccess) {
+          buffer = nullptr;
+          LOG_WARNING
+              << "Unable to allocate pinned system memory, pinned memory "
+                 "pool will not be available: "
+              << std::string(cudaGetErrorString(err));
+        } else if (options.pinned_memory_pool_byte_size_ != 0) {
+          LOG_INFO << "Pinned memory pool is created at '"
+                   << PointerToString(buffer) << "' with size "
+                   << options.pinned_memory_pool_byte_size_;
+        } else {
+          LOG_INFO << "Pinned memory pool disabled";
+        }
 #endif  // TRITON_ENABLE_GPU
-      ResetNumaMemoryPolicy();
-      try {
-        instance_->AddPinnedMemoryBuffer(
-            std::shared_ptr<PinnedMemory>(new PinnedMemory(
-                buffer, options.pinned_memory_pool_byte_size_)),
-            node_mask);
+        ResetNumaMemoryPolicy();
+        try {
+          instance_->AddPinnedMemoryBuffer(
+              std::shared_ptr<PinnedMemory>(new PinnedMemory(
+                  buffer, options.pinned_memory_pool_byte_size_)),
+              node_mask);
+        }
+        catch (const std::exception& ex) {
+          return Status(
+              Status::Code::INTERNAL,
+              "Failed to add Pinned Memory buffer with host policy: " +
+                  std::string(ex.what()));
+        }
       }
-      catch (const std::exception& ex) {
-        return Status(
-            Status::Code::INTERNAL,
-            "Failed to add Pinned Memory buffer with host policy: " +
-                std::string(ex.what()));
-      }
+    }
+    else
+    {
+      LOG_INFO << "Pinned memory pool disabled";
     }
     // If no pinned memory is allocated, add an empty entry where all allocation
     // will be on normal system memory

--- a/src/pinned_memory_manager.cc
+++ b/src/pinned_memory_manager.cc
@@ -356,26 +356,24 @@ PinnedMemoryManager::Create(const Options& options)
               "Failed to add Pinned Memory buffer with host policy: " +
                   std::string(ex.what()));
         }
+      } else {
+        LOG_INFO << "Pinned memory pool disabled";
       }
-    }
-    else
-    {
-      LOG_INFO << "Pinned memory pool disabled";
-    }
-    // If no pinned memory is allocated, add an empty entry where all allocation
-    // will be on normal system memory
-    if (instance_->pinned_memory_buffers_.empty()) {
-      try {
-        instance_->AddPinnedMemoryBuffer(
-            std::shared_ptr<PinnedMemory>(new PinnedMemory(
-                nullptr, options.pinned_memory_pool_byte_size_)),
-            0);
-      }
-      catch (const std::exception& ex) {
-        return Status(
-            Status::Code::INTERNAL,
-            "Failed to add empty Pinned Memory entry: " +
-                std::string(ex.what()));
+      // If no pinned memory is allocated, add an empty entry where all
+      // allocation will be on normal system memory
+      if (instance_->pinned_memory_buffers_.empty()) {
+        try {
+          instance_->AddPinnedMemoryBuffer(
+              std::shared_ptr<PinnedMemory>(new PinnedMemory(
+                  nullptr, options.pinned_memory_pool_byte_size_)),
+              0);
+        }
+        catch (const std::exception& ex) {
+          return Status(
+              Status::Code::INTERNAL,
+              "Failed to add empty Pinned Memory entry: " +
+                  std::string(ex.what()));
+        }
       }
     }
   }

--- a/src/pinned_memory_manager.cc
+++ b/src/pinned_memory_manager.cc
@@ -36,8 +36,7 @@
 #include <cuda_runtime_api.h>
 #endif  // TRITON_ENABLE_GPU
 
-namespace triton {
-namespace core {
+namespace triton { namespace core {
 
 namespace {
 
@@ -264,8 +263,8 @@ PinnedMemoryManager::Create(const Options& options)
   instance_.reset(new PinnedMemoryManager());
   if (options.host_policy_map_.empty()) {
     void* buffer = nullptr;
-    if (options.pinned_memory_pool_byte_size_ > 0) {
 #ifdef TRITON_ENABLE_GPU
+    if (options.pinned_memory_pool_byte_size_ > 0) {
       auto err = cudaHostAlloc(
           &buffer, options.pinned_memory_pool_byte_size_,
           cudaHostAllocPortable);
@@ -325,8 +324,8 @@ PinnedMemoryManager::Create(const Options& options)
         continue;
       }
       void* buffer = nullptr;
-      if (options.pinned_memory_pool_byte_size_ > 0) {
 #ifdef TRITON_ENABLE_GPU
+      if (options.pinned_memory_pool_byte_size_ > 0) {
         auto err = cudaHostAlloc(
             &buffer, options.pinned_memory_pool_byte_size_,
             cudaHostAllocPortable);
@@ -357,84 +356,89 @@ PinnedMemoryManager::Create(const Options& options)
               "Failed to add Pinned Memory buffer with host policy: " +
                   std::string(ex.what()));
         }
-      } else {
-        LOG_INFO << "Pinned memory pool disabled";
-      }
-      // If no pinned memory is allocated, add an empty entry where all
-      // allocation will be on normal system memory
-      if (instance_->pinned_memory_buffers_.empty()) {
-        try {
-          instance_->AddPinnedMemoryBuffer(
-              std::shared_ptr<PinnedMemory>(new PinnedMemory(
-                  nullptr, options.pinned_memory_pool_byte_size_)),
-              0);
-        }
-        catch (const std::exception& ex) {
-          return Status(
-              Status::Code::INTERNAL,
-              "Failed to add empty Pinned Memory entry: " +
-                  std::string(ex.what()));
-        }
       }
     }
-    pinned_memory_byte_size_ = options.pinned_memory_pool_byte_size_;
-    return Status::Success;
-  }
-
-  Status PinnedMemoryManager::Alloc(
-      void** ptr, uint64_t size, TRITONSERVER_MemoryType* allocated_type,
-      bool allow_nonpinned_fallback)
-  {
-    if (instance_ == nullptr) {
-      return Status(
-          Status::Code::UNAVAILABLE,
-          "PinnedMemoryManager has not been created");
+    else
+    {
+      LOG_INFO << "Pinned memory pool disabled";
     }
-
-    auto pinned_memory_buffer =
-        instance_->pinned_memory_buffers_.begin()->second.get();
-    if (instance_->pinned_memory_buffers_.size() > 1) {
-      unsigned long node_mask;
-      if (GetNumaMemoryPolicyNodeMask(&node_mask).IsOk()) {
-        auto it = instance_->pinned_memory_buffers_.find(node_mask);
-        if (it != instance_->pinned_memory_buffers_.end()) {
-          pinned_memory_buffer = it->second.get();
-        }
+    // If no pinned memory is allocated, add an empty entry where all allocation
+    // will be on normal system memory
+    if (instance_->pinned_memory_buffers_.empty()) {
+      try {
+        instance_->AddPinnedMemoryBuffer(
+            std::shared_ptr<PinnedMemory>(new PinnedMemory(
+                nullptr, options.pinned_memory_pool_byte_size_)),
+            0);
+      }
+      catch (const std::exception& ex) {
+        return Status(
+            Status::Code::INTERNAL,
+            "Failed to add empty Pinned Memory entry: " +
+                std::string(ex.what()));
       }
     }
-
-    return instance_->AllocInternal(
-        ptr, size, allocated_type, allow_nonpinned_fallback,
-        pinned_memory_buffer);
   }
-
-  Status PinnedMemoryManager::Free(void* ptr)
-  {
-    if (instance_ == nullptr) {
-      return Status(
-          Status::Code::UNAVAILABLE,
-          "PinnedMemoryManager has not been created");
-    }
-
-    return instance_->FreeInternal(ptr);
-  }
-
-  uint64_t PinnedMemoryManager::GetTotalPinnedMemoryByteSize()
-  {
-    return pinned_memory_byte_size_;
-  }
-
-  uint64_t PinnedMemoryManager::GetUsedPinnedMemoryByteSize()
-  {
-    std::lock_guard<std::mutex> lk(allocated_buffer_mtx_);
-    uint64_t used_pinned_memory_size = 0;
-    if (!allocated_pinned_memory_buffers_.empty()) {
-      for (const auto& it : allocated_pinned_memory_buffers_) {
-        used_pinned_memory_size += it->GetUsedPinnedMemorySizeInternal();
-      }
-    }
-
-    return used_pinned_memory_size;
-  }
+  pinned_memory_byte_size_ = options.pinned_memory_pool_byte_size_;
+  return Status::Success;
 }
-}  // namespace triton::core
+
+Status
+PinnedMemoryManager::Alloc(
+    void** ptr, uint64_t size, TRITONSERVER_MemoryType* allocated_type,
+    bool allow_nonpinned_fallback)
+{
+  if (instance_ == nullptr) {
+    return Status(
+        Status::Code::UNAVAILABLE, "PinnedMemoryManager has not been created");
+  }
+
+  auto pinned_memory_buffer =
+      instance_->pinned_memory_buffers_.begin()->second.get();
+  if (instance_->pinned_memory_buffers_.size() > 1) {
+    unsigned long node_mask;
+    if (GetNumaMemoryPolicyNodeMask(&node_mask).IsOk()) {
+      auto it = instance_->pinned_memory_buffers_.find(node_mask);
+      if (it != instance_->pinned_memory_buffers_.end()) {
+        pinned_memory_buffer = it->second.get();
+      }
+    }
+  }
+
+  return instance_->AllocInternal(
+      ptr, size, allocated_type, allow_nonpinned_fallback,
+      pinned_memory_buffer);
+}
+
+Status
+PinnedMemoryManager::Free(void* ptr)
+{
+  if (instance_ == nullptr) {
+    return Status(
+        Status::Code::UNAVAILABLE, "PinnedMemoryManager has not been created");
+  }
+
+  return instance_->FreeInternal(ptr);
+}
+
+uint64_t
+PinnedMemoryManager::GetTotalPinnedMemoryByteSize()
+{
+  return pinned_memory_byte_size_;
+}
+
+uint64_t
+PinnedMemoryManager::GetUsedPinnedMemoryByteSize()
+{
+  std::lock_guard<std::mutex> lk(allocated_buffer_mtx_);
+  uint64_t used_pinned_memory_size = 0;
+  if (!allocated_pinned_memory_buffers_.empty()) {
+    for (const auto& it : allocated_pinned_memory_buffers_) {
+      used_pinned_memory_size += it->GetUsedPinnedMemorySizeInternal();
+    }
+  }
+
+  return used_pinned_memory_size;
+}
+
+}}  // namespace triton::core

--- a/src/pinned_memory_manager.cc
+++ b/src/pinned_memory_manager.cc
@@ -263,8 +263,8 @@ PinnedMemoryManager::Create(const Options& options)
   instance_.reset(new PinnedMemoryManager());
   if (options.host_policy_map_.empty()) {
     void* buffer = nullptr;
-#ifdef TRITON_ENABLE_GPU
     if (options.pinned_memory_pool_byte_size_ > 0) {
+#ifdef TRITON_ENABLE_GPU
       auto err = cudaHostAlloc(
           &buffer, options.pinned_memory_pool_byte_size_,
           cudaHostAllocPortable);
@@ -324,8 +324,8 @@ PinnedMemoryManager::Create(const Options& options)
         continue;
       }
       void* buffer = nullptr;
-#ifdef TRITON_ENABLE_GPU
       if (options.pinned_memory_pool_byte_size_ > 0) {
+#ifdef TRITON_ENABLE_GPU
         auto err = cudaHostAlloc(
             &buffer, options.pinned_memory_pool_byte_size_,
             cudaHostAllocPortable);

--- a/src/server.cc
+++ b/src/server.cc
@@ -201,15 +201,11 @@ InferenceServer::Init()
     ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
     return status;
   }
-  if (pinned_memory_pool_size_ > 0) {
-    PinnedMemoryManager::Options options(pinned_memory_pool_size_);
-    status = PinnedMemoryManager::Create(options);
-    if (!status.IsOk()) {
-      ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
-      return status;
-    }
-  } else {
-    LOG_INFO << "Pinned memory pool disabled";
+  PinnedMemoryManager::Options options(pinned_memory_pool_size_);
+  status = PinnedMemoryManager::Create(options);
+  if (!status.IsOk()) {
+    ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
+    return status;
   }
 
 #ifdef TRITON_ENABLE_GPU


### PR DESCRIPTION
1. Update C API version for changes in 
"Added new flag for GPU peer access API control #361"
2. Fix a seg fault in PinnedMemoryManager::AllocInternal(

Seg Fault Details:

Triton tries to access pinned_memory_buffer [here](https://github.com/triton-inference-server/core/blob/190d8e3b7e5cf89234a4e8b7006f8b87bfa4c237/src/pinned_memory_manager.cc#L153)
Which was null because of the new change introduced in #361.

Triton behavior is to verify it failed to allocate pinned memory by looping through pinned_memory_buffer AND then do a malloc. This looks like a design choice made.

