### PR TITLE
Allow missing ensemble output(s) (#399)

### DIFF
--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -1200,11 +1200,6 @@ EnsembleContext::CheckAndSetEnsembleOutput(
         ready = false;
         break;
       }
-      // check if the output is provided
-      else if (tensor[iteration_count].data_ == nullptr) {
-        ready = false;
-        break;
-      }
     }
   }
   if (!ready) {
@@ -1223,6 +1218,12 @@ EnsembleContext::CheckAndSetEnsembleOutput(
     // Check if output is ready
     auto& tensor_data = tensor_data_[output_pair.first];
     auto& tensor = tensor_data.tensor_[iteration_count];
+
+    if (tensor.data_ == nullptr) {
+      LOG_VERBOSE(1) << "Composing models did not output tensor "
+                     << output_pair.first;
+      continue;
+    }
 
     auto shape = ReshapeTensorDims(
         output_pair.second, (lrequest->BatchSize() != 0),


### PR DESCRIPTION
Cherry-pick https://github.com/triton-inference-server/core/pull/399 PR's [merged commit to main](https://github.com/triton-inference-server/core/commit/571c5dcee325a78cd8f02e2ee8ebb17e1df2ac75) into [r24.10](https://github.com/triton-inference-server/core/tree/r24.10)