### PR TITLE
test: Improve stability of server shutdown test in L0_python_api::test_api::test_stop

### DIFF
--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -357,8 +357,11 @@ class ServerTests(unittest.TestCase):
                     {
                         "backend": "python",
                         "parameters": {"decoupled": {"string_value": "False"}},
-                        # Keep instance count low for fast startup/cleanup
-                        "instance_group": [{"kind": "KIND_GPU", "count": 1}],
+                        # Keep instance count low for fast startup/cleanup.
+                        # Alternatively can use KIND_CPU here, but keeping gpus/count explicit.
+                        "instance_group": [
+                            {"kind": "KIND_GPU", "gpus": [0], "count": 1}
+                        ],
                     }
                 )
             },

--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -70,7 +70,7 @@ server_options = tritonserver.Options(
     exit_on_error=True,
     strict_model_config=False,
     model_control_mode=tritonserver.ModelControlMode.EXPLICIT,
-    exit_timeout=10,
+    exit_timeout=30,
 )
 
 
@@ -357,6 +357,8 @@ class ServerTests(unittest.TestCase):
                     {
                         "backend": "python",
                         "parameters": {"decoupled": {"string_value": "False"}},
+                        # Keep instance count low for fast startup/cleanup
+                        "instance_group": [{"kind": "KIND_GPU", "count": 1}],
                     }
                 )
             },


### PR DESCRIPTION
## Problem Analysis

1. Since merging [this PR](https://github.com/triton-inference-server/core/pull/381), I have been unable to reproduce the known failure in test_stop on my **local machine** where the server would take longer to shutdown than the 10 second exit timeout configured in the test.
    - This has included 1000's of runs of specific tests, the whole test suite, variations of the test, different backends, etc.
    - Prior to that PR, I was able to reproduce the issue on my local machine pretty consistently
2. However, the test still appears to be failing (less frequently than before) in our CI pipelines.
3. I have dug further into the code via GDB and breakpoints all over trying to determine a case where the request is still not getting released before or during server shutdown - but was unable to reproduce it or reason about a logical case in the code where it might happen.
4. Upon further analysis of the CI jobs that have been failing, and the job logs of those failed jobs, I observed a few things:
    - In the recently failed jobs, the request is actually getting released, and the instances are calling finalize() to get destroyed:

  ```
  I0723 14:14:31.844348 12517 server.cc:305] "Waiting for in-flight requests to complete."
  I0723 14:14:31.844364 12517 model_lifecycle.cc:226] "StopAllModels()"
  I0723 14:14:31.844369 12517 model_lifecycle.cc:244] "InflightStatus()"
  I0723 14:14:31.844373 12517 server.cc:321] "Timeout 10: Found 0 model versions that have in-flight inferences"
  I0723 14:14:31.844400 12517 python_be.cc:2032] "TRITONBACKEND_ModelInstanceExecute: model instance name test_0 released 1 requests"
  ...
  I0723 14:14:31.844482 12517 server.cc:345] "Timeout 10: Found 1 live models and 0 in-flight non-inference requests"
  I0723 14:14:31.844485 12517 server.cc:351] "test v1: UNLOADING"
  I0723 14:14:31.844698 12517 backend_model_instance.cc:806] "Stopping backend thread for test_0..."
  I0723 14:14:31.844819 12517 python_be.cc:2050] "TRITONBACKEND_ModelInstanceFinalize: delete instance state"
  I0723 14:14:32.844616 12517 model_lifecycle.cc:193] "LiveModelStates()"
  I0723 14:14:32.844658 12517 model_lifecycle.cc:268] "BackgroundModelsSize()"
  I0723 14:14:32.844670 12517 server.cc:345] "Timeout 9: Found 1 live models and 0 in-flight non-inference requests"
  ...
  I0723 14:14:41.846338 12517 server.cc:345] "Timeout 0: Found 1 live models and 0 in-flight non-inference requests"
  I0723 14:14:41.846349 12517 server.cc:351] "test v1: UNLOADING"
  FAILED
  ```

The failed jobs only appear to be failing when scheduled to machines with 16 GPUs.

The failed job logs for these 16 GPU machines are attempting to shutdown 16 instances (with default Triton instance group behavior of 1 instance per GPU)

  ```
  I0723 14:14:30.442040 12517 python_be.cc:1933] "TRITONBACKEND_ModelInstanceInitialize: instance initialization successful test_0 (device 0)"
  I0723 14:14:30.442169 12517 backend_model_instance.cc:783] "Starting backend thread for test_0 at nice 0 on device 0..."
  I0723 14:14:30.443583 12517 backend_model.cc:675] "Created model instance named 'test_0' with device id '0'"
  I0723 14:14:30.715163 12517 python_be.cc:1933] "TRITONBACKEND_ModelInstanceInitialize: instance initialization successful test_0 (device 6)"
  I0723 14:14:30.715258 12517 backend_model_instance.cc:783] "Starting backend thread for test_0 at nice 0 on device 6..."
  I0723 14:14:30.717204 12517 backend_model.cc:675] "Created model instance named 'test_0' with device id '6'"
  I0723 14:14:30.951120 12517 python_be.cc:1933] "TRITONBACKEND_ModelInstanceInitialize: instance initialization successful test_0 (device 9)"
  I0723 14:14:30.951248 12517 backend_model_instance.cc:783] "Starting backend thread for test_0 at nice 0 on device 9..."
  I0723 14:14:30.952666 12517 backend_model.cc:675] "Created model instance named 'test_0' with device id '9'"
  I0723 14:14:31.090501 12517 python_be.cc:1933] "TRITONBACKEND_ModelInstanceInitialize: instance initialization successful test_0 (device 12)"
  I0723 14:14:31.090651 12517 backend_model_instance.cc:783] "Starting backend thread for test_0 at nice 0 on device 12..."
  ...
  I0723 14:14:36.817971 12517 python_be.cc:2050] "TRITONBACKEND_ModelInstanceFinalize: delete instance state"
  I0723 14:14:37.019637 12517 python_be.cc:2050] "TRITONBACKEND_ModelInstanceFinalize: delete instance state"
  I0723 14:14:38.207853 12517 python_be.cc:2050] "TRITONBACKEND_ModelInstanceFinalize: delete instance state"
  I0723 14:14:40.163283 12517 python_be.cc:2050] "TRITONBACKEND_ModelInstanceFinalize: delete instance state"
  ...
  ```

5. After this, I tried using 16 instances on my local machine via:
```
"instance_group": [{"kind": "KIND_GPU", "count": 16}]
```
6. This was able to reproduce the failure on my local machine consistently. The request is getting released, and the instances are attempting to shutdown, but it takes longer than the 10 seconds configured to shut down 16 instances.

## Solution

To tackle this, I'm proposing two changes:
1. Increase the exit timeout used in the test from 10 seconds to 30 seconds to match the default value for our `tritonserver` binary, and give us some more runway in testing to reduce chance of intermittence.
2. Explicitly set the instance count to 1 for the test, regardless of the number of GPUs available to the scheduled CI machine. As far as I know, our CI tags actually request 1 GPU, and there is some infra/configuration issue that gives us these 16-GPU machines occasionally for these 1-GPU jobs. 
  - Alternatively, this test happens to be computing on CPU, so it could be set to KIND_CPU as well.
  - However, if later on someone toggled "CPU" to "GPU" without setting "gpus" and "count" fields, we can run into the same issue later. So I opted to make it more explicit with the KIND_GPU setting.

I'd like to merge something like this, and watch the job over the next few weeks to see if it has started to consistently pass or not.