### PR TITLE
Revert "Change compute capablity min value (#401)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
   option(TRITON_ENABLE_NVTX "Include NVTX support in server" OFF)
   option(TRITON_ENABLE_GPU "Enable GPU support in server" ON)
   option(TRITON_ENABLE_MALI_GPU "Enable Arm Mali GPU support in server" OFF)
-  set(TRITON_MIN_COMPUTE_CAPABILITY "7.5" CACHE STRING
+  set(TRITON_MIN_COMPUTE_CAPABILITY "6.0" CACHE STRING
       "The minimum CUDA compute capability supported by Triton" )
   set(TRITON_EXTRA_LIB_PATHS "" CACHE PATH "Extra library paths for Triton Server build")
 


### PR DESCRIPTION
This reverts commit a6b3e261d1fc96b95b7b4611e6b480c8844ac367.
https://github.com/triton-inference-server/onnxruntime_backend/pull/277
https://github.com/triton-inference-server/server/pull/7721
