### PR TITLE
Update cupy-cud13x version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-GPU = ["cupy-cuda12x"]
+GPU = ["cupy-cuda13x"]
 test = ["pytest"]
 all = ["tritonserver[GPU]", "tritonserver[test]"]
 


### PR DESCRIPTION
cuda-cupy package has been released with support of CUDA 13.
Updating configuration in order to confirm that the package can be used.

Related to: https://github.com/triton-inference-server/server/pull/8377