### PR TITLE
feat: Load new model version should not reload loaded existing model version(s)

### DIFF
--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -2432,13 +2432,15 @@ TritonToDataType(const TRITONSERVER_DataType dtype)
 }
 
 bool
-EquivalentInNonInstanceGroupConfig(
+EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
     const inference::ModelConfig& old_config,
     const inference::ModelConfig& new_config)
 {
   ::google::protobuf::util::MessageDifferencer pb_diff;
   pb_diff.IgnoreField(
       old_config.descriptor()->FindFieldByLowercaseName("instance_group"));
+  pb_diff.IgnoreField(
+      old_config.descriptor()->FindFieldByLowercaseName("version_policy"));
   return pb_diff.Compare(old_config, new_config);
 }
 

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -2432,7 +2432,7 @@ TritonToDataType(const TRITONSERVER_DataType dtype)
 }
 
 bool
-EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
+ConfigChangeRequiresReload(
     const inference::ModelConfig& old_config,
     const inference::ModelConfig& new_config)
 {
@@ -2441,7 +2441,7 @@ EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
       old_config.descriptor()->FindFieldByLowercaseName("instance_group"));
   pb_diff.IgnoreField(
       old_config.descriptor()->FindFieldByLowercaseName("version_policy"));
-  return pb_diff.Compare(old_config, new_config);
+  return !pb_diff.Compare(old_config, new_config);
 }
 
 bool

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -292,10 +292,10 @@ inference::DataType TritonToDataType(const TRITONSERVER_DataType dtype);
 /// configs are equivalent.
 /// \param old_config The old model config.
 /// \param new_config The new model config.
-/// \return True if the model configs are equivalent in all non instance group
-/// and non version policy settings. False if they differ in non instance group
+/// \return False if the model configs are equivalent in all non instance group
+/// and non version policy settings. True if they differ in non instance group
 /// and non version policy settings.
-bool EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
+bool ConfigChangeRequiresReload(
     const inference::ModelConfig& old_config,
     const inference::ModelConfig& new_config);
 

--- a/src/model_config_utils.h
+++ b/src/model_config_utils.h
@@ -288,12 +288,14 @@ TRITONSERVER_DataType DataTypeToTriton(const inference::DataType dtype);
 /// \return The data type.
 inference::DataType TritonToDataType(const TRITONSERVER_DataType dtype);
 
-/// Check if non instance group settings on the model configs are equivalent.
+/// Check if non instance group and non version policy settings on the model
+/// configs are equivalent.
 /// \param old_config The old model config.
 /// \param new_config The new model config.
 /// \return True if the model configs are equivalent in all non instance group
-/// settings. False if they differ in non instance group settings.
-bool EquivalentInNonInstanceGroupConfig(
+/// and non version policy settings. False if they differ in non instance group
+/// and non version policy settings.
+bool EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
     const inference::ModelConfig& old_config,
     const inference::ModelConfig& new_config);
 

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -434,7 +434,7 @@ Status
 ModelLifeCycle::AsyncLoad(
     const ModelIdentifier& model_id, const std::string& model_path,
     const inference::ModelConfig& model_config, const bool is_config_provided,
-    const bool is_model_file_updated,
+    const ModelTimestamp& prev_timestamp, const ModelTimestamp& curr_timestamp,
     const std::shared_ptr<TritonRepoAgentModelList>& agent_model_list,
     std::function<void(Status)>&& OnComplete)
 {
@@ -488,7 +488,8 @@ ModelLifeCycle::AsyncLoad(
       if (serving_model->state_ == ModelReadyState::READY) {
         // The model is currently being served. Check if the model load could
         // be completed with a simple config update.
-        if (!is_model_file_updated && !serving_model->is_ensemble_ &&
+        if (!serving_model->is_ensemble_ &&
+            !prev_timestamp.IsModelVersionModified(curr_timestamp, version) &&
             EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
                 serving_model->model_config_, model_config)) {
           // Update the model

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -489,7 +489,7 @@ ModelLifeCycle::AsyncLoad(
         // The model is currently being served. Check if the model load could
         // be completed with a simple config update.
         if (!is_model_file_updated && !serving_model->is_ensemble_ &&
-            EquivalentInNonInstanceGroupConfig(
+            EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
                 serving_model->model_config_, model_config)) {
           // Update the model
           model_info = serving_model.get();

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -490,7 +490,7 @@ ModelLifeCycle::AsyncLoad(
         // be completed with a simple config update.
         if (!serving_model->is_ensemble_ &&
             !prev_timestamp.IsModelVersionModified(curr_timestamp, version) &&
-            EquivalentInNonInstanceGroupAndNonVersionPolicyConfig(
+            !ConfigChangeRequiresReload(
                 serving_model->model_config_, model_config)) {
           // Update the model
           model_info = serving_model.get();

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -162,6 +162,7 @@ class TritonRepoAgentModelList {
 };
 
 class InferenceServer;
+class ModelTimestamp;
 
 class ModelLifeCycle {
  public:
@@ -183,7 +184,8 @@ class ModelLifeCycle {
   Status AsyncLoad(
       const ModelIdentifier& model_id, const std::string& model_path,
       const inference::ModelConfig& model_config, const bool is_config_provided,
-      const bool is_model_file_updated,
+      const ModelTimestamp& prev_timestamp,
+      const ModelTimestamp& curr_timestamp,
       const std::shared_ptr<TritonRepoAgentModelList>& agent_model_list,
       std::function<void(Status)>&& OnComplete);
 

--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -317,6 +317,7 @@ GetPathModifiedTime(const std::string& path)
 ModelTimestamp::ModelTimestamp(
     const std::string& model_dir_path, const std::string& model_config_path)
 {
+  // DLIS-7221: Raise an exception when failed to create timestamp
   bool init_success =
       ModelDirectoryPathIsValid(model_dir_path) &&
       ReadModelDirectoryTimestamp(model_dir_path, model_config_path) &&

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -63,6 +63,12 @@ class ModelTimestamp {
   void SetModelConfigModifiedTime(const int64_t time_ns);
 
  private:
+  bool ModelDirectoryPathIsValid(const std::string& path) const;
+  bool ReadModelDirectoryTimestamp(
+      const std::string& model_dir_path, const std::string& model_config_path);
+  bool ReadModelDirectoryContentTimestamps(
+      const std::string& model_dir_path, const std::string& model_config_path);
+
   int64_t GetModifiedTime() const;
   int64_t GetModelVersionModifiedTime(const int64_t version) const;
   int64_t GetNonModelConfigNorVersionNorDirModifiedTime() const;

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -52,26 +52,20 @@ enum ActionType { NO_ACTION, LOAD, UNLOAD };
 // Information about timestamps in model directory.
 class ModelTimestamp {
  public:
-  ModelTimestamp() noexcept {}
+  ModelTimestamp() {}
   ModelTimestamp(
       const std::string& model_dir_path, const std::string& model_config_path);
 
-  bool IsModified(const ModelTimestamp& new_timestamp) const noexcept;
+  bool IsModified(const ModelTimestamp& new_timestamp) const;
   bool IsModelVersionModified(
-      const ModelTimestamp& new_timestamp,
-      const int64_t version) const noexcept;
+      const ModelTimestamp& new_timestamp, const int64_t version) const;
 
   void SetModelConfigModifiedTime(const int64_t time_ns);
 
  private:
-  void AssertPathIsDirectory(const std::string& path) const;
-  void PopulateModelDirectoryTime(const std::string& dir_path);
-  void PopulateModelDirectoryContentsTime(
-      const std::string& dir_path, const std::string& config_path);
-
-  int64_t GetModifiedTime() const noexcept;
-  int64_t GetModelVersionModifiedTime(const int64_t version) const noexcept;
-  int64_t GetNonModelConfigNorVersionNorDirModifiedTime() const noexcept;
+  int64_t GetModifiedTime() const;
+  int64_t GetModelVersionModifiedTime(const int64_t version) const;
+  int64_t GetNonModelConfigNorVersionNorDirModifiedTime() const;
 
   // Timestamps of all contents in the model directory, i.e.
   // - "<model_config_content_name_>": ns timestamp of model config (directory)

--- a/src/model_repository_manager/model_repository_manager.h
+++ b/src/model_repository_manager/model_repository_manager.h
@@ -52,20 +52,26 @@ enum ActionType { NO_ACTION, LOAD, UNLOAD };
 // Information about timestamps in model directory.
 class ModelTimestamp {
  public:
-  ModelTimestamp() {}
+  ModelTimestamp() noexcept {}
   ModelTimestamp(
       const std::string& model_dir_path, const std::string& model_config_path);
 
-  bool IsModified(const ModelTimestamp& new_timestamp) const;
+  bool IsModified(const ModelTimestamp& new_timestamp) const noexcept;
   bool IsModelVersionModified(
-      const ModelTimestamp& new_timestamp, const int64_t version) const;
+      const ModelTimestamp& new_timestamp,
+      const int64_t version) const noexcept;
 
   void SetModelConfigModifiedTime(const int64_t time_ns);
 
  private:
-  int64_t GetModifiedTime() const;
-  int64_t GetModelVersionModifiedTime(const int64_t version) const;
-  int64_t GetNonModelConfigNorVersionNorDirModifiedTime() const;
+  void AssertPathIsDirectory(const std::string& path) const;
+  void PopulateModelDirectoryTime(const std::string& dir_path);
+  void PopulateModelDirectoryContentsTime(
+      const std::string& dir_path, const std::string& config_path);
+
+  int64_t GetModifiedTime() const noexcept;
+  int64_t GetModelVersionModifiedTime(const int64_t version) const noexcept;
+  int64_t GetNonModelConfigNorVersionNorDirModifiedTime() const noexcept;
 
   // Timestamps of all contents in the model directory, i.e.
   // - "<model_config_content_name_>": ns timestamp of model config (directory)


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
It is requested that any model version(s) already loaded should not be reloaded upon adding and loading new version(s), if the already loaded version(s) are not modified. This is a small optimization to the model load/unload logic to avoid reloading unchanged model version(s) unload a load request.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
https://github.com/triton-inference-server/server/pull/7527

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->
Start with the changes to model_lifecycle to see why the small twist to the logic enables the previously reloaded model version to be updated, and then move towards model_config_utils and model_repository_manager to see how those changes support the decision to update vs reload.

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
New tests on not reloading already loaded model version upon loading other model versions is added. See the tests on server PR.

- CI Pipeline ID: 17511909  17650341
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->
N/A

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
Previously, the model (all versions) will always be reloaded if there is a change in the model directory beyond the model config. This will cause unnecessary reload of unmodified model version(s), which this change makes model directory change detection more granular and decides if a model version should be reloaded or updated based on the model file(s) of the version.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
