### PR TITLE
fix: Release GIL during server.stop() to allow request release callbacks to complete

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -345,11 +345,6 @@ class ServerTests(unittest.TestCase):
         server = tritonserver.Server(self._server_options).start()
         self.assertTrue(server.ready())
 
-    @pytest.mark.xfail(
-        tritonserver.__version__ <= "2.48.0",
-        reason="Known issue on stop: Exit timeout expired. Exiting immediately",
-        raises=tritonserver.InternalError,
-    )
     def test_stop(self):
         server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
 

--- a/python/tritonserver/_c/tritonserver_pybind.cc
+++ b/python/tritonserver/_c/tritonserver_pybind.cc
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/python/tritonserver/_c/tritonserver_pybind.cc
+++ b/python/tritonserver/_c/tritonserver_pybind.cc
@@ -1434,7 +1434,18 @@ class PyServer : public PyWrapper<struct TRITONSERVER_Server> {
     owned_ = true;
   }
 
-  void Stop() const { ThrowIfError(TRITONSERVER_ServerStop(triton_object_)); }
+  void Stop() const
+  {
+    // ServerStop is blocking for the duration of the server exit timeout, so
+    // ensure to release the GIL. This can allow request release callbacks
+    // to be interleaved while server is waiting for live requests/models
+    // to complete. Without releasing GIL, this function may acquire the GIL
+    // first and block the Triton request from being released/freed, thus
+    // blocking the server's shutdown in a circular manner thinking a model is
+    // still alive.
+    py::gil_scoped_release release;
+    ThrowIfError(TRITONSERVER_ServerStop(triton_object_));
+  }
 
   void RegisterModelRepository(
       const std::string& repository_path,


### PR DESCRIPTION
#### What does the PR do?

This PR fixes an issue where `server.stop()` in the `L0_python_api::test_api::test_stop()` unit test would intermittently fail waiting the full server exit timeout, waiting for all "live models" to be unloaded. However, the "live models" were not getting unloaded because the relevant request object was not getting destructed before `server.stop()`. The Triton C++ request object holds a reference to a Triton Model object, preventing the model from getting destructed and unloaded, thus preventing the server from shutting down gracefully.

The root cause was that the final reference to the request object would be decremented by the request release callback internally in the python core bindings - but this callback was trying to [acquire the Python GIL](https://github.com/triton-inference-server/core/blob/8153c2eb546ba7ff7f8d11985b009d28a1ab6a53/python/tritonserver/_c/tritonserver_pybind.cc#L962). If `server.stop()` was executed first and acquired the GIL, the request release callback (and request destruction) would be blocked for the full exit timeout until `server.stop()` returns/raises. Similarly, the `server.stop()` call would be blocked waiting for the request (and model) to be destructed for the full exit timeout. 

The solution in this PR is to release the GIL internally while making the call to `TRITONSERVER_ServerStop`, which allows the `PyTritonRequestReleaseCallback` to acquire the GIL, proceed, release the final reference to the request, destroy the request and model, and allow the server to gracefully shutdown.

**NOTE**: See the **Caveats** below.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:

N/A

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- `L0_python_api`
- CI Pipeline ID: 16660542

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

There was a pre-existing issue with the current bindings and test, where if you omit the `server.stop()` call and let the server object simply go out of scope, it may run into the same issue this PR fixes with the manual call to `server.stop()`. This is because the C++ implementation of TRITONSERVER_ServerDelete also calls server->Stop().

This leads to a "Exit timeout expired" message being printed to STDOUT for some tests when run the test with `pytest -s -v test_api.py`, for example:
```
$ pytest -v -s test_api.py
...
test_api.py::ModelTests::test_create_request PASSED
test_api.py::AllocatorTests::test_allocate_on_cpu_and_reshape SKIPPED (Skipping test, torch not installed)
test_api.py::AllocatorTests::test_allocate_on_gpu_and_reshape SKIPPED (Skipping test, torch not installed)
test_api.py::AllocatorTests::test_memory_allocator_exception PASSED
test_api.py::AllocatorTests::test_memory_fallback_to_cpu PASSED Exit timeout expired. Exiting immediately.  <---
test_api.py::AllocatorTests::test_unsupported_memory_type PASSED
test_api.py::TensorTests::test_cpu_to_gpu PASSED
test_api.py::TensorTests::test_gpu_tensor_from_dl_pack SKIPPED (Skipping gpu memory, torch not installed)
test_api.py::TensorTests::test_tensor_from_numpy SKIPPED (Skipping test, torch not installed)
test_api.py::ServerTests::test_invalid_option_type PASSED
test_api.py::ServerTests::test_invalid_repo PASSED
test_api.py::ServerTests::test_model_repository_not_specified PASSED
test_api.py::ServerTests::test_not_started PASSED
test_api.py::ServerTests::test_ready PASSED
test_api.py::ServerTests::test_stop PASSED
test_api.py::InferenceTests::test_basic_inference PASSED Exit timeout expired. Exiting immediately.  <---
test_api.py::InferenceTests::test_gpu_output PASSED
test_api.py::InferenceTests::test_parameters PASSED Exit timeout expired. Exiting immediately.  <---
```

This issue shouldn't be ignored, and may have a similar solution to this PR.  However, a couple naive attempts to apply the same fix to this issue caused some crashes/segfaults, so it will require further investigation to fix and this was already broken beforehand - so I'd like to merge this fix in first to reduce flakiness in CI and investigate the follow-up separately.

#### Background

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A