### PR TITLE
fix: Avoid invoking internal release callback multiple times when reusing request object

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1041,7 +1041,8 @@ TRITONSERVER_InferenceRequestNew(
     struct TRITONSERVER_Server* server, const char* model_name,
     const int64_t model_version);
 
-/// Delete an inference request object.
+/// Delete an inference request object. The request object must be
+/// released before deletion.
 ///
 /// \param inference_request The request object.
 /// \return a TRITONSERVER_Error indicating success or failure.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -548,7 +548,7 @@ class InferenceRequest {
   // and they will be invoked in reversed order.
   Status AddInternalReleaseCallback(InternalReleaseFn&& callback)
   {
-    release_callbacks_.emplace_back(std::move(callback));
+    release_callbacks_.emplace_back(std::make_pair(std::move(callback), true));
     return Status::Success;
   }
 
@@ -832,8 +832,9 @@ class InferenceRequest {
   TRITONSERVER_InferenceRequestReleaseFn_t release_fn_;
   void* release_userp_;
 
-  // Additional release callbacks invoked before 'release_fn_'.
-  std::vector<InternalReleaseFn> release_callbacks_;
+  // Additional release callbacks invoked before 'release_fn_'. Set boolean to
+  // true if release callback is internal and should be evicted after invoking.
+  std::vector<std::pair<InternalReleaseFn, bool>> release_callbacks_;
 
   // Delegator to be invoked on sending responses.
   std::function<void(std::unique_ptr<InferenceResponse>&&, const uint32_t)>


### PR DESCRIPTION
Avoid adding duplicated internal release callback and invoking multiple times when reusing request object
Add a boolean flag to indicate internal release callbacks.