### PR TITLE
feat: Allow per-model metric configuration

### DIFF
--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -192,7 +192,8 @@ TritonModelInstance::TritonModelInstance(
         model_->Server()->ResponseCacheEnabled();
     MetricModelReporter::Create(
         model_->ModelId(), model_->Version(), id, response_cache_enabled,
-        model_->IsDecoupled(), model_->Config().metric_tags(), &reporter_);
+        model_->IsDecoupled(), model_->Config().metric_tags(),
+        model_->Config().model_metrics(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -86,6 +86,7 @@ constexpr char kInitialStateFolder[] = "initial_state";
 // Metric names
 constexpr char kPendingRequestMetric[] = "inf_pending_request_count";
 constexpr char kModelLoadTimeMetric[] = "model_load_time";
+constexpr char kFirstResponseHistogram[] = "first_response_histogram";
 
 constexpr uint64_t NANOS_PER_SECOND = 1000000000;
 constexpr uint64_t NANOS_PER_MILLIS = 1000000;

--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -1477,7 +1477,7 @@ EnsembleScheduler::EnsembleScheduler(
     MetricModelReporter::Create(
         model_id, 1 /* model_version */, METRIC_REPORTER_ID_CPU,
         false /* response_cache_enabled */, is_decoupled, config.metric_tags(),
-        &metric_reporter_);
+        config.model_metrics(), &metric_reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
 

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -317,7 +317,7 @@ InferenceResponse::UpdateResponseMetrics() const
                       .count();
     if (auto reporter = model_->MetricReporter()) {
       reporter->ObserveHistogram(
-          "first_response_histogram",
+          kFirstResponseHistogram,
           (now_ns - infer_start_ns_) / NANOS_PER_MILLIS);
     }
   }

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -80,12 +80,13 @@ MetricReporterConfig::ParseConfig(
   for (const auto& metric_control : model_metrics.metric_control()) {
     const std::string& family_name =
         metric_control.metric_identifier().family();
-    // Copy protobuf RepeatedField to std::vector
-    const auto& buckets_proto = metric_control.histogram_options().buckets();
-    const prometheus::Histogram::BucketBoundaries buckets(
-        buckets_proto.begin(), buckets_proto.end());
 
+    // If family name exists, override with new options.
     if (metric_map_.find(family_name) != metric_map_.end()) {
+      // Copy protobuf RepeatedField to std::vector
+      const auto& buckets_proto = metric_control.histogram_options().buckets();
+      const prometheus::Histogram::BucketBoundaries buckets(
+          buckets_proto.begin(), buckets_proto.end());
       histogram_options_[metric_map_.at(family_name)] = buckets;
     }
   }

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -91,7 +91,8 @@ MetricReporterConfig::ParseConfig(
     } else {
       // metric_control config may be extended to support backend metrics.
       LOG_WARNING << "Metric family '" << family_name
-                  << "' in 'metric_identifier' is not a Triton core metric.";
+                  << "' in 'metric_identifier' is not a customizable metric in "
+                     "Triton core.";
     }
   }
 }

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -304,6 +304,7 @@ void
 MetricModelReporter::InitializeHistograms(
     const std::map<std::string, std::string>& labels)
 {
+  // Update MetricReporterConfig::metric_map_ for new histograms.
   // Only create response metrics if decoupled model to reduce metric output
   if (config_.latency_histograms_enabled_) {
     if (config_.is_decoupled_) {

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -88,6 +88,10 @@ MetricReporterConfig::ParseConfig(
       const prometheus::Histogram::BucketBoundaries buckets(
           buckets_proto.begin(), buckets_proto.end());
       histogram_options_[metric_map_.at(family_name)] = buckets;
+    } else {
+      // metric_control config may be extended to support backend metrics.
+      LOG_WARNING << "Metric family '" << family_name
+                  << "' in 'model_identifier' is not a Triton core metric.";
     }
   }
 }

--- a/src/metric_model_reporter.cc
+++ b/src/metric_model_reporter.cc
@@ -91,7 +91,7 @@ MetricReporterConfig::ParseConfig(
     } else {
       // metric_control config may be extended to support backend metrics.
       LOG_WARNING << "Metric family '" << family_name
-                  << "' in 'model_identifier' is not a Triton core metric.";
+                  << "' in 'metric_identifier' is not a Triton core metric.";
     }
   }
 }

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -80,9 +80,9 @@ struct MetricReporterConfig {
 
  private:
   // Maps the metric family fullname to its lookup key. This field is required
-  // because the users are expected to configure metric configuration "ModelMetrics"
-  // with the full name displayed from metrics reporting while a different name is used internally .
-  // All new histograms must update the map.
+  // because the users are expected to configure metric configuration
+  // "ModelMetrics" with the full name displayed from metrics reporting while a
+  // different name is used internally. All new histograms must update the map.
   const std::unordered_map<std::string, std::string> metric_map_ = {
       {"nv_inference_first_response_histogram_ms", kFirstResponseHistogram}};
 #endif  // TRITON_ENABLE_METRICS

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -79,7 +79,9 @@ struct MetricReporterConfig {
   bool is_decoupled_ = false;
 
  private:
-  // Maps the metric fullname to its lookup key.
+  // Maps the metric family fullname to its lookup key. This field is required
+  // to find the lookup key given its fullname when users specify in the custom
+  // metric configuration "ModelMetrics".
   // All new histograms must update the map.
   const std::unordered_map<std::string, std::string> metric_map_ = {
       {"nv_inference_first_response_histogram_ms", kFirstResponseHistogram}};

--- a/src/metric_model_reporter.h
+++ b/src/metric_model_reporter.h
@@ -80,8 +80,8 @@ struct MetricReporterConfig {
 
  private:
   // Maps the metric family fullname to its lookup key. This field is required
-  // to find the lookup key given its fullname when users specify in the custom
-  // metric configuration "ModelMetrics".
+  // because the users are expected to configure metric configuration "ModelMetrics"
+  // with the full name displayed from metrics reporting while a different name is used internally .
   // All new histograms must update the map.
   const std::unordered_map<std::string, std::string> metric_map_ = {
       {"nv_inference_first_response_histogram_ms", kFirstResponseHistogram}};

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -109,12 +109,6 @@ Metrics::Metrics()
                     "execution per-model.")
               .Register(*registry_)),
 
-      inf_first_response_histogram_ms_family_(
-          prometheus::BuildHistogram()
-              .Name("nv_inference_first_response_histogram_ms")
-              .Help("Duration from request to first response in milliseconds")
-              .Register(*registry_)),
-
       model_load_time_family_(prometheus::BuildGauge()
                                   .Name("nv_model_load_duration_secs")
                                   .Help("Model load time in seconds")
@@ -153,6 +147,14 @@ Metrics::Metrics()
               .Name("nv_cache_miss_duration_per_model")
               .Help("Total cache miss (insert+lookup) duration per model, in "
                     "microseconds")
+              .Register(*registry_)),
+
+      // Histograms
+      // New histograms must be added to MetricReporterConfig.metric_map_
+      inf_first_response_histogram_ms_family_(
+          prometheus::BuildHistogram()
+              .Name("nv_inference_first_response_histogram_ms")
+              .Help("Duration from request to first response in milliseconds")
               .Register(*registry_)),
 
       // Summaries

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -312,8 +312,6 @@ class Metrics {
   prometheus::Family<prometheus::Counter>&
       inf_compute_output_duration_us_family_;
   prometheus::Family<prometheus::Gauge>& inf_pending_request_count_family_;
-  prometheus::Family<prometheus::Histogram>&
-      inf_first_response_histogram_ms_family_;
   prometheus::Family<prometheus::Gauge>& model_load_time_family_;
 
   prometheus::Family<prometheus::Gauge>& pinned_memory_pool_total_family_;
@@ -329,6 +327,10 @@ class Metrics {
   prometheus::Family<prometheus::Counter>& cache_hit_duration_us_model_family_;
   prometheus::Family<prometheus::Counter>& cache_num_misses_model_family_;
   prometheus::Family<prometheus::Counter>& cache_miss_duration_us_model_family_;
+
+  // Histograms
+  prometheus::Family<prometheus::Histogram>&
+      inf_first_response_histogram_ms_family_;
 
   // Summaries
   prometheus::Family<prometheus::Summary>& inf_request_summary_us_family_;

--- a/src/model.cc
+++ b/src/model.cc
@@ -135,7 +135,8 @@ Model::Init(const bool is_config_provided)
 #ifdef TRITON_ENABLE_METRICS
   MetricModelReporter::Create(
       ModelId(), Version(), METRIC_REPORTER_ID_UTILITY, ResponseCacheEnabled(),
-      IsDecoupled(), Config().metric_tags(), &reporter_);
+      IsDecoupled(), Config().metric_tags(), Config().model_metrics(),
+      &reporter_);
 #endif  // TRITON_ENABLE_METRICS
 
   return Status::Success;

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1624,16 +1624,16 @@ ValidateModelConfig(
   if (config.has_model_metrics()) {
 #ifdef TRITON_ENABLE_METRICS
     for (const auto& metric_control : config.model_metrics().metric_control()) {
-      if (metric_control.has_metric_identifier()) {
-        if (metric_control.metric_identifier().family().empty()) {
-          return Status(
-              Status::Code::INVALID_ARG,
-              "metric_identifier must specify 'family'");
-        }
-      } else {
+      if (!metric_control.has_metric_identifier()) {
         return Status(
             Status::Code::INVALID_ARG,
             "model_control must specify 'metric_identifier'");
+      }
+
+      if (metric_control.metric_identifier().family().empty()) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "metric_identifier must specify 'family'");
       }
 
       if (!metric_control.has_histogram_options()) {

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1656,10 +1656,7 @@ ValidateModelConfig(
   // If model_metric is specified, validate it.
   if (config.has_model_metrics()) {
 #ifdef TRITON_ENABLE_METRICS
-    Status status = ValidateModelMetrics(config.model_metrics());
-    if (!status.IsOk()) {
-      return status;
-    }
+    RETURN_IF_ERROR(ValidateModelMetrics(config.model_metrics()));
 #else
     return Status(Status::Code::INVALID_ARG, "metrics not supported");
 #endif  // TRITON_ENABLE_METRICS

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -446,6 +446,39 @@ ValidateNonLinearFormatIO(
   return Status::Success;
 }
 
+// Helper function to validate that model_metrics contains all required data.
+Status
+ValidateModelMetrics(const inference::ModelMetrics& model_metrics)
+{
+  for (const auto& metric_control : model_metrics.metric_control()) {
+    if (!metric_control.has_metric_identifier()) {
+      return Status(
+          Status::Code::INVALID_ARG,
+          "metric control must specify 'metric_identifier'");
+    }
+
+    if (metric_control.metric_identifier().family().empty()) {
+      return Status(
+          Status::Code::INVALID_ARG,
+          "metric identifier must specify non-empty 'family'");
+    }
+
+    if (!metric_control.has_histogram_options()) {
+      return Status(
+          Status::Code::INVALID_ARG,
+          "metric control must specify 'histogram_options'");
+    }
+
+    if (metric_control.histogram_options().buckets_size() == 0) {
+      return Status(
+          Status::Code::INVALID_ARG,
+          "histogram options must specify non-empty 'buckets'");
+    }
+  }
+
+  return Status::Success;
+}
+
 }  // namespace
 
 Status
@@ -1623,30 +1656,9 @@ ValidateModelConfig(
   // If model_metric is specified, validate it.
   if (config.has_model_metrics()) {
 #ifdef TRITON_ENABLE_METRICS
-    for (const auto& metric_control : config.model_metrics().metric_control()) {
-      if (!metric_control.has_metric_identifier()) {
-        return Status(
-            Status::Code::INVALID_ARG,
-            "metric control must specify 'metric_identifier'");
-      }
-
-      if (metric_control.metric_identifier().family().empty()) {
-        return Status(
-            Status::Code::INVALID_ARG,
-            "metric identifier must specify non-empty 'family'");
-      }
-
-      if (!metric_control.has_histogram_options()) {
-        return Status(
-            Status::Code::INVALID_ARG,
-            "metric control must specify 'histogram_options'");
-      }
-
-      if (metric_control.histogram_options().buckets_size() == 0) {
-        return Status(
-            Status::Code::INVALID_ARG,
-            "histogram options must specify non-empty 'buckets'");
-      }
+    Status status = ValidateModelMetrics(config.model_metrics());
+    if (!status.IsOk()) {
+      return status;
     }
 #else
     return Status(Status::Code::INVALID_ARG, "metrics not supported");

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1627,19 +1627,25 @@ ValidateModelConfig(
       if (!metric_control.has_metric_identifier()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "model_control must specify 'metric_identifier'");
+            "metric control must specify 'metric_identifier'");
       }
 
       if (metric_control.metric_identifier().family().empty()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "metric_identifier must specify 'family'");
+            "metric identifier must specify non-empty 'family'");
       }
 
       if (!metric_control.has_histogram_options()) {
         return Status(
             Status::Code::INVALID_ARG,
-            "model_control must specify 'histogram_options'");
+            "metric control must specify 'histogram_options'");
+      }
+
+      if (metric_control.histogram_options().buckets_size() == 0) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "histogram options must specify non-empty 'buckets'");
       }
     }
 #else


### PR DESCRIPTION
#### What does the PR do?
Tests new model_metrics message in pbtxt. Add example to override histogram buckets per-family.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] feat

#### Related PRs:
https://github.com/triton-inference-server/common/pull/126
https://github.com/triton-inference-server/server/pull/7752

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
L0_metrics

- CI Pipeline ID:
20106057

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
Default histogram buckets does not satisfy all use cases.