### PR TITLE
fix: RequestTracker counter mismatch

### DIFF
--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -87,7 +87,24 @@ class RequestTracker {
   {
   }
 
+  // Unsynchronized access -- only safe under EnsembleContext::mutex_ during
+  // normal (non-finalization) paths where no concurrent Release can occur.
   std::unique_ptr<InferenceRequest>& Request() { return request_; }
+
+  // Thread-safe accessors for the error-finalization path where request_
+  // may be concurrently moved by DecrementCounter -> Release.
+  bool IsCancelled()
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    return (request_ == nullptr) || request_->IsCancelled();
+  }
+
+  std::string LogRequest()
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    return (request_ != nullptr) ? request_->LogRequest()
+                                 : std::string("[request released] ");
+  }
 
   InferenceStatsAggregator* StatsAggregator() { return stats_aggregator_; }
 
@@ -141,6 +158,23 @@ class RequestTracker {
     status_ = status;
   }
 
+  void RespondIfError(const Status& status, FailureReason reason)
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (request_ != nullptr) {
+      InferenceRequest::RespondIfError(
+          request_, status, false /* release_request */, reason);
+    }
+  }
+
+  void SendFlags(const uint32_t flags)
+  {
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (request_ != nullptr) {
+      request_->ResponseFactory()->SendFlags(flags);
+    }
+  }
+
  private:
   std::mutex mtx_;
   uint32_t inflight_request_counter_;
@@ -153,6 +187,7 @@ class RequestTracker {
   triton::common::ThreadPool* const callback_pool_;
 };
 
+using RequestTrackerReference = std::shared_ptr<RequestTracker>;
 // Step is used as 'userp' and keeps ensemble context alive
 // until no more internal requests are inflight.
 // Step contains metadata, and status for the
@@ -188,6 +223,12 @@ struct Step {
   const bool preserve_responses_order_;
 
   size_t step_idx_;
+
+  // Raw pointer to the heap-allocated RequestTrackerReference passed as
+  // release callback userp.  Normally freed by RequestComplete when the
+  // request is released; stored here so ScheduleSteps can clean it up if
+  // InferAsync fails and the release callback will never fire.
+  RequestTrackerReference* tracker_ref_{nullptr};
 };
 
 struct TensorData {
@@ -396,7 +437,7 @@ class EnsembleContext {
 
   // Objects related to the ensemble infer request
   Status ensemble_status_;
-  RequestTracker* request_tracker_;
+  std::shared_ptr<RequestTracker> request_tracker_;
   // Use in conjunction with 'is_decoupled_' in EnsembleInfo to
   // better distinguish ensemble ending behavior (see annotation in
   // FinishEnsemble for details).
@@ -429,7 +470,7 @@ EnsembleContext::EnsembleContext(
 {
   uint64_t compute_start_ns = 0;
   INFER_STATS_SET_TIMESTAMP(compute_start_ns);
-  request_tracker_ = new RequestTracker(
+  request_tracker_ = std::make_shared<RequestTracker>(
       std::move(request), compute_start_ns, metric_reporter, stats_aggregator,
       callback_pool);
 
@@ -646,16 +687,18 @@ void
 EnsembleContext::RequestComplete(
     TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
 {
-  auto request_tracker = reinterpret_cast<RequestTracker*>(userp);
+  auto request_tracker_ref =
+      reinterpret_cast<RequestTrackerReference*>(userp);
+  auto request_tracker = *request_tracker_ref;
   auto pool = request_tracker->CallbackPool();
-  auto fn = [request, flags, request_tracker]() {
+  auto fn = [request, flags, request_tracker, request_tracker_ref]() {
     if ((flags & TRITONSERVER_REQUEST_RELEASE_ALL) != 0) {
+      std::unique_ptr<RequestTrackerReference> managed_tracker_ref(
+          request_tracker_ref);
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(request),
           "deleting ensemble inference request");
-      if (request_tracker->DecrementCounter()) {
-        delete request_tracker;
-      }
+      request_tracker->DecrementCounter();
     }
   };
 
@@ -1070,12 +1113,18 @@ EnsembleContext::InitStep(
   irequest->SetSecondaryStatsAggregator(
       &request_tracker_->ContextStatsAggregator());
 #endif
+  // Heap-allocate a shared_ptr to the tracker so it can be passed through the
+  // C callback API (void* userp).  Ownership transfers to the callback on
+  // successful PrepareForInference; cleaned up by unique_ptr on early return.
+  auto request_tracker_ref =
+      std::make_unique<RequestTrackerReference>(request_tracker_);
   irequest->SetResponseCallback(
       reinterpret_cast<ResponseAllocator*>(allocator_.get()), step->get(),
       ResponseComplete, step->get());
-  irequest->SetReleaseCallback(RequestComplete, request_tracker_);
+  irequest->SetReleaseCallback(RequestComplete, request_tracker_ref.get());
 
   RETURN_IF_ERROR(irequest->PrepareForInference());
+  (*step)->tracker_ref_ = request_tracker_ref.release();
 
 #ifdef TRITON_ENABLE_TRACING
   auto& parent_trace = request_tracker_->Request()->TraceProxy();
@@ -1220,16 +1269,13 @@ EnsembleContext::FinishEnsemble(std::unique_ptr<InferenceResponse>&& response)
         ensemble_status_ = Status(
             Status::Code::INVALID_ARG,
             "in ensemble '" + info_->ensemble_name_ + "', " +
-                request_tracker_->Request()->LogRequest() +
+                request_tracker_->LogRequest() +
                 "unexpected deadlock, at least one output is not set while no "
                 "more "
                 "ensemble steps can be made");
-        InferenceRequest::RespondIfError(
-            request_tracker_->Request(), ensemble_status_,
-            false /* release_requests */, FailureReason::OTHER);
+        request_tracker_->RespondIfError(ensemble_status_, FailureReason::OTHER);
       } else {
-        request_tracker_->Request()->ResponseFactory()->SendFlags(
-            TRITONSERVER_RESPONSE_COMPLETE_FINAL);
+        request_tracker_->SendFlags(TRITONSERVER_RESPONSE_COMPLETE_FINAL);
       }
     }
   } else {
@@ -1239,9 +1285,7 @@ EnsembleContext::FinishEnsemble(std::unique_ptr<InferenceResponse>&& response)
             std::move(response), TRITONSERVER_RESPONSE_COMPLETE_FINAL,
             ensemble_status_);
       } else {
-        InferenceRequest::RespondIfError(
-            request_tracker_->Request(), ensemble_status_,
-            false /* release_requests */, FailureReason::OTHER);
+        request_tracker_->RespondIfError(ensemble_status_, FailureReason::OTHER);
       }
       error_response_sent_ = true;
     }
@@ -1251,10 +1295,8 @@ EnsembleContext::FinishEnsemble(std::unique_ptr<InferenceResponse>&& response)
     // Reach here when the ensemble execution comes to the end,
     // 'ensemble_status_' at this point is representative.
     request_tracker_->SetStatus(ensemble_status_);
-    if (request_tracker_->DecrementCounter()) {
-      delete request_tracker_;
-    }
-    request_tracker_ = nullptr;
+    request_tracker_->DecrementCounter();
+    request_tracker_.reset();
   }
   return ensemble_status_;
 }
@@ -1436,7 +1478,7 @@ EnsembleContext::ScheduleSteps(
     if (should_schedule) {
       // If the ensemble request is cancelled, propagate the cancellation to the
       // next request step.
-      if (context->request_tracker_->Request()->IsCancelled()) {
+      if (context->request_tracker_->IsCancelled()) {
         step->request_->Cancel();
       }
       // Acquire a slot from the per-step shared limiter only for steps that
@@ -1477,8 +1519,14 @@ EnsembleContext::ScheduleSteps(
     }
 
     std::lock_guard<std::mutex> lock(context->mutex_);
-    // Decrement only when IncrementCounter was called. An unconditional
-    // decrement would underflow the counter and cause a use-after-free.
+    // The request is not sent to server properly, shouldn't expect its
+    // release function get called.  Clean up the heap-allocated tracker
+    // reference that would normally be freed by RequestComplete.
+    delete step->tracker_ref_;
+    step->tracker_ref_ = nullptr;
+    // Only undo IncrementCounter() for steps that actually reached the
+    // scheduling path. Otherwise the counter can underflow and release the
+    // top-level request while FinishEnsemble is still using it.
     if (should_schedule) {
       context->request_tracker_->DecrementCounter();
     }

--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -87,12 +87,11 @@ class RequestTracker {
   {
   }
 
-  // Unsynchronized access -- only safe under EnsembleContext::mutex_ during
-  // normal (non-finalization) paths where no concurrent Release can occur.
+  // Accessed without additional synchronization while protected by
+  // EnsembleContext::mutex_.
   std::unique_ptr<InferenceRequest>& Request() { return request_; }
 
-  // Thread-safe accessors for the error-finalization path where request_
-  // may be concurrently moved by DecrementCounter -> Release.
+  // Used from paths where request_ may be released concurrently.
   bool IsCancelled()
   {
     std::lock_guard<std::mutex> lk(mtx_);
@@ -224,10 +223,8 @@ struct Step {
 
   size_t step_idx_;
 
-  // Raw pointer to the heap-allocated RequestTrackerReference passed as
-  // release callback userp.  Normally freed by RequestComplete when the
-  // request is released; stored here so ScheduleSteps can clean it up if
-  // InferAsync fails and the release callback will never fire.
+  // Release callback userp. ScheduleSteps may clean this up directly if
+  // InferAsync fails before the release callback is installed.
   RequestTrackerReference* tracker_ref_{nullptr};
 };
 

--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -687,8 +687,7 @@ void
 EnsembleContext::RequestComplete(
     TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
 {
-  auto request_tracker_ref =
-      reinterpret_cast<RequestTrackerReference*>(userp);
+  auto request_tracker_ref = reinterpret_cast<RequestTrackerReference*>(userp);
   auto request_tracker = *request_tracker_ref;
   auto pool = request_tracker->CallbackPool();
   auto fn = [request, flags, request_tracker, request_tracker_ref]() {
@@ -1273,7 +1272,8 @@ EnsembleContext::FinishEnsemble(std::unique_ptr<InferenceResponse>&& response)
                 "unexpected deadlock, at least one output is not set while no "
                 "more "
                 "ensemble steps can be made");
-        request_tracker_->RespondIfError(ensemble_status_, FailureReason::OTHER);
+        request_tracker_->RespondIfError(
+            ensemble_status_, FailureReason::OTHER);
       } else {
         request_tracker_->SendFlags(TRITONSERVER_RESPONSE_COMPLETE_FINAL);
       }
@@ -1285,7 +1285,8 @@ EnsembleContext::FinishEnsemble(std::unique_ptr<InferenceResponse>&& response)
             std::move(response), TRITONSERVER_RESPONSE_COMPLETE_FINAL,
             ensemble_status_);
       } else {
-        request_tracker_->RespondIfError(ensemble_status_, FailureReason::OTHER);
+        request_tracker_->RespondIfError(
+            ensemble_status_, FailureReason::OTHER);
       }
       error_response_sent_ = true;
     }
@@ -1510,7 +1511,6 @@ EnsembleContext::ScheduleSteps(
 
     // Reaching here means the step is not being scheduled, update corresponding
     // counters and attempt to finish ensemble if it is the last step.
-
 
     // Release the limiter slot if one was acquired, and update counters.
     if (should_schedule &&

--- a/src/ensemble_scheduler/ensemble_scheduler.cc
+++ b/src/ensemble_scheduler/ensemble_scheduler.cc
@@ -223,9 +223,10 @@ struct Step {
 
   size_t step_idx_;
 
-  // Release callback userp. ScheduleSteps may clean this up directly if
-  // InferAsync fails before the release callback is installed.
-  RequestTrackerReference* tracker_ref_{nullptr};
+  // Heap allocation passed as the release-callback userp. The allocation
+  // stores a shared_ptr<RequestTracker> so the tracker stays alive until the
+  // release callback or local failure cleanup drops this reference.
+  RequestTrackerReference* callback_tracker_ref_{nullptr};
 };
 
 struct TensorData {
@@ -684,13 +685,13 @@ void
 EnsembleContext::RequestComplete(
     TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
 {
-  auto request_tracker_ref = reinterpret_cast<RequestTrackerReference*>(userp);
-  auto request_tracker = *request_tracker_ref;
+  auto callback_tracker_ref = reinterpret_cast<RequestTrackerReference*>(userp);
+  auto request_tracker = *callback_tracker_ref;
   auto pool = request_tracker->CallbackPool();
-  auto fn = [request, flags, request_tracker, request_tracker_ref]() {
+  auto fn = [request, flags, request_tracker, callback_tracker_ref]() {
     if ((flags & TRITONSERVER_REQUEST_RELEASE_ALL) != 0) {
-      std::unique_ptr<RequestTrackerReference> managed_tracker_ref(
-          request_tracker_ref);
+      std::unique_ptr<RequestTrackerReference> managed_callback_tracker_ref(
+          callback_tracker_ref);
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(request),
           "deleting ensemble inference request");
@@ -1109,18 +1110,19 @@ EnsembleContext::InitStep(
   irequest->SetSecondaryStatsAggregator(
       &request_tracker_->ContextStatsAggregator());
 #endif
-  // Heap-allocate a shared_ptr to the tracker so it can be passed through the
-  // C callback API (void* userp).  Ownership transfers to the callback on
-  // successful PrepareForInference; cleaned up by unique_ptr on early return.
-  auto request_tracker_ref =
+  // Heap-allocate the release-callback userp because the C callback API only
+  // stores a raw void*. The heap object itself is single-owner here, while the
+  // object stored inside it is a shared_ptr<RequestTracker> that keeps the
+  // tracker alive until the callback or local cleanup drops this reference.
+  auto callback_tracker_ref =
       std::make_unique<RequestTrackerReference>(request_tracker_);
   irequest->SetResponseCallback(
       reinterpret_cast<ResponseAllocator*>(allocator_.get()), step->get(),
       ResponseComplete, step->get());
-  irequest->SetReleaseCallback(RequestComplete, request_tracker_ref.get());
+  irequest->SetReleaseCallback(RequestComplete, callback_tracker_ref.get());
 
   RETURN_IF_ERROR(irequest->PrepareForInference());
-  (*step)->tracker_ref_ = request_tracker_ref.release();
+  (*step)->callback_tracker_ref_ = callback_tracker_ref.release();
 
 #ifdef TRITON_ENABLE_TRACING
   auto& parent_trace = request_tracker_->Request()->TraceProxy();
@@ -1516,11 +1518,10 @@ EnsembleContext::ScheduleSteps(
     }
 
     std::lock_guard<std::mutex> lock(context->mutex_);
-    // The request is not sent to server properly, shouldn't expect its
-    // release function get called.  Clean up the heap-allocated tracker
-    // reference that would normally be freed by RequestComplete.
-    delete step->tracker_ref_;
-    step->tracker_ref_ = nullptr;
+    // The request never reaches the callback-owned release path, so drop the
+    // heap-allocated callback userp here.
+    delete step->callback_tracker_ref_;
+    step->callback_tracker_ref_ = nullptr;
     // Only undo IncrementCounter() for steps that actually reached the
     // scheduling path. Otherwise the counter can underflow and release the
     // top-level request while FinishEnsemble is still using it.

--- a/src/ensemble_scheduler/ensemble_scheduler.h
+++ b/src/ensemble_scheduler/ensemble_scheduler.h
@@ -27,7 +27,9 @@
 
 #ifdef TRITON_ENABLE_ENSEMBLE
 
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 
 #include "metric_model_reporter.h"
 #include "model.h"

--- a/src/ensemble_scheduler/ensemble_scheduler.h
+++ b/src/ensemble_scheduler/ensemble_scheduler.h
@@ -52,18 +52,22 @@ using cudaStream_t = void*;
 
 class InferenceServer;
 
-// Enforces a per-step limit on concurrent in-flight requests shared across
-// active requests for an ensemble model.
+// Enforces a per-step limit on concurrent in-flight requests, shared across
+// all active ensemble requests for a given ensemble model. Tracks in-flight
+// request count and blocks producers when the limit is reached.
 class StepInflightRequestLimiter {
  public:
   explicit StepInflightRequestLimiter(size_t max_inflight);
 
-  // Waits for capacity unless the request has already been cancelled.
+  // Blocks until a slot is available or the request is cancelled. Cancelled
+  // requests skip the wait so cancellation propagates via the normal
+  // step-scheduling path. The const reference prevents ownership transfer;
+  // only IsCancelled() is queried on the pointed-to request.
   void Acquire(
       const std::unique_ptr<InferenceRequest>& request, size_t step_idx,
       const std::string& ensemble_name);
 
-  // Releases one slot and wakes one waiting thread.
+  // Releases one acquired slot and wakes one waiting thread.
   void Release();
 
  private:
@@ -107,8 +111,14 @@ struct EnsembleInfo {
   // backward path, ensemble tensor to the step that provides its data
   std::unordered_map<std::string, size_t> tensor_to_prev_step_;
 
-  // Maximum concurrent in-flight requests allowed per ensemble step across
-  // all requests for this model. A value of 0 disables the limit.
+  // The maximum number of concurrent in-flight requests allowed at each
+  // ensemble step across all concurrent ensemble requests for this model.
+  // The limit is applied per step index and is shared across all concurrent
+  // requests for this ensemble model.
+  // This limit prevents unbounded memory growth when upstream steps
+  // produce responses faster than downstream steps can consume them.
+  // A value of 0 means no limit is enforced.
+  // Configured via the 'max_inflight_requests' field in ensemble_scheduling.
   size_t max_inflight_requests_ = 0;
   std::vector<std::unique_ptr<StepInflightRequestLimiter>>
       step_inflight_request_limiters_;

--- a/src/ensemble_scheduler/ensemble_scheduler.h
+++ b/src/ensemble_scheduler/ensemble_scheduler.h
@@ -52,22 +52,18 @@ using cudaStream_t = void*;
 
 class InferenceServer;
 
-// Enforces a per-step limit on concurrent in-flight requests, shared across
-// all active ensemble requests for a given ensemble model. Tracks in-flight
-// request count and blocks producers when the limit is reached.
+// Enforces a per-step limit on concurrent in-flight requests shared across
+// active requests for an ensemble model.
 class StepInflightRequestLimiter {
  public:
   explicit StepInflightRequestLimiter(size_t max_inflight);
 
-  // Blocks until a slot is available or the request is cancelled. Cancelled
-  // requests skip the wait so cancellation propagates via the normal
-  // step-scheduling path. The const reference prevents ownership transfer;
-  // only IsCancelled() is queried on the pointed-to request.
+  // Waits for capacity unless the request has already been cancelled.
   void Acquire(
       const std::unique_ptr<InferenceRequest>& request, size_t step_idx,
       const std::string& ensemble_name);
 
-  // Releases one acquired slot and wakes one waiting thread.
+  // Releases one slot and wakes one waiting thread.
   void Release();
 
  private:
@@ -111,14 +107,8 @@ struct EnsembleInfo {
   // backward path, ensemble tensor to the step that provides its data
   std::unordered_map<std::string, size_t> tensor_to_prev_step_;
 
-  // The maximum number of concurrent in-flight requests allowed at each
-  // ensemble step across all concurrent ensemble requests for this model.
-  // The limit is applied per step index and is shared across all concurrent
-  // requests for this ensemble model.
-  // This limit prevents unbounded memory growth when upstream steps
-  // produce responses faster than downstream steps can consume them.
-  // A value of 0 means no limit is enforced.
-  // Configured via the 'max_inflight_requests' field in ensemble_scheduling.
+  // Maximum concurrent in-flight requests allowed per ensemble step across
+  // all requests for this model. A value of 0 disables the limit.
   size_t max_inflight_requests_ = 0;
   std::vector<std::unique_ptr<StepInflightRequestLimiter>>
       step_inflight_request_limiters_;


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes a `RequestTracker` counter and lifetime mismatch in `ScheduleSteps()` that could prematurely release the top-level ensemble request when a parallel step failed to enqueue, typically surfacing after `FAILED_ENQUEUE` / `Exceeds maximum queue size` as a SIGSEGV during ensemble error finalization.

Issue
When multiple steps were prepared in a single `ScheduleSteps()` pass, the per-step cleanup path always called `RequestTracker::DecrementCounter()`, even for steps that never called `IncrementCounter()` because scheduling had already failed or been skipped. That could corrupt `inflight_request_counter_` and release the top-level request while `FinishEnsemble()` was still using it, leaving later error-handling and cleanup paths operating on invalid request-tracker state.

Fix
Preserve the shared per-step `max_inflight_requests` limiter flow from `main` while correcting the failure path in `ScheduleSteps()`.

Keep the top-level `RequestTracker` alive across async release and finalization using `std::shared_ptr`, and route cancellation, logging, and error response paths through synchronized helper methods.

Pass a heap-allocated `RequestTrackerReference` through the C release callback and explicitly clean it up for prepared steps that never reach the callback-owned release path.

Only call `RequestTracker::DecrementCounter()` for steps that actually called `IncrementCounter()`, while still decrementing `inflight_step_counter_` for unscheduled steps and releasing any acquired limiter slot.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
https://github.com/triton-inference-server/server/pull/8722

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->
The request processing follows this order:
PrepareSteps() in src/ensemble_scheduler/ensemble_scheduler.cc: 1011-1015
ScheduleSteps() decision to schedule and take the lifetime ref: 1467-1474
ScheduleSteps() handoff to InferAsync() and failure capture: 1496-1506
ScheduleSteps() local cleanup for unscheduled / failed-dispatch steps: 1512-1528
FinishEnsemble() final release of the top-level tracker: 1292-1297

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
Test case here:
https://github.com/triton-inference-server/server/pull/8722

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->
47868062

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
