### PR TITLE
fix: wrong cast of string value for sequence_id in ensemble scheduler

### DIFF
--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -669,7 +669,7 @@ EnsembleContext::ConsumeResponse(const std::unique_ptr<Step>& completed_step)
             break;
           case TRITONSERVER_PARAMETER_STRING:
             correlation_id = InferenceRequest::SequenceId(
-                std::string(*reinterpret_cast<const char* const*>(vvalue)));
+                std::string(reinterpret_cast<const char*>(vvalue)));
             parameter_override = true;
             break;
           default:


### PR DESCRIPTION
This PR fixes the wrong cast of sequence_id in ensemble scheduler if a string value is stored.