### PR TITLE
Pin Pybind Version

### DIFF
--- a/python/tritonserver/CMakeLists.txt
+++ b/python/tritonserver/CMakeLists.txt
@@ -44,7 +44,7 @@ FetchContent_Declare(
   pybind11
   GIT_REPOSITORY "https://github.com/pybind/pybind11"
   # COMMIT ID for v2.10.0
-  GIT_TAG "aa304c9c7d725ffb9d10af08a3b34cb372307020"
+  GIT_TAG "3e9dfa2866941655c56877882565e7577de6fc7b"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(pybind11)

--- a/python/tritonserver/CMakeLists.txt
+++ b/python/tritonserver/CMakeLists.txt
@@ -43,7 +43,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY "https://github.com/pybind/pybind11"
-  # COMMIT ID for v2.10.0
+  # COMMIT ID for v2.12.0
   GIT_TAG "3e9dfa2866941655c56877882565e7577de6fc7b"
   GIT_SHALLOW ON
 )


### PR DESCRIPTION
Pin the version of Pybind to match the version set in the PYBE CMakeLists.txt

Server changes: https://github.com/triton-inference-server/server/pull/7859
PYBE changes: https://github.com/triton-inference-server/python_backend/pull/389