### PR TITLE
UTF-16 Path Support

### DIFF
--- a/src/filesystem/api.h
+++ b/src/filesystem/api.h
@@ -25,6 +25,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <codecvt>
+#include <locale>
 #include <string>
 
 #include "../status.h"
@@ -67,6 +69,20 @@ class LocalizedPath {
   // tmp directory for the lifetime of this object
   // FIXME: Remove when no longer required
   std::vector<std::shared_ptr<LocalizedPath>> other_localized_path;
+
+  static inline std::wstring string2wstring(const std::string& str)
+  {
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring wide = converter.from_bytes(str);
+    return wide;
+  }
+
+  static inline std::string wstring2string(const std::wstring& str)
+  {
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::string narrow = converter.to_bytes(str);
+    return narrow;
+  }
 
  private:
   std::string original_path_;

--- a/src/filesystem/api.h
+++ b/src/filesystem/api.h
@@ -32,6 +32,12 @@
 #include "../status.h"
 #include "google/protobuf/message.h"
 
+#ifdef _WIN32
+// suppress the min and max definitions in Windef.h.
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 namespace triton { namespace core {
 
 enum class FileSystemType { LOCAL, GCS, S3, AS };
@@ -70,14 +76,42 @@ class LocalizedPath {
   // FIXME: Remove when no longer required
   std::vector<std::shared_ptr<LocalizedPath>> other_localized_path;
 
-  static inline std::wstring string2wstring(const std::string& str)
+#ifdef _WIN32
+  //! Converts incoming utf-8 path to an OS valid path
+  //!
+  //! On Linux there is not much to do but make sure correct slashes are used
+  //! On Windows we need to take care of the long paths and handle them
+  //! correctly to avoid legacy issues with MAX_PATH
+  //!
+  //! More details:
+  //! https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+  //!
+  static inline std::wstring GetWindowsValidPath(const std::string& path)
+  {
+    std::string l_path(path);
+    // On Windows long paths must be marked correctly otherwise, due to
+    // backwards compatibility, all paths are limited to MAX_PATH length
+    static constexpr const char* kWindowsLongPathPrefix = "\\\\?\\";
+    if (l_path.size() >= MAX_PATH) {
+      // Must be prefixed with "\\?\" to be considered long path
+      if (l_path.substr(0, 4) != (kWindowsLongPathPrefix)) {
+        // Long path but not "tagged" correctly
+        l_path = (kWindowsLongPathPrefix) + l_path;
+      }
+    }
+    std::replace(l_path.begin(), l_path.end(), '/', '\\');
+    return String2Wstring(l_path);
+  }
+#endif  // _WIN32
+
+  static inline std::wstring String2Wstring(const std::string& str)
   {
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     std::wstring wide = converter.from_bytes(str);
     return wide;
   }
 
-  static inline std::string wstring2string(const std::wstring& str)
+  static inline std::string Wstring2String(const std::wstring& str)
   {
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
     std::string narrow = converter.to_bytes(str);

--- a/src/shared_library.cc
+++ b/src/shared_library.cc
@@ -64,7 +64,8 @@ SharedLibrary::SetLibraryDirectory(const std::string& path)
 {
 #ifdef _WIN32
   LOG_VERBOSE(1) << "SetLibraryDirectory: path = " << path;
-  if (!SetDllDirectory(path.c_str())) {
+  std::wstring wpath = LocalizedPath::string2wstring(path);
+  if (!SetDllDirectoryW(wpath.c_str())) {
     LPSTR err_buffer = nullptr;
     size_t size = FormatMessageA(
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
@@ -88,7 +89,7 @@ SharedLibrary::ResetLibraryDirectory()
 {
 #ifdef _WIN32
   LOG_VERBOSE(1) << "ResetLibraryDirectory";
-  if (!SetDllDirectory(NULL)) {
+  if (!SetDllDirectoryW(NULL)) {
     LPSTR err_buffer = nullptr;
     size_t size = FormatMessageA(
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
@@ -130,7 +131,8 @@ SharedLibrary::OpenLibraryHandle(const std::string& path, void** handle)
   // HMODULE is typedef of void*
   // https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
   LOG_VERBOSE(1) << "OpenLibraryHandle: path = " << path;
-  *handle = LoadLibrary(path.c_str());
+  std::wstring wpath = LocalizedPath::string2wstring(path);
+  *handle = LoadLibraryW(wpath.c_str());
 
   // Remove the dll path added above... do this unconditionally before
   // check for failure in dll load.

--- a/src/shared_library.cc
+++ b/src/shared_library.cc
@@ -64,7 +64,7 @@ SharedLibrary::SetLibraryDirectory(const std::string& path)
 {
 #ifdef _WIN32
   LOG_VERBOSE(1) << "SetLibraryDirectory: path = " << path;
-  std::wstring wpath = LocalizedPath::string2wstring(path);
+  std::wstring wpath = LocalizedPath::GetWindowsValidPath(path);
   if (!SetDllDirectoryW(wpath.c_str())) {
     LPSTR err_buffer = nullptr;
     size_t size = FormatMessageA(
@@ -131,7 +131,7 @@ SharedLibrary::OpenLibraryHandle(const std::string& path, void** handle)
   // HMODULE is typedef of void*
   // https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
   LOG_VERBOSE(1) << "OpenLibraryHandle: path = " << path;
-  std::wstring wpath = LocalizedPath::string2wstring(path);
+  std::wstring wpath = LocalizedPath::GetWindowsValidPath(path);
   *handle = LoadLibraryW(wpath.c_str());
 
   // Remove the dll path added above... do this unconditionally before


### PR DESCRIPTION
Triton core server does not currently support paths that contain special unicode characters. This PR aims to fix this by decoding the paths just before use to a "std::wstring" and pass it to the relevant UTF16 supporting variants of functions being used in the core.