### PR TITLE
fix: Fix core pull request workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: nvcr.io/nvidia/tritonserver:25.06-py3
+      image: nvcr.io/nvidia/tritonserver:24.10-py3
       volumes:
         - ${{ github.workspace }}:/core
         # Mount /usr so we can free space
@@ -35,7 +35,7 @@ jobs:
           apt update
           apt install -y --no-install-recommends clang-format-15 cmake libb64-dev rapidjson-dev libre2-dev
           wget -O /tmp/boost.tar.gz https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && (cd /tmp && tar xzf boost.tar.gz) && mv /tmp/boost_1_80_0/boost /usr/include/boost && rm /tmp/boost.tar.gz
-          pip install build pytest
+          pip install build pytest pytest-asyncio
 
       - name: Build
         run: |


### PR DESCRIPTION
Currently any new PR to core is blocked. https://github.com/triton-inference-server/core/pull/442/commits
The pipeline passed before because the following two tests were unintentionally skipped. See https://github.com/triton-inference-server/core/actions/runs/15383261092/job/43277349990.
```
=============================== warnings summary ===============================
python/test/test_api.py:443
  /core/python/test/test_api.py:443: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

python/test/test_api.py:536
  /core/python/test/test_api.py:536: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED python/test/test_api.py::TestInference::test_basic_async_inference - Failed: async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
FAILED python/test/test_api.py::TestInference::test_async_inference_with_response_queue - Failed: async def functions are not natively supported.
You need to install a suitable plugin for your async framework, for example:
  - anyio
  - pytest-asyncio
  - pytest-tornasync
  - pytest-trio
  - pytest-twisted
== 2 failed, 79 passed, 6 skipped, 1 xfailed, 2 warnings in 101.66s (0:01:41) ==
```