### PR TITLE
refactor: Migrates Python tests to pytest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,15 +14,27 @@ jobs:
       image: nvcr.io/nvidia/tritonserver:24.10-py3
       volumes:
         - ${{ github.workspace }}:/core
+        # Mount /usr so we can free space
+        - /usr:/host_usr
+      env:
+        AGENT_TOOLSDIRECTORY: "$AGENT_TOOLSDIRECTORY"
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Free space
+        run: |
+          rm -rf \
+            /host_usr/share/dotnet /host_usr/local/lib/android /opt/ghc \
+            /host_usr/local/share/powershell /host_usr/share/swift /host_usr/local/.ghcup \
+            /host_usr/lib/jvm
+          rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Install dependencies
         run: |
           apt update
           apt install -y --no-install-recommends clang-format-15 cmake libb64-dev rapidjson-dev libre2-dev
-          wget -O /tmp/boost.tar.gz https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && (cd /tmp && tar xzf boost.tar.gz) && mv /tmp/boost_1_80_0/boost /usr/include/boost
+          wget -O /tmp/boost.tar.gz https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && (cd /tmp && tar xzf boost.tar.gz) && mv /tmp/boost_1_80_0/boost /usr/include/boost && rm /tmp/boost.tar.gz
           pip install build pytest
 
       - name: Build

--- a/python/test/test_api.py
+++ b/python/test/test_api.py
@@ -24,14 +24,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import asyncio
-import copy
 import json
 import os
-import queue
 import shutil
-import time
-import unittest
 
 import numpy
 import pytest
@@ -50,46 +45,44 @@ try:
 except ImportError:
     torch = None
 
-module_directory = os.path.split(os.path.abspath(__file__))[0]
-test_model_directory = os.path.abspath(
-    os.path.join(module_directory, "test_api_models")
-)
-test_logs_directory = os.path.abspath(os.path.join(module_directory, "test_api_logs"))
-
-shutil.rmtree(test_logs_directory, ignore_errors=True)
-
-os.makedirs(test_logs_directory)
-
-server_options = tritonserver.Options(
-    server_id="TestServer",
-    model_repository=test_model_directory,
-    log_verbose=6,
-    log_error=True,
-    log_warn=True,
-    log_info=True,
-    exit_on_error=True,
-    strict_model_config=False,
-    model_control_mode=tritonserver.ModelControlMode.EXPLICIT,
-    exit_timeout=30,
-)
+TEST_ROOT = os.path.abspath(os.path.dirname(__file__))
+TEST_MODEL_DIR = os.path.abspath(os.path.join(TEST_ROOT, "test_api_models"))
+TEST_LOGS_DIR = os.path.abspath(os.path.join(TEST_ROOT, "test_api_logs"))
 
 
-class ModelTests(unittest.TestCase):
-    def setup_method(self, method):
-        self._server_options = copy.copy(server_options)
-        self._server_options.log_file = os.path.join(
-            test_logs_directory, method.__name__ + ".server.log"
-        )
+@pytest.fixture(autouse=True, scope="module")
+def create_log_dir():
+    shutil.rmtree(TEST_LOGS_DIR, ignore_errors=True)
+    os.makedirs(TEST_LOGS_DIR)
 
-    def test_create_request(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+
+@pytest.fixture()
+def server_options(request):
+    return tritonserver.Options(
+        server_id="TestServer",
+        model_repository=TEST_MODEL_DIR,
+        log_verbose=6,
+        log_error=True,
+        log_warn=True,
+        log_info=True,
+        exit_on_error=True,
+        strict_model_config=False,
+        model_control_mode=tritonserver.ModelControlMode.EXPLICIT,
+        exit_timeout=5,
+        log_file=os.path.join(TEST_LOGS_DIR, request.node.name + ".server.log"),
+    )
+
+
+class TestModels:
+    def test_create_request(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
         request = server.models()["test"].create_request()
 
         request = tritonserver.InferenceRequest(server.model("test"))
 
 
-class AllocatorTests(unittest.TestCase):
+class TestAllocators:
     class MockMemoryAllocator(tritonserver.MemoryAllocator):
         def __init__(self):
             pass
@@ -97,17 +90,11 @@ class AllocatorTests(unittest.TestCase):
         def allocate(self, *args, **kwargs):
             raise Exception("foo")
 
-    def setup_method(self, method):
-        self._server_options = copy.copy(server_options)
-        self._server_options.log_file = os.path.join(
-            test_logs_directory, method.__name__ + ".server.log"
-        )
-
     @pytest.mark.skipif(cupy is None, reason="Skipping gpu memory, cupy not installed")
-    def test_memory_fallback_to_cpu(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_memory_fallback_to_cpu(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         allocator = tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU]
 
@@ -133,18 +120,16 @@ class AllocatorTests(unittest.TestCase):
         for response in server.model("test").infer(
             inputs={"fp16_input": fp16_input},
         ):
-            self.assertEqual(
-                response.outputs["fp16_output"].memory_type, tritonserver.MemoryType.CPU
-            )
+            assert response.outputs["fp16_output"].memory_type == tritonserver.MemoryType.CPU
             fp16_output = numpy.from_dlpack(response.outputs["fp16_output"])
-            self.assertEqual(fp16_input[0][0], fp16_output[0][0])
+            assert fp16_input[0][0] == fp16_output[0][0]
 
         tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU] = allocator
 
-    def test_memory_allocator_exception(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_memory_allocator_exception(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -158,20 +143,18 @@ class AllocatorTests(unittest.TestCase):
             },
         )
 
-        with self.assertRaises(tritonserver.InternalError):
+        with pytest.raises(tritonserver.InternalError):
             for response in server.model("test").infer(
-                inputs={
-                    "string_input": tritonserver.Tensor.from_string_array([["hello"]])
-                },
+                inputs={"string_input": tritonserver.Tensor.from_string_array([["hello"]])},
                 output_memory_type="gpu",
-                output_memory_allocator=AllocatorTests.MockMemoryAllocator(),
+                output_memory_allocator=TestAllocators.MockMemoryAllocator(),
             ):
                 pass
 
-    def test_unsupported_memory_type(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_unsupported_memory_type(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -186,126 +169,97 @@ class AllocatorTests(unittest.TestCase):
         )
 
         if tritonserver.MemoryType.GPU in tritonserver.default_memory_allocators:
-            allocator = tritonserver.default_memory_allocators[
-                tritonserver.MemoryType.GPU
-            ]
+            allocator = tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU]
 
             del tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU]
         else:
             allocator = None
 
-        with self.assertRaises(tritonserver.InvalidArgumentError):
+        with pytest.raises(tritonserver.InvalidArgumentError):
             for response in server.model("test").infer(
-                inputs={
-                    "string_input": tritonserver.Tensor.from_string_array([["hello"]])
-                },
+                inputs={"string_input": tritonserver.Tensor.from_string_array([["hello"]])},
                 output_memory_type="gpu",
             ):
                 pass
 
         if allocator is not None:
-            tritonserver.default_memory_allocators[
-                tritonserver.MemoryType.GPU
-            ] = allocator
+            tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU] = allocator
 
     @pytest.mark.skipif(torch is None, reason="Skipping test, torch not installed")
     def test_allocate_on_cpu_and_reshape(self):
         allocator = tritonserver.default_memory_allocators[tritonserver.MemoryType.CPU]
 
-        memory_buffer = allocator.allocate(
-            memory_type=tritonserver.MemoryType.CPU, memory_type_id=0, size=200
-        )
+        memory_buffer = allocator.allocate(memory_type=tritonserver.MemoryType.CPU, memory_type_id=0, size=200)
 
         cpu_array = memory_buffer.owner
 
-        self.assertEqual(memory_buffer.size, 200)
+        assert memory_buffer.size == 200
 
         fp32_size = int(memory_buffer.size / 4)
 
-        tensor = tritonserver.Tensor(
-            tritonserver.DataType.FP32, shape=[fp32_size], memory_buffer=memory_buffer
-        )
+        tensor = tritonserver.Tensor(tritonserver.DataType.FP32, shape=[fp32_size], memory_buffer=memory_buffer)
 
         cpu_fp32_array = numpy.from_dlpack(tensor)
-        self.assertEqual(cpu_array.ctypes.data, cpu_fp32_array.ctypes.data)
-        self.assertEqual(cpu_fp32_array.dtype, numpy.float32)
-        self.assertEqual(cpu_fp32_array.nbytes, 200)
+        assert cpu_array.ctypes.data == cpu_fp32_array.ctypes.data
+        assert cpu_fp32_array.dtype == numpy.float32
+        assert cpu_fp32_array.nbytes == 200
 
     @pytest.mark.skipif(cupy is None, reason="Skipping gpu memory, cupy not installed")
     @pytest.mark.skipif(torch is None, reason="Skipping test, torch not installed")
     def test_allocate_on_gpu_and_reshape(self):
-        if cupy is None:
-            return
-
         allocator = tritonserver.default_memory_allocators[tritonserver.MemoryType.GPU]
 
-        memory_buffer = allocator.allocate(
-            memory_type=tritonserver.MemoryType.GPU, memory_type_id=0, size=200
-        )
+        memory_buffer = allocator.allocate(memory_type=tritonserver.MemoryType.GPU, memory_type_id=0, size=200)
 
         gpu_array = memory_buffer.owner
 
         gpu_array = cupy.empty([10, 20], dtype=cupy.uint8)
         memory_buffer = tritonserver.MemoryBuffer.from_dlpack(gpu_array)
 
-        self.assertEqual(memory_buffer.size, 200)
+        assert memory_buffer.size == 200
 
         fp32_size = int(memory_buffer.size / 4)
 
-        tensor = tritonserver.Tensor(
-            tritonserver.DataType.FP32, shape=[fp32_size], memory_buffer=memory_buffer
-        )
+        tensor = tritonserver.Tensor(tritonserver.DataType.FP32, shape=[fp32_size], memory_buffer=memory_buffer)
 
         gpu_fp32_array = cupy.from_dlpack(tensor)
-        self.assertEqual(
-            gpu_array.__cuda_array_interface__["data"][0],
-            gpu_fp32_array.__cuda_array_interface__["data"][0],
-        )
-        self.assertEqual(gpu_fp32_array.dtype, cupy.float32)
-        self.assertEqual(gpu_fp32_array.nbytes, 200)
+        assert gpu_array.__cuda_array_interface__["data"][0] == gpu_fp32_array.__cuda_array_interface__["data"][0]
+
+        assert gpu_fp32_array.dtype == cupy.float32
+        assert gpu_fp32_array.nbytes == 200
 
         torch_fp32_tensor = torch.from_dlpack(tensor)
-        self.assertEqual(torch_fp32_tensor.dtype, torch.float32)
-        self.assertEqual(
-            torch_fp32_tensor.data_ptr(), gpu_array.__cuda_array_interface__["data"][0]
-        )
-        self.assertEqual(torch_fp32_tensor.nbytes, 200)
+        assert torch_fp32_tensor.dtype == torch.float32
+        assert torch_fp32_tensor.data_ptr() == gpu_array.__cuda_array_interface__["data"][0]
+        assert torch_fp32_tensor.nbytes == 200
 
 
-class TensorTests(unittest.TestCase):
+class TestTensor:
     @pytest.mark.skipif(cupy is None, reason="Skipping gpu memory, cupy not installed")
     def test_cpu_to_gpu(self):
-        if cupy is None:
-            return
         cpu_array = numpy.random.rand(1, 3, 100, 100).astype(numpy.float32)
         cpu_tensor = tritonserver.Tensor.from_dlpack(cpu_array)
         gpu_tensor = cpu_tensor.to_device("gpu:0")
         gpu_array = cupy.from_dlpack(gpu_tensor)
 
-        self.assertEqual(gpu_array.device, cupy.cuda.Device(0))
+        assert gpu_array.device == cupy.cuda.Device(0)
 
         numpy.testing.assert_array_equal(cpu_array, gpu_array.get())
 
         memory_buffer = tritonserver.MemoryBuffer.from_dlpack(gpu_array)
 
-        self.assertEqual(
-            gpu_array.__cuda_array_interface__["data"][0], memory_buffer.data_ptr
-        )
+        assert gpu_array.__cuda_array_interface__["data"][0] == memory_buffer.data_ptr
 
-    @pytest.mark.skipif(
-        torch is None, reason="Skipping gpu memory, torch not installed"
-    )
+    @pytest.mark.skipif(torch is None, reason="Skipping gpu memory, torch not installed")
     @pytest.mark.skipif(cupy is None, reason="Skipping gpu memory, cupy not installed")
     def test_gpu_tensor_from_dl_pack(self):
-        if cupy is None or torch is None:
-            return
         cupy_array = cupy.ones([100]).astype(cupy.float64)
         tensor = tritonserver.Tensor.from_dlpack(cupy_array)
         torch_tensor = torch.from_dlpack(cupy_array)
 
-        self.assertEqual(torch_tensor.data_ptr(), tensor.data_ptr)
-        self.assertEqual(torch_tensor.nbytes, tensor.size)
-        self.assertEqual(torch_tensor.__dlpack_device__(), tensor.__dlpack_device__())
+        assert torch_tensor.data_ptr() == tensor.data_ptr
+        assert torch_tensor.nbytes == tensor.size
+        assert torch_tensor.__dlpack_device__() == tensor.__dlpack_device__()
 
     @pytest.mark.skipif(torch is None, reason="Skipping test, torch not installed")
     def test_tensor_from_numpy(self):
@@ -313,42 +267,36 @@ class TensorTests(unittest.TestCase):
         tensor = tritonserver.Tensor.from_dlpack(cpu_array)
         torch_tensor = torch.from_dlpack(tensor)
         numpy.testing.assert_array_equal(torch_tensor.numpy(), cpu_array)
-        self.assertEqual(torch_tensor.data_ptr(), cpu_array.ctypes.data)
+        assert torch_tensor.data_ptr() == cpu_array.ctypes.data
 
 
-class ServerTests(unittest.TestCase):
-    def setup_method(self, method):
-        self._server_options = copy.copy(server_options)
-        self._server_options.log_file = os.path.join(
-            test_logs_directory, method.__name__ + ".server.log"
-        )
-
+class TestServer:
     def test_not_started(self):
         server = tritonserver.Server()
-        with self.assertRaises(tritonserver.InvalidArgumentError):
+        with pytest.raises(tritonserver.InvalidArgumentError):
             server.ready()
 
     def test_invalid_option_type(self):
         server = tritonserver.Server(server_id=1)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             server.start()
 
         server = tritonserver.Server(model_repository=1)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             server.start()
 
     def test_invalid_repo(self):
-        with self.assertRaises(tritonserver.InternalError):
+        with pytest.raises(tritonserver.InternalError):
             tritonserver.Server(model_repository="foo").start()
 
-    def test_ready(self):
-        server = tritonserver.Server(self._server_options).start()
-        self.assertTrue(server.ready())
+    def test_ready(self, server_options):
+        server = tritonserver.Server(server_options).start()
+        assert server.ready()
 
-    def test_stop(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_stop(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -376,22 +324,16 @@ class ServerTests(unittest.TestCase):
         server.stop()
 
     def test_model_repository_not_specified(self):
-        with self.assertRaises(tritonserver.InvalidArgumentError):
+        with pytest.raises(tritonserver.InvalidArgumentError):
             tritonserver.Server(model_repository=None).start()
 
 
-class InferenceTests(unittest.TestCase):
-    def setup_method(self, method):
-        self._server_options = copy.copy(server_options)
-        self._server_options.log_file = os.path.join(
-            test_logs_directory, method.__name__ + ".server.log"
-        )
-
+class TestInference:
     @pytest.mark.skipif(cupy is None, reason="Skipping gpu memory, cupy not installed")
-    def test_gpu_output(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_gpu_output(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -412,14 +354,14 @@ class InferenceTests(unittest.TestCase):
             output_memory_type="gpu",
         ):
             fp16_output = cupy.from_dlpack(response.outputs["fp16_output"])
-            self.assertEqual(fp16_input[0][0], fp16_output[0][0])
+            assert fp16_input[0][0] == fp16_output[0][0]
 
         for response in server.model("test").infer(
             inputs={"string_input": [["hello"]]},
             output_memory_type="gpu",
         ):
             text_output = response.outputs["string_output"].to_string_array()
-            self.assertEqual(text_output[0][0], "hello")
+            assert text_output[0][0] == "hello"
 
         for response in server.model("test").infer(
             inputs={"string_input": tritonserver.Tensor.from_string_array([["hello"]])},
@@ -427,12 +369,12 @@ class InferenceTests(unittest.TestCase):
         ):
             text_output = response.outputs["string_output"].to_string_array()
             text_output = response.outputs["string_output"].to_string_array()
-            self.assertEqual(text_output[0][0], "hello")
+            assert text_output[0][0] == "hello"
 
-    def test_basic_inference(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_basic_inference(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -470,15 +412,13 @@ class InferenceTests(unittest.TestCase):
             raise_on_error=True,
         ):
             for input_name, input_value in inputs.items():
-                output_value = numpy.from_dlpack(
-                    response.outputs[input_name.replace("input", "output")]
-                )
+                output_value = numpy.from_dlpack(response.outputs[input_name.replace("input", "output")])
                 numpy.testing.assert_array_equal(input_value, output_value)
 
-    def test_parameters(self):
-        server = tritonserver.Server(self._server_options).start(wait_until_ready=True)
+    def test_parameters(self, server_options):
+        server = tritonserver.Server(server_options).start(wait_until_ready=True)
 
-        self.assertTrue(server.ready())
+        assert server.ready()
 
         server.load(
             "test",
@@ -508,12 +448,10 @@ class InferenceTests(unittest.TestCase):
         ):
             fp16_output = numpy.from_dlpack(response.outputs["fp16_output"])
             numpy.testing.assert_array_equal(fp16_input, fp16_output)
-            output_parameters = json.loads(
-                response.outputs["output_parameters"].to_string_array()[0]
-            )
+            output_parameters = json.loads(response.outputs["output_parameters"].to_string_array()[0])
             assert input_parameters == output_parameters
 
-        with self.assertRaises(tritonserver.InvalidArgumentError):
+        with pytest.raises(tritonserver.InvalidArgumentError):
             input_parameters = {
                 "invalid": {"test": 1},
             }
@@ -525,7 +463,7 @@ class InferenceTests(unittest.TestCase):
                 raise_on_error=True,
             )
 
-        with self.assertRaises(tritonserver.InvalidArgumentError):
+        with pytest.raises(tritonserver.InvalidArgumentError):
             input_parameters = {
                 "invalid": None,
             }


### PR DESCRIPTION
[Migrates test_api.py to pytest](https://github.com/triton-inference-server/core/commit/a147b5517f0d5dae5f64ca8db222a29d3c5a6e71)

Migrates test_api.py to pytest and removes `unittest`. Changes setup functions
to fixtures and replaces `unittest` assertion methods with regular Python `assert`s.

Also lowers the timeout for the server to make the tests run a bit faster.

[Updates test_binding.py to use pytest](https://github.com/triton-inference-server/core/commit/488fca7f48072f89be5f3b581c9b06f742558cfd)

Replaces all `unittest` APIs with equivalent `pytest` ones. This change
also updates the tests to use `tempfile` instead of manually creating and
removing files and directories.

[Parametrizes tests instead of running loops](https://github.com/triton-inference-server/core/pull/413/commits/8cced02512b407a800e65474707e5cdd7d479680)