### PR TITLE
fix: Pass raise_on_error to response iterators

### DIFF
--- a/python/tritonserver/_api/_model.py
+++ b/python/tritonserver/_api/_model.py
@@ -179,7 +179,7 @@ class Model:
 
         request = inference_request._create_tritonserver_inference_request()
         self._server.infer_async(request)
-        return AsyncResponseIterator(self, request, inference_request)
+        return AsyncResponseIterator(self, request, inference_request, raise_on_error)
 
     def infer(
         self,
@@ -250,7 +250,7 @@ class Model:
 
         request = inference_request._create_tritonserver_inference_request()
         self._server.infer_async(request)
-        return ResponseIterator(self, request, inference_request)
+        return ResponseIterator(self, request, inference_request, raise_on_error)
 
     def metadata(self) -> dict[str, Any]:
         """Returns medatadata about a model and its inputs and outputs


### PR DESCRIPTION
#### What does the PR do?
Pass the raise_on_error flag from infer functions to its response iterator.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
N/A

- CI Pipeline ID: [See [GitHub action tests](https://github.com/triton-inference-server/core/actions/runs/15121897865/job/42505966965?pr=439)]

#### Caveats:
N/A

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx