### PR TITLE
refactor: return error if tensorflow related configs are found by AutoCompleteBackendFields

### DIFF
--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/model_config_utils.cc
+++ b/src/model_config_utils.cc
@@ -1072,55 +1072,43 @@ AutoCompleteBackendFields(
 
   // Trying to fill the 'backend', 'default_model_filename' field.
 
-  // TensorFlow
-  // For TF backend, the platform is required
-  if (config->platform().empty()) {
-    // Check 'backend', 'default_model_filename', and the actual directory
-    // to determine the platform
-    if (config->backend().empty() ||
-        (config->backend() == kTensorFlowBackend)) {
-      if (config->default_model_filename() == kTensorFlowSavedModelFilename) {
-        config->set_platform(kTensorFlowSavedModelPlatform);
-      } else if (
-          config->default_model_filename() == kTensorFlowGraphDefFilename) {
-        config->set_platform(kTensorFlowGraphDefPlatform);
-      } else if (config->default_model_filename().empty() && has_version) {
-        bool is_dir = false;
-        if (version_dir_content.find(kTensorFlowSavedModelFilename) !=
-            version_dir_content.end()) {
-          RETURN_IF_ERROR(IsDirectory(
-              JoinPath({version_path, kTensorFlowSavedModelFilename}),
-              &is_dir));
-          if (is_dir) {
-            config->set_platform(kTensorFlowSavedModelPlatform);
-          }
-        }
-        if (version_dir_content.find(kTensorFlowGraphDefFilename) !=
-            version_dir_content.end()) {
-          RETURN_IF_ERROR(IsDirectory(
-              JoinPath({version_path, kTensorFlowGraphDefFilename}), &is_dir));
-          if (!is_dir) {
-            config->set_platform(kTensorFlowGraphDefPlatform);
-          }
-        }
+  // TensorFlow is not supported since version 25.03.
+  // Return error if TensorFlow is found being set or TensorFlow models are
+  // found in the version directory.
+  if ((config->backend() == kTensorFlowBackend) ||
+      (config->platform() == kTensorFlowSavedModelPlatform) ||
+      (config->platform() == kTensorFlowGraphDefPlatform) ||
+      (config->default_model_filename() == kTensorFlowSavedModelFilename) ||
+      (config->default_model_filename() == kTensorFlowGraphDefFilename)) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "TensorFlow backend is not supported since version 25.03, please do "
+        "NOT set backend, platform or default_model_filename related to "
+        "TensorFlow.");
+  } else if (has_version) {
+    bool is_dir = false;
+    if (version_dir_content.find(kTensorFlowSavedModelFilename) !=
+        version_dir_content.end()) {
+      RETURN_IF_ERROR(IsDirectory(
+          JoinPath({version_path, kTensorFlowSavedModelFilename}), &is_dir));
+      if (is_dir) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "TensorFlow is not supported since version 25.03, however, " +
+                kTensorFlowSavedModelFilename + " dir is found.");
       }
     }
-  }
-
-  // Fill 'backend' and 'default_model_filename' if missing
-  if ((config->platform() == kTensorFlowSavedModelPlatform) ||
-      (config->platform() == kTensorFlowGraphDefPlatform)) {
-    if (config->backend().empty()) {
-      config->set_backend(kTensorFlowBackend);
-    }
-    if (config->default_model_filename().empty()) {
-      if (config->platform() == kTensorFlowSavedModelPlatform) {
-        config->set_default_model_filename(kTensorFlowSavedModelFilename);
-      } else {
-        config->set_default_model_filename(kTensorFlowGraphDefFilename);
+    if (version_dir_content.find(kTensorFlowGraphDefFilename) !=
+        version_dir_content.end()) {
+      RETURN_IF_ERROR(IsDirectory(
+          JoinPath({version_path, kTensorFlowGraphDefFilename}), &is_dir));
+      if (!is_dir) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "TensorFlow is not supported for version >= 25.03, however, " +
+                kTensorFlowGraphDefFilename + " file is found.");
       }
     }
-    return Status::Success;
   }
 
   // TensorRT


### PR DESCRIPTION
#### What does the PR do?
Since 25.03, TensorFlow backend is no longer supported by Triton. So if TF related configs are detected by AutoCompleteBackendFields, it should throw error.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [] Added [test plan](#test-plan) and verified test passes.
- [] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [] perf
- [x] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:

#### Where should the reviewer start?


#### Test plan:
WIP

- CI Pipeline ID:

#### Caveats:

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
