### PR TITLE
Fix shape and reformat free tensor handling in the input byte size check

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1200,7 +1200,6 @@ InferenceRequest::Normalize()
     // make sure that all the normalization is before the check.
     {
       const auto& data_type = input.DType();
-      bool skip_byte_size_check = false;
 
       if (!input.IsReformatFreeTensor()) {
         TRITONSERVER_MemoryType input_memory_type;

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1201,6 +1201,8 @@ InferenceRequest::Normalize()
     {
       const auto& data_type = input.DType();
 
+      // Non-linear IO format input byte size validation will be handled in the
+      // backend.
       if (!input.IsNonLinearFormatIo()) {
         TRITONSERVER_MemoryType input_memory_type;
         // Because Triton expects STRING type to be in special format
@@ -1213,6 +1215,9 @@ InferenceRequest::Normalize()
           // FIXME: Temporarily skips byte size checks for GPU tensors. See
           // DLIS-6820.
         } else {
+          // Shape tensor with dynamic batching does not introduce a new
+          // dimension to the tensor but adds an additional value to the 1-D
+          // array.
           const std::vector<int64_t>& input_dims =
               input.IsShapeTensor() ? input.OriginalShape()
                                     : input.ShapeWithBatchDim();

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1563,7 +1563,7 @@ Status
 InferenceRequest::Input::SetIsNonLinearFormatIo(
     const bool is_non_linear_format_io)
 {
-  is_non_linear_  format_io_ = is_non_linear_format_io;
+  is_non_linear_format_io_ = is_non_linear_format_io;
   return Status::Success;
 }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1211,7 +1211,12 @@ InferenceRequest::Normalize()
           // FIXME: Temporarily skips byte size checks for GPU tensors. See
           // DLIS-6820.
         } else {
-          const std::vector<int64_t>& input_dims = input.ShapeWithBatchDim();
+          // Shape tensor with dynamic batching does not introduce a new
+          // dimension to the tensor but adds an additional value to the 1-D
+          // array.
+          const std::vector<int64_t>& input_dims =
+              input.IsShapeTensor() ? input.OriginalShape()
+                                    : input.ShapeWithBatchDim();
           int64_t expected_byte_size = INT_MAX;
           expected_byte_size =
               triton::common::GetByteSize(data_type, input_dims);

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1023,10 +1023,10 @@ InferenceRequest::Normalize()
         input.SetIsShapeTensor(true);
       }
 
-      // For a refromat-free tensor, mark that the input is a refromat-free
-      // tensor.
-      if (input_config->is_reformat_free_tensor()) {
-        input.SetIsReformatFreeTensor(true);
+      // If a tensor uses a non-linear IO format, indicate that the input uses a
+      // non-linear IO format.
+      if (input_config->is_non_linear_format_io()) {
+        input.SetIsNonLinearFormatIo(true);
       }
     }
   } else {
@@ -1040,10 +1040,10 @@ InferenceRequest::Normalize()
       const inference::ModelInput* input_config;
       RETURN_IF_ERROR(model_raw_->GetInput(input.Name(), &input_config));
 
-      // For a refromat-free tensor, mark that the input is a refromat-free
-      // tensor.
-      if (input_config->is_reformat_free_tensor()) {
-        input.SetIsReformatFreeTensor(true);
+      // If a tensor uses a non-linear IO format, indicate that the input uses a
+      // non-linear IO format.
+      if (input_config->is_non_linear_format_io()) {
+        input.SetIsNonLinearFormatIo(true);
       }
 
       // For a shape tensor, keep the tensor's shape as it is and mark
@@ -1201,7 +1201,7 @@ InferenceRequest::Normalize()
     {
       const auto& data_type = input.DType();
 
-      if (!input.IsReformatFreeTensor()) {
+      if (!input.IsNonLinearFormatIo()) {
         TRITONSERVER_MemoryType input_memory_type;
         // Because Triton expects STRING type to be in special format
         // (prepend 4 bytes to specify string length), so need to add all the
@@ -1518,7 +1518,7 @@ InferenceRequest::ReportStatisticsCacheHit(MetricModelReporter* metric_reporter)
 // Input
 //
 InferenceRequest::Input::Input()
-    : is_shape_tensor_(false), is_reformat_free_tensor_(false),
+    : is_shape_tensor_(false), is_non_linear_format_io_(false),
       data_(new MemoryReference), has_host_policy_specific_data_(false)
 {
 }
@@ -1528,7 +1528,7 @@ InferenceRequest::Input::Input(
     const int64_t* shape, const uint64_t dim_count)
     : name_(name), datatype_(datatype),
       original_shape_(shape, shape + dim_count), is_shape_tensor_(false),
-      is_reformat_free_tensor_(false), data_(new MemoryReference),
+      is_non_linear_format_io_(false), data_(new MemoryReference),
       has_host_policy_specific_data_(false)
 {
 }
@@ -1537,7 +1537,7 @@ InferenceRequest::Input::Input(
     const std::string& name, const inference::DataType datatype,
     const std::vector<int64_t>& shape)
     : name_(name), datatype_(datatype), original_shape_(shape),
-      is_shape_tensor_(false), is_reformat_free_tensor_(false),
+      is_shape_tensor_(false), is_non_linear_format_io_(false),
       data_(new MemoryReference), has_host_policy_specific_data_(false)
 {
 }
@@ -1560,10 +1560,10 @@ InferenceRequest::Input::SetIsShapeTensor(const bool is_shape_tensor)
 }
 
 Status
-InferenceRequest::Input::SetIsReformatFreeTensor(
-    const bool is_reformat_free_tensor)
+InferenceRequest::Input::SetIsNonLinearFormatIo(
+    const bool is_non_linear_format_io)
 {
-  is_reformat_free_tensor_ = is_reformat_free_tensor;
+  is_non_linear_  format_io_ = is_non_linear_format_io;
   return Status::Success;
 }
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -122,14 +122,7 @@ class InferenceRequest {
     // into batch + shape.
     const std::vector<int64_t>& ShapeWithBatchDim() const
     {
-      if (tensor_type_ == TensorType::SHAPE_TENSOR) {
-        // Shape tensor with dynamic batching does not introduce a new
-        // dimension to the tensor but adds an additional value to the 1-D
-        // array.
-        return original_shape_;
-      } else {
         return shape_with_batch_dim_;
-      }
     }
     std::vector<int64_t>* MutableShapeWithBatchDim()
     {

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -122,7 +122,7 @@ class InferenceRequest {
     // into batch + shape.
     const std::vector<int64_t>& ShapeWithBatchDim() const
     {
-        return shape_with_batch_dim_;
+      return shape_with_batch_dim_;
     }
     std::vector<int64_t>* MutableShapeWithBatchDim()
     {

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -136,8 +136,14 @@ class InferenceRequest {
     // Whether or not the input is a tensorrt shape tensor
     bool IsShapeTensor() const { return is_shape_tensor_; }
 
+    // Whether or not the input is a tensorrt reformat-free tensor
+    bool IsReformatFreeTensor() const { return is_reformat_free_tensor_; }
+
     // Set the input to be treated as a shape tensor.
     Status SetIsShapeTensor(const bool is_shape_tensor);
+
+    // Set the input to be treated as a reformat-free tensor.
+    Status SetIsReformatFreeTensor(const bool is_reformat_free_tensor);
 
     // The data for this input.
     const std::shared_ptr<Memory>& Data() const { return data_; }
@@ -241,6 +247,7 @@ class InferenceRequest {
     std::vector<int64_t> shape_;
     std::vector<int64_t> shape_with_batch_dim_;
     bool is_shape_tensor_;
+    bool is_reformat_free_tensor_;
     std::shared_ptr<Memory> data_;
 
     bool has_host_policy_specific_data_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -136,14 +136,14 @@ class InferenceRequest {
     // Whether or not the input is a tensorrt shape tensor
     bool IsShapeTensor() const { return is_shape_tensor_; }
 
-    // Whether or not the input is a tensorrt reformat-free tensor
-    bool IsReformatFreeTensor() const { return is_reformat_free_tensor_; }
+    // Specifies whether the input uses a non-linear IO format
+    bool IsNonLinearFormatIo() const { return is_non_linear_format_io_; }
 
     // Set the input to be treated as a shape tensor.
     Status SetIsShapeTensor(const bool is_shape_tensor);
 
-    // Set the input to be treated as a reformat-free tensor.
-    Status SetIsReformatFreeTensor(const bool is_reformat_free_tensor);
+    // Set the input uses a non-linear IO format
+    Status SetIsNonLinearFormatIo(const bool is_non_linear_format_io_);
 
     // The data for this input.
     const std::shared_ptr<Memory>& Data() const { return data_; }
@@ -247,7 +247,7 @@ class InferenceRequest {
     std::vector<int64_t> shape_;
     std::vector<int64_t> shape_with_batch_dim_;
     bool is_shape_tensor_;
-    bool is_reformat_free_tensor_;
+    bool is_non_linear_format_io_;
     std::shared_ptr<Memory> data_;
 
     bool has_host_policy_specific_data_;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1716,13 +1716,18 @@ Status
 ValidateNonLinearFormatIO(
     const inference::ModelInput& io, const std::string& platform, bool is_input)
 {
-  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io()) {
+  if (!io.is_non_linear_format_io()) {
+    // Nothing to validate as the tensor is not non-linear format.
+    return Status::Success;
+  }
+
+  if (platform != kTensorRTPlanPlatform) {
     return Status(
         Status::Code::INVALID_ARG,
         "Non-linear IO format is only supported for the TensorRT platform");
   }
 
-  if (io.is_non_linear_format_io() && (io.dims_size() != 3)) {
+  if (io.dims_size() != 3) {
     std::string io_type = is_input ? "input" : "output";
     return Status(
         Status::Code::INVALID_ARG,

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1740,8 +1740,7 @@ ValidateModelInput(
 
   if (io.is_non_linear_format_io() && (io.dims_size() != 3)) {
     return Status(
-        Status::Code::INVALID_ARG,
-        "Non-linear IO format input require 3 dims");
+        Status::Code::INVALID_ARG, "Non-linear IO format input require 3 dims");
   }
 
   return Status::Success;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1732,15 +1732,16 @@ ValidateModelInput(
         "shape tensors are only supported for TensorRT platform");
   }
 
-  if ((platform != kTensorRTPlanPlatform) && io.is_reformat_free_tensor()) {
+  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io_()) {
     return Status(
         Status::Code::INVALID_ARG,
-        "Reformat-free tensors are only supported for the TensorRT platform");
+        "Non-linear IO format is only supported for the TensorRT platform");
   }
 
-  if (io.is_reformat_free_tensor() && (io.dims_size() != 3)) {
+  if (io.is_non_linear_format_io_() && (io.dims_size() != 3)) {
     return Status(
-        Status::Code::INVALID_ARG, "Reformat-free tensor input require 3 dims");
+        Status::Code::INVALID_ARG,
+        "Non-linear IO format require input with 3 dims");
   }
 
   return Status::Success;
@@ -1779,10 +1780,10 @@ ValidateModelOutput(
         "shape tensors are only supported for TensorRT platform");
   }
 
-  if ((platform != kTensorRTPlanPlatform) && io.is_reformat_free_tensor()) {
+  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io_()) {
     return Status(
         Status::Code::INVALID_ARG,
-        "Reformat-free tensors are only supported for the TensorRT platform");
+        "Non-linear IO format is only supported for the TensorRT platform");
   }
 
   return Status::Success;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1741,7 +1741,7 @@ ValidateModelInput(
   if (io.is_non_linear_format_io() && (io.dims_size() != 3)) {
     return Status(
         Status::Code::INVALID_ARG,
-        "Non-linear IO format require input with 3 dims");
+        "Non-linear IO format input require 3 dims");
   }
 
   return Status::Success;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1732,13 +1732,13 @@ ValidateModelInput(
         "shape tensors are only supported for TensorRT platform");
   }
 
-  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io_()) {
+  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io()) {
     return Status(
         Status::Code::INVALID_ARG,
         "Non-linear IO format is only supported for the TensorRT platform");
   }
 
-  if (io.is_non_linear_format_io_() && (io.dims_size() != 3)) {
+  if (io.is_non_linear_format_io() && (io.dims_size() != 3)) {
     return Status(
         Status::Code::INVALID_ARG,
         "Non-linear IO format require input with 3 dims");
@@ -1780,7 +1780,7 @@ ValidateModelOutput(
         "shape tensors are only supported for TensorRT platform");
   }
 
-  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io_()) {
+  if ((platform != kTensorRTPlanPlatform) && io.is_non_linear_format_io()) {
     return Status(
         Status::Code::INVALID_ARG,
         "Non-linear IO format is only supported for the TensorRT platform");

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -418,6 +418,34 @@ ValidateIOShape(
   return Status::Success;
 }
 
+/// Validate that Non-linear format inputs or outputs are specified correctly
+/// in a model configuration.
+template <class ModelIO>
+Status
+ValidateNonLinearFormatIO(
+    const ModelIO& io, const std::string& platform, bool is_input)
+{
+  if (!io.is_non_linear_format_io()) {
+    // Nothing to validate as the tensor is not non-linear format.
+    return Status::Success;
+  }
+
+  if (platform != kTensorRTPlanPlatform) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Non-linear IO format is only supported for the TensorRT platform");
+  }
+
+  if (io.dims_size() != 3) {
+    std::string io_type = is_input ? "input" : "output";
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Non-linear IO format " + io_type + " requires 3 dims");
+  }
+
+  return Status::Success;
+}
+
 }  // namespace
 
 Status
@@ -1709,31 +1737,6 @@ ValidateInstanceGroup(
       }
     }
   }
-  return Status::Success;
-}
-
-Status
-ValidateNonLinearFormatIO(
-    const inference::ModelInput& io, const std::string& platform, bool is_input)
-{
-  if (!io.is_non_linear_format_io()) {
-    // Nothing to validate as the tensor is not non-linear format.
-    return Status::Success;
-  }
-
-  if (platform != kTensorRTPlanPlatform) {
-    return Status(
-        Status::Code::INVALID_ARG,
-        "Non-linear IO format is only supported for the TensorRT platform");
-  }
-
-  if (io.dims_size() != 3) {
-    std::string io_type = is_input ? "input" : "output";
-    return Status(
-        Status::Code::INVALID_ARG,
-        "Non-linear IO format " + io_type + " requires 3 dims");
-  }
-
   return Status::Success;
 }
 

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1732,6 +1732,17 @@ ValidateModelInput(
         "shape tensors are only supported for TensorRT platform");
   }
 
+  if ((platform != kTensorRTPlanPlatform) && io.is_reformat_free_tensor()) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Reformat-free tensors are only supported for the TensorRT platform");
+  }
+
+  if (io.is_reformat_free_tensor() && (io.dims_size() != 3)) {
+    return Status(
+        Status::Code::INVALID_ARG, "Reformat-free tensor input require 3 dims");
+  }
+
   return Status::Success;
 }
 
@@ -1766,6 +1777,12 @@ ValidateModelOutput(
     return Status(
         Status::Code::INVALID_ARG,
         "shape tensors are only supported for TensorRT platform");
+  }
+
+  if ((platform != kTensorRTPlanPlatform) && io.is_reformat_free_tensor()) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "Reformat-free tensors are only supported for the TensorRT platform");
   }
 
   return Status::Success;

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -172,6 +172,17 @@ Status ValidateInstanceGroup(
 /// is not valid.
 Status ValidateModelIOConfig(const inference::ModelConfig& config);
 
+/// Validate that Non-linear format inputs or outputs are specified correctly
+/// in a model configuration.
+/// \param io The model input.
+/// \param platform The platform name
+/// \param is_input Specifies whether it is an input or an output.
+/// \return The error status. A non-OK status indicates the configuration
+/// is not valid.
+Status ValidateNonLinearFormatIO(
+    const inference::ModelInput& io, const std::string& platform,
+    bool is_input);
+
 /// Validate that input is specified correctly in a model
 /// configuration.
 /// \param io The model input.

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -172,17 +172,6 @@ Status ValidateInstanceGroup(
 /// is not valid.
 Status ValidateModelIOConfig(const inference::ModelConfig& config);
 
-/// Validate that Non-linear format inputs or outputs are specified correctly
-/// in a model configuration.
-/// \param io The model input.
-/// \param platform The platform name
-/// \param is_input Specifies whether it is an input or an output.
-/// \return The error status. A non-OK status indicates the configuration
-/// is not valid.
-Status ValidateNonLinearFormatIO(
-    const inference::ModelInput& io, const std::string& platform,
-    bool is_input);
-
 /// Validate that input is specified correctly in a model
 /// configuration.
 /// \param io The model input.

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -70,8 +70,9 @@ InferenceRequest::Input::Input(
     const std::string& name, const inference::DataType datatype,
     const int64_t* shape, const uint64_t dim_count)
     : name_(name), datatype_(datatype),
-      original_shape_(shape, shape + dim_count), is_shape_tensor_(false),
-      data_(new MemoryReference), has_host_policy_specific_data_(false)
+      original_shape_(shape, shape + dim_count),
+      tensor_type_(TensorType::TENSOR), data_(new MemoryReference),
+      has_host_policy_specific_data_(false)
 {
 }
 


### PR DESCRIPTION
- Added support for the `is_non_linear_format_io` flag in the model configuration to identify if input/output tensors use a non-linear IO format.
- For shape tensors, use the original shape for byte size validation.
- For tensors using the non-linear IO format (reformat-free tensors), validate the input byte size in the backend.