### PR TITLE
ci: Restrict numpy to version 1.x

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/python/setup.py
+++ b/python/setup.py
@@ -108,6 +108,6 @@ setup(
     zip_safe=False,
     cmdclass={"bdist_wheel": bdist_wheel},
     data_files=data_files,
-    install_requires=["numpy"],
+    install_requires=["numpy<2"],
     extras_require={"GPU": gpu_extras, "test": test_extras, "all": all_extras},
 )


### PR DESCRIPTION
Numpy 2.0 introduces breaking changes, so proactively making sure this is accounted for.

Credit to @rmccorm4 for pointing out the issue.