### PR TITLE
feat: Add model_load_time metric

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -85,6 +85,7 @@ constexpr char kInitialStateFolder[] = "initial_state";
 
 // Metric names
 constexpr char kPendingRequestMetric[] = "inf_pending_request_count";
+constexpr char kModelLoadTimeMetric[] = "model_load_time";
 
 constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -251,6 +251,7 @@ MetricModelReporter::InitializeGauges(
 {
   // Always setup these inference request metrics, regardless of config
   gauge_families_[kPendingRequestMetric] = &Metrics::FamilyInferenceQueueSize();
+  gauge_families_[kModelLoadTimeMetric] = &Metrics::FamilyModelLoadTime();
 
   for (auto& iter : gauge_families_) {
     const auto& name = iter.first;
@@ -389,6 +390,15 @@ MetricModelReporter::IncrementGauge(const std::string& name, double value)
   auto gauge = GetGauge(name);
   if (gauge) {
     gauge->Increment(value);
+  }
+}
+
+void
+MetricModelReporter::SetGauge(const std::string& name, double value)
+{
+  auto gauge = GetGauge(name);
+  if (gauge) {
+    gauge->Set(value);
   }
 }
 

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -87,7 +87,7 @@ class MetricModelReporter {
   const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
-  // Increase gauge by value.
+  // Set gauge value.
   void SetGauge(const std::string& name, double value);
   // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -88,6 +88,8 @@ class MetricModelReporter {
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
   // Increase gauge by value.
+  void SetGauge(const std::string& name, double value);
+  // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);
   // Decrease gauge by value.
   void DecrementGauge(const std::string& name, double value);

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -87,7 +87,7 @@ class MetricModelReporter {
   const MetricReporterConfig& Config();
   // Lookup counter metric by name, and increment it by value if it exists.
   void IncrementCounter(const std::string& name, double value);
-  // Set gauge value.
+  // Overwrite gauge to value
   void SetGauge(const std::string& name, double value);
   // Increase gauge by value.
   void IncrementGauge(const std::string& name, double value);

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -111,7 +111,7 @@ Metrics::Metrics()
 
       model_load_time_family_(prometheus::BuildGauge()
                                   .Name("nv_model_load_time")
-                                  .Help("Load Time per-model")
+                                  .Help("Load Time per-model in nanoseconds")
                                   .Register(*registry_)),
 
       pinned_memory_pool_total_family_(

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -111,7 +111,7 @@ Metrics::Metrics()
 
       model_load_time_family_(prometheus::BuildGauge()
                                   .Name("nv_model_load_time")
-                                  .Help("Load Time per-model in nanoseconds")
+                                  .Help("Load Time per-model in seconds")
                                   .Register(*registry_)),
 
       pinned_memory_pool_total_family_(

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -109,6 +109,11 @@ Metrics::Metrics()
                     "execution per-model.")
               .Register(*registry_)),
 
+      model_load_time_family_(prometheus::BuildGauge()
+                                  .Name("nv_model_load_time")
+                                  .Help("Load Time per-model")
+                                  .Register(*registry_)),
+
       pinned_memory_pool_total_family_(
           prometheus::BuildGauge()
               .Name("nv_pinned_memory_pool_total_bytes")

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -110,8 +110,8 @@ Metrics::Metrics()
               .Register(*registry_)),
 
       model_load_time_family_(prometheus::BuildGauge()
-                                  .Name("nv_model_load_time")
-                                  .Help("Load Time per-model in seconds")
+                                  .Name("nv_model_load_duration_secs")
+                                  .Help("Model load time in seconds")
                                   .Register(*registry_)),
 
       pinned_memory_pool_total_family_(

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -215,6 +215,12 @@ class Metrics {
     return GetSingleton()->inf_pending_request_count_family_;
   }
 
+  // Metric family of load time per model
+  static prometheus::Family<prometheus::Counter>& FamilyModelLoadTime()
+  {
+    return GetSingleton()->model_load_time_family_;
+  }
+
   // Metric families of per-model response cache metrics
   // NOTE: These are used in infer_stats for perf_analyzer
   static prometheus::Family<prometheus::Counter>& FamilyCacheHitCount()
@@ -300,6 +306,7 @@ class Metrics {
   prometheus::Family<prometheus::Counter>&
       inf_compute_output_duration_us_family_;
   prometheus::Family<prometheus::Gauge>& inf_pending_request_count_family_;
+  prometheus::Family<prometheus::Gauge>& model_load_time_family_;
 
   prometheus::Family<prometheus::Gauge>& pinned_memory_pool_total_family_;
   prometheus::Family<prometheus::Gauge>& pinned_memory_pool_used_family_;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -216,7 +216,7 @@ class Metrics {
   }
 
   // Metric family of load time per model
-  static prometheus::Family<prometheus::Counter>& FamilyModelLoadTime()
+  static prometheus::Family<prometheus::Gauge>& FamilyModelLoadTime()
   {
     return GetSingleton()->model_load_time_family_;
   }

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -471,7 +471,12 @@ ModelLifeCycle::AsyncLoad(
     ModelInfo* model_info = linfo.get();
 
     LOG_INFO << "loading: " << model_id << ":" << version;
-    model_info->load_start_ns_ = now_ns;
+    const uint64_t model_load_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+
+    model_info->load_start_ns_ = model_load_ns;
     model_info->state_ = ModelReadyState::LOADING;
     model_info->state_reason_.clear();
     model_info->agent_model_list_ = agent_model_list;

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -803,7 +803,7 @@ ModelLifeCycle::OnLoadFinal(
       std::lock_guard<std::mutex> curr_info_lk(loaded.second->mtx_);
       loaded.second->state_ = ModelReadyState::READY;
       loaded.second->state_reason_.clear();
-#ifdef TRITON_ENABLE_METRICS      
+#ifdef TRITON_ENABLE_METRICS
       auto reporter = loaded.second->model_->MetricReporter();
       const uint64_t now_ns =
           std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -571,7 +571,9 @@ ModelLifeCycle::CreateModel(
         is_config_provided, &model);
     is.reset(model.release());
     if (status.IsOk()) {
+#ifdef TRITON_ENABLE_METRICS
       CalculateAndReportLoadTime(model_info);
+#endif  // TRITON_ENABLE_METRICS
     }
   } else {
 #ifdef TRITON_ENABLE_ENSEMBLE

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -804,16 +804,7 @@ ModelLifeCycle::OnLoadFinal(
       loaded.second->state_ = ModelReadyState::READY;
       loaded.second->state_reason_.clear();
 #ifdef TRITON_ENABLE_METRICS
-      auto reporter = loaded.second->model_->MetricReporter();
-      const uint64_t now_ns =
-          std::chrono::duration_cast<std::chrono::nanoseconds>(
-              std::chrono::steady_clock::now().time_since_epoch())
-              .count();
-      uint64_t time_to_load_ns = now_ns - loaded.second->load_start_ns_;
-      std::chrono::duration<double> time_to_load =
-          std::chrono::duration_cast<std::chrono::duration<double>>(
-              std::chrono::nanoseconds(time_to_load_ns));
-      ReportModelLoadTime(reporter, time_to_load);
+      CalculateAndReportLoadTime(loaded.second);
 #endif  // TRITON_ENABLE_METRICS
       auto bit = background_models_.find((uintptr_t)loaded.second);
       // Check if the version model is loaded in background, if so,
@@ -857,6 +848,21 @@ ModelLifeCycle::OnLoadFinal(
             ? Status(Status::Code::INVALID_ARG, load_tracker->reason_)
             : Status::Success);
   }
+}
+
+void
+ModelLifeCycle::CalculateAndReportLoadTime(ModelInfo* loaded_model_info)
+{
+  auto reporter = loaded_model_info->model_->MetricReporter();
+  const uint64_t now_ns =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count();
+  uint64_t time_to_load_ns = now_ns - loaded_model_info->load_start_ns_;
+  std::chrono::duration<double> time_to_load =
+      std::chrono::duration_cast<std::chrono::duration<double>>(
+          std::chrono::nanoseconds(time_to_load_ns));
+  ReportModelLoadTime(reporter, time_to_load);
 }
 
 void

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -528,7 +528,6 @@ ModelLifeCycle::AsyncLoad(
     load_pool_->Enqueue([this, model_id, version, model_info, OnComplete,
                          load_tracker, is_config_provided]() {
       for (size_t retry = 0; retry <= options_.load_retry; ++retry) {
-        // TODO add here
         model_info->state_ = ModelReadyState::LOADING;
         CreateModel(model_id, version, model_info, is_config_provided);
         // Model state will be changed to NOT loading if failed to load,
@@ -866,8 +865,6 @@ ModelLifeCycle::ReportModelLoadTime(
     const std::chrono::duration<double>& time_to_load)
 {
 #ifdef TRITON_ENABLE_METRICS
-  // Pending request count should always be 0 or 1 per-request. A request should
-  // not decrement the count unless it has already been incremented.
   if (reporter) {
     double load_time_in_seconds = time_to_load.count();
     reporter->SetGauge(kModelLoadTimeMetric, load_time_in_seconds);

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -860,6 +860,7 @@ void
 ModelLifeCycle::CalculateAndReportLoadTime(
     ModelInfo* loaded_model_info, std::unique_ptr<Model>* model)
 {
+#ifdef TRITON_ENABLE_METRICS
   auto reporter = (*model)->MetricReporter();
   const uint64_t now_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -870,6 +871,7 @@ ModelLifeCycle::CalculateAndReportLoadTime(
       std::chrono::duration_cast<std::chrono::duration<double>>(
           std::chrono::nanoseconds(time_to_load_ns));
   ReportModelLoadTime(reporter, time_to_load);
+#endif  // TRITON_ENABLE_METRICS
 }
 
 void

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -801,21 +801,21 @@ ModelLifeCycle::OnLoadFinal(
 
     // Mark current versions ready and track info in foreground
     for (auto& loaded : load_tracker->load_set_) {
-      // loaded is of type ModelInfo
       std::lock_guard<std::mutex> curr_info_lk(loaded.second->mtx_);
       loaded.second->state_ = ModelReadyState::READY;
-      // Use this Metric
+      loaded.second->state_reason_.clear();
       auto reporter = loaded.second->model_->MetricReporter();
       const uint64_t now_ns =
           std::chrono::duration_cast<std::chrono::nanoseconds>(
               std::chrono::steady_clock::now().time_since_epoch())
               .count();
       uint64_t time_to_load_ns = now_ns - loaded.second->load_start_ns_;
-      #ifdef TRITON_ENABLE_METRICS
-        std::chrono::duration<double> time_to_load = 
-          std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::nanoseconds(time_to_load_ns));
+#ifdef TRITON_ENABLE_METRICS
+      std::chrono::duration<double> time_to_load =
+          std::chrono::duration_cast<std::chrono::duration<double>>(
+              std::chrono::nanoseconds(time_to_load_ns));
       ReportModelLoadTime(reporter, time_to_load);
-      #endif  // TRITON_ENABLE_METRICS
+#endif  // TRITON_ENABLE_METRICS
       auto bit = background_models_.find((uintptr_t)loaded.second);
       // Check if the version model is loaded in background, if so,
       // replace and unload the current serving version

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -572,7 +572,7 @@ ModelLifeCycle::CreateModel(
     is.reset(model.release());
     if (status.IsOk()) {
 #ifdef TRITON_ENABLE_METRICS
-      CalculateAndReportLoadTime(model_info);
+      CalculateAndReportLoadTime(model_info, &is);
 #endif  // TRITON_ENABLE_METRICS
     }
   } else {
@@ -857,9 +857,10 @@ ModelLifeCycle::OnLoadFinal(
 }
 
 void
-ModelLifeCycle::CalculateAndReportLoadTime(ModelInfo* loaded_model_info)
+ModelLifeCycle::CalculateAndReportLoadTime(
+    ModelInfo* loaded_model_info, std::unique_ptr<Model>* model)
 {
-  auto reporter = loaded_model_info->model_->MetricReporter();
+  auto reporter = (*model)->MetricReporter();
   const uint64_t now_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           std::chrono::steady_clock::now().time_since_epoch())

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -803,13 +803,13 @@ ModelLifeCycle::OnLoadFinal(
       std::lock_guard<std::mutex> curr_info_lk(loaded.second->mtx_);
       loaded.second->state_ = ModelReadyState::READY;
       loaded.second->state_reason_.clear();
+#ifdef TRITON_ENABLE_METRICS      
       auto reporter = loaded.second->model_->MetricReporter();
       const uint64_t now_ns =
           std::chrono::duration_cast<std::chrono::nanoseconds>(
               std::chrono::steady_clock::now().time_since_epoch())
               .count();
       uint64_t time_to_load_ns = now_ns - loaded.second->load_start_ns_;
-#ifdef TRITON_ENABLE_METRICS
       std::chrono::duration<double> time_to_load =
           std::chrono::duration_cast<std::chrono::duration<double>>(
               std::chrono::nanoseconds(time_to_load_ns));

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -315,7 +315,7 @@ class ModelLifeCycle {
       const std::function<void(Status)>& OnComplete,
       std::shared_ptr<LoadTracker> load_tracker);
   // Calculate time to load model
-  void ModelLifeCycle::CalculateAndReportLoadTime(ModelInfo* loaded_model_info);
+  void CalculateAndReportLoadTime(ModelInfo* loaded_model_info);
   // Report Load time per model metrics
   void ReportModelLoadTime(
       std::shared_ptr<MetricModelReporter> reporter,

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -231,14 +231,14 @@ class ModelLifeCycle {
     ModelInfo(
         const std::string& model_path,
         const inference::ModelConfig& model_config,
-        const uint64_t last_update_ns, const uint64_t load_start_ns)
+        const uint64_t last_update_ns)
         : model_config_(model_config), model_path_(model_path),
 #ifdef TRITON_ENABLE_ENSEMBLE
           is_ensemble_(model_config.platform() == kEnsemblePlatform),
 #else
           is_ensemble_(false),
 #endif  // TRITON_ENABLE_ENSEMBLE
-          last_update_ns_(last_update_ns), load_start_ns_(load_start_ns),
+          last_update_ns_(last_update_ns),
           state_(ModelReadyState::UNKNOWN)
     {
     }
@@ -315,6 +315,10 @@ class ModelLifeCycle {
       ModelInfo* model_info, const bool is_update,
       const std::function<void(Status)>& OnComplete,
       std::shared_ptr<LoadTracker> load_tracker);
+  // Report Load time per model metrics
+  void ReportModelLoadTime(
+      std::shared_ptr<MetricModelReporter> reporter,
+      const std::chrono::duration<double>& time_to_load);
   // Helper function for 'OnLoadComplete()' to finish final operations after
   // loading **all** model versions.
   void OnLoadFinal(

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -231,14 +231,15 @@ class ModelLifeCycle {
     ModelInfo(
         const std::string& model_path,
         const inference::ModelConfig& model_config,
-        const uint64_t last_update_ns)
+        const uint64_t last_update_ns, const uint64_t load_start_ns)
         : model_config_(model_config), model_path_(model_path),
 #ifdef TRITON_ENABLE_ENSEMBLE
           is_ensemble_(model_config.platform() == kEnsemblePlatform),
 #else
           is_ensemble_(false),
 #endif  // TRITON_ENABLE_ENSEMBLE
-          last_update_ns_(last_update_ns), state_(ModelReadyState::UNKNOWN)
+          last_update_ns_(last_update_ns), load_start_ns_(load_start_ns),
+          state_(ModelReadyState::UNKNOWN)
     {
     }
 
@@ -260,6 +261,7 @@ class ModelLifeCycle {
     std::mutex mtx_;
 
     uint64_t last_update_ns_;
+    uint64_t load_start_ns_;
 
     ModelReadyState state_;
     std::string state_reason_;

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -238,8 +238,7 @@ class ModelLifeCycle {
 #else
           is_ensemble_(false),
 #endif  // TRITON_ENABLE_ENSEMBLE
-          last_update_ns_(last_update_ns),
-          state_(ModelReadyState::UNKNOWN)
+          last_update_ns_(last_update_ns), state_(ModelReadyState::UNKNOWN)
     {
     }
 

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <mutex>
 
+#include "backend_model.h"
 #include "infer_parameter.h"
 #include "model.h"
 #include "model_config.pb.h"
@@ -315,7 +316,8 @@ class ModelLifeCycle {
       const std::function<void(Status)>& OnComplete,
       std::shared_ptr<LoadTracker> load_tracker);
   // Calculate time to load model
-  void CalculateAndReportLoadTime(ModelInfo* loaded_model_info);
+  void CalculateAndReportLoadTime(
+      ModelInfo* loaded_model_info, std::unique_ptr<Model>* model);
   // Report Load time per model metrics
   void ReportModelLoadTime(
       std::shared_ptr<MetricModelReporter> reporter,

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -314,6 +314,8 @@ class ModelLifeCycle {
       ModelInfo* model_info, const bool is_update,
       const std::function<void(Status)>& OnComplete,
       std::shared_ptr<LoadTracker> load_tracker);
+  // Calculate time to load model
+  void ModelLifeCycle::CalculateAndReportLoadTime(ModelInfo* loaded_model_info);
   // Report Load time per model metrics
   void ReportModelLoadTime(
       std::shared_ptr<MetricModelReporter> reporter,

--- a/src/model_repository_manager/model_lifecycle.h
+++ b/src/model_repository_manager/model_lifecycle.h
@@ -261,7 +261,6 @@ class ModelLifeCycle {
     std::mutex mtx_;
 
     uint64_t last_update_ns_;
-    uint64_t load_start_ns_;
 
     ModelReadyState state_;
     std::string state_reason_;
@@ -317,7 +316,7 @@ class ModelLifeCycle {
       std::shared_ptr<LoadTracker> load_tracker);
   // Calculate time to load model
   void CalculateAndReportLoadTime(
-      ModelInfo* loaded_model_info, std::unique_ptr<Model>* model);
+      uint64_t load_start_ns_, std::unique_ptr<Model>* model);
   // Report Load time per model metrics
   void ReportModelLoadTime(
       std::shared_ptr<MetricModelReporter> reporter,


### PR DESCRIPTION
#### What does the PR do?
Add new metric nv_load_time per model to metrics
Added load time gauge metric per model.
New metric added example

```
HELP nv_model_load_time Load Time per-model
TYPE nv_model_load_time gauge
nv_model_load_time{model="libtorch_float32_float32_float32",version="1"} 0.311423712
```

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/server/pull/7697

#### Where should the reviewer start?
ReportModelLoadTime func use-age.

#### Test plan:
Added in server PR

- CI Pipeline ID: https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/19322776
<!-- Only Pipeline ID and no direct link here -->
