### PR TITLE
fix: Fix response iterator in Python In-Process API

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -455,15 +455,20 @@ class InferenceTests(unittest.TestCase):
             "bool_input": numpy.random.rand(1, 100).astype(dtype=numpy.bool_),
         }
 
-        for response in server.model("test").infer(
+        response_iterator = server.model("test").infer(
             inputs=inputs,
             output_memory_type="cpu",
             raise_on_error=True,
-        ):
-            for input_name, input_value in inputs.items():
-                output_value = response.outputs[input_name.replace("input", "output")]
-                output_value = numpy.from_dlpack(output_value)
-                numpy.testing.assert_array_equal(input_value, output_value)
+        )
+
+        responses = list(response_iterator)
+        self.assertTrue(len(responses), 1)
+        response = responses[0]
+
+        for input_name, input_value in inputs.items():
+            output_value = response.outputs[input_name.replace("input", "output")]
+            output_value = numpy.from_dlpack(output_value)
+            numpy.testing.assert_array_equal(input_value, output_value)
 
         # test normal bool
         inputs = {"bool_input": [[True, False, False, True]]}

--- a/python/tritonserver/_api/_response.py
+++ b/python/tritonserver/_api/_response.py
@@ -29,7 +29,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import queue
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Optional
@@ -182,9 +181,6 @@ class AsyncResponseIterator:
                 asyncio.run_coroutine_threadsafe(
                     self._user_queue.put(response), self._loop
                 )
-            if flags == TRITONSERVER_ResponseCompleteFlag.FINAL:
-                del self._request
-                self._request = None
         except Exception as e:
             message = f"Catastrophic failure in response callback: {e}"
             LogMessage(LogLevel.ERROR, message)
@@ -308,9 +304,6 @@ class ResponseIterator:
             self._queue.put(response)
             if self._user_queue is not None:
                 self._user_queue.put(response)
-            if flags == TRITONSERVER_ResponseCompleteFlag.FINAL:
-                del self._request
-                self._request = None
         except Exception as e:
             message = f"Catastrophic failure in response callback: {e}"
             LogMessage(LogLevel.ERROR, message)


### PR DESCRIPTION
#### What does the PR do?
The response iterator destroyed the request object after final response is received which lead to destruction of the queue and responses not being retrieved by the user.


#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [X] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
Updated L0_python_api.

- CI Pipeline ID:
15804851

#### Caveats:
N/A

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
