### PR TITLE
Fix documentation and parameter name in TRITONBACKEND_ModelBackend fu…

### DIFF
--- a/include/triton/core/tritonbackend.h
+++ b/include/triton/core/tritonbackend.h
@@ -1100,7 +1100,7 @@ TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelServer(
 /// Get the backend used by the model.
 ///
 /// \param model The model.
-/// \param model Returns the backend object.
+/// \param backend Returns the backend object.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONBACKEND_DECLSPEC TRITONSERVER_Error* TRITONBACKEND_ModelBackend(
     TRITONBACKEND_Model* model, TRITONBACKEND_Backend** backend);


### PR DESCRIPTION
This merge request fixes the parameter naming in the `TRITONBACKEND_ModelBackend` function.

The changes include:

- Clarifying the second parameter description in the comment block to accurately describe its purpose.

Reviewers
 - @szalpal 
 - @tanmayv25 