### PR TITLE
Unused variable causing L0_build_variants--build to fail. 

### DIFF
--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -560,10 +560,12 @@ ModelLifeCycle::CreateModel(
   // backend.
   if (!model_config.backend().empty()) {
     std::unique_ptr<TritonModel> model;
+#ifdef TRITON_ENABLE_METRICS
     const uint64_t model_load_ns =
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::steady_clock::now().time_since_epoch())
             .count();
+#endif  // TRITON_ENABLE_METRICS            
     status = TritonModel::Create(
         server_, model_info->model_path_, options_.backend_cmdline_config_map,
         options_.host_policy_map, model_id, version, model_config,

--- a/src/model_repository_manager/model_lifecycle.cc
+++ b/src/model_repository_manager/model_lifecycle.cc
@@ -565,7 +565,7 @@ ModelLifeCycle::CreateModel(
         std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::steady_clock::now().time_since_epoch())
             .count();
-#endif  // TRITON_ENABLE_METRICS            
+#endif  // TRITON_ENABLE_METRICS
     status = TritonModel::Create(
         server_, model_info->model_path_, options_.backend_cmdline_config_map,
         options_.host_policy_map, model_id, version, model_config,


### PR DESCRIPTION
Unused variable in case of TRITON_ENABLE_METRICS set to OFF causing build failure here
https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/117883872

New Pipeline in progress

https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/19741134