### PR TITLE
build: add Conan 2 + CMakePresets build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ project(tritoncore LANGUAGES C CXX)
 # TRITON_CORE_HEADERS_ONLY=OFF to also build libtritonserver.so.
 option(TRITON_CORE_HEADERS_ONLY "Build only headers and stub" ON)
 
+option(TRITON_SKIP_THIRD_PARTY_FETCH
+  "Skip FetchContent/ExternalProject for third-party deps (provided by Conan)" OFF)
+
 #
 # Specifying min required C++ standard
 #
@@ -153,7 +156,7 @@ set_target_properties(
 #
 # Shared library implementing Triton Server API
 #
-if(NOT TRITON_CORE_HEADERS_ONLY)
+if(NOT TRITON_CORE_HEADERS_ONLY AND NOT TRITON_SKIP_THIRD_PARTY_FETCH)
   include(CMakeDependentOption)
 
   set(TRITON_VERSION "0.0.0" CACHE STRING "The version of the Triton shared library" )
@@ -357,7 +360,12 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
       -DTRITON_VERSION:STRING=${TRITON_VERSION}
     DEPENDS ${TRITON_DEPENDS}
   )
-endif() # NOT TRITON_CORE_HEADERS_ONLY
+endif() # NOT TRITON_CORE_HEADERS_ONLY AND NOT TRITON_SKIP_THIRD_PARTY_FETCH
+
+if(NOT TRITON_CORE_HEADERS_ONLY AND TRITON_SKIP_THIRD_PARTY_FETCH)
+  # When called from the parent server build — deps already provided by Conan
+  add_subdirectory(src)
+endif()
 
 #
 # Install

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,4 @@
+{
+  "version": 6,
+  "include": ["cmake/CMakePresets.json"]
+}

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -1,0 +1,63 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 31, "patch": 8 },
+  "$comment": "Standalone build presets for triton-core. For integrated server builds use server/cmake/CMakePresets.json — it includes core via add_subdirectory and its variables take precedence.",
+  "configurePresets": [
+    {
+      "name": "conan-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "toolchainFile": "${sourceDir}/build/${presetName}/conan/conan_toolchain.cmake",
+      "cacheVariables": { "CMAKE_EXPORT_COMPILE_COMMANDS": "ON" }
+    },
+    {
+      "name": "release",
+      "inherits": "conan-base",
+      "displayName": "Release (GPU + Metrics)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":      "Release",
+        "TRITON_ENABLE_GPU":     "ON",
+        "TRITON_ENABLE_METRICS": "ON",
+        "TRITON_CORE_HEADERS_ONLY": "OFF"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "conan-base",
+      "displayName": "Debug (GPU + Metrics)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":      "Debug",
+        "TRITON_ENABLE_GPU":     "ON",
+        "TRITON_ENABLE_METRICS": "ON",
+        "TRITON_CORE_HEADERS_ONLY": "OFF"
+      }
+    },
+    {
+      "name": "headers-only",
+      "inherits": "conan-base",
+      "displayName": "Headers only (no build)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":         "Release",
+        "TRITON_CORE_HEADERS_ONLY": "ON"
+      }
+    },
+    {
+      "name": "cpu-only",
+      "inherits": "conan-base",
+      "displayName": "Release CPU-only",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":         "Release",
+        "TRITON_ENABLE_GPU":        "OFF",
+        "TRITON_ENABLE_METRICS":    "ON",
+        "TRITON_CORE_HEADERS_ONLY": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "release",      "configurePreset": "release" },
+    { "name": "debug",        "configurePreset": "debug" },
+    { "name": "headers-only", "configurePreset": "headers-only" },
+    { "name": "cpu-only",     "configurePreset": "cpu-only" }
+  ]
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,53 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+
+
+class TritonCoreConan(ConanFile):
+    name = "triton-core"
+    version = "2.68.0"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "enable_gpu":     [True, False],
+        "enable_metrics": [True, False],
+        "headers_only":   [True, False],
+    }
+    default_options = {
+        "enable_gpu":     True,
+        "enable_metrics": True,
+        "headers_only":   False,
+    }
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("triton-core only supports Linux")
+
+    def requirements(self):
+        if not self.options.headers_only:
+            self.requires("protobuf/3.21.12")
+            self.requires("re2/20230301")
+            self.requires("rapidjson/cci.20230929")
+            if self.options.enable_gpu:
+                self.requires("cnmem/1.0.0")
+                self.requires("dcgm/4.5.3")
+            if self.options.enable_metrics:
+                self.requires("prometheus-cpp/1.2.4")
+
+    def configure(self):
+        if not self.options.headers_only:
+            if self.options.enable_metrics:
+                self.options["prometheus-cpp"].shared = False
+                self.options["prometheus-cpp"].with_pull = False
+                self.options["prometheus-cpp"].with_push = False
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TRITON_CORE_HEADERS_ONLY"]      = self.options.headers_only
+        tc.variables["TRITON_ENABLE_GPU"]             = self.options.enable_gpu
+        tc.variables["TRITON_ENABLE_METRICS"]         = self.options.enable_metrics
+        tc.variables["TRITON_SKIP_THIRD_PARTY_FETCH"] = True
+        tc.generate()
+        CMakeDeps(self).generate()

--- a/profiles/linux-gcc13-debug
+++ b/profiles/linux-gcc13-debug
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Debug
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin

--- a/profiles/linux-gcc13-release
+++ b/profiles/linux-gcc13-release
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Release
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,15 +40,17 @@ endif()
 #
 include(FetchContent)
 
-FetchContent_Declare(
-  repo-common
-  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/common.git
-  GIT_TAG ${TRITON_COMMON_REPO_TAG}
-)
+if(NOT TRITON_SKIP_THIRD_PARTY_FETCH)
+  FetchContent_Declare(
+    repo-common
+    GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/common.git
+    GIT_TAG ${TRITON_COMMON_REPO_TAG}
+  )
 
-set(TRITON_COMMON_ENABLE_PROTOBUF ON)
+  set(TRITON_COMMON_ENABLE_PROTOBUF ON)
 
-FetchContent_MakeAvailable(repo-common)
+  FetchContent_MakeAvailable(repo-common)
+endif()
 
 #
 # CUDA
@@ -262,7 +264,7 @@ else()
     triton-core
     PROPERTIES
       LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtritonserver.ldscript
-      LINK_FLAGS "-Wl,--version-script libtritonserver.ldscript"
+      LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtritonserver.ldscript"
   )
 endif()
 
@@ -287,11 +289,13 @@ target_include_directories(
 )
 
 if(${TRITON_ENABLE_GPU})
-  target_include_directories(
-    triton-core
-    PRIVATE
-      ${CNMEM_PATH}/include
-  )
+  if(NOT TARGET cnmem::cnmem)
+    target_include_directories(
+      triton-core
+      PRIVATE
+        ${CNMEM_PATH}/include
+    )
+  endif()
 endif() # TRITON_ENABLE_GPU
 
 if(${TRITON_ENABLE_METRICS})
@@ -503,14 +507,16 @@ if(${TRITON_ENABLE_AZURE_STORAGE})
   )
 endif() # TRITON_ENABLE_AZURE_STORAGE
 
-if(${TRITON_ENABLE_GPU})
-  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
-  target_link_libraries(
-    triton-core
-    PRIVATE
-      ${CNMEM_LIBRARY}
-      CUDA::cudart
-  )
+if(TRITON_ENABLE_GPU)
+  if(TARGET cnmem::cnmem)
+    # Provided by Conan — use imported target
+    target_link_libraries(triton-core PRIVATE cnmem::cnmem CUDA::cudart)
+  else()
+    # Fallback for standalone builds
+    find_library(CNMEM_LIBRARY cnmem PATHS ${CNMEM_PATH}/lib)
+    target_include_directories(triton-core PRIVATE ${CNMEM_PATH}/include)
+    target_link_libraries(triton-core PRIVATE ${CNMEM_LIBRARY} CUDA::cudart)
+  endif()
 endif() # TRITON_ENABLE_GPU
 
 if(${TRITON_ENABLE_METRICS_GPU})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 #
 if(${TRITON_ENABLE_GPU})
   find_package(CUDAToolkit REQUIRED)
+  set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
 endif() # TRITON_ENABLE_GPU
 
 #

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -125,7 +125,6 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/..
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
-      ${CNMEM_PATH}/include
       ${Boost_INCLUDE_DIRS}
   )
 
@@ -136,8 +135,6 @@ if(${TRITON_ENABLE_GPU})
       TRITON_ENABLE_GPU=1
       TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
   )
-
-  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
 
   target_link_libraries(
     response_cache_test
@@ -150,7 +147,9 @@ if(${TRITON_ENABLE_GPU})
       GTest::gtest
       GTest::gtest_main
       protobuf::libprotobuf
-      ${CNMEM_LIBRARY}
+      cnmem::cnmem
+      rapidjson
+      re2::re2
       CUDA::cudart
   )
 
@@ -240,7 +239,6 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/..
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
-      ${CNMEM_PATH}/include
   )
 
   target_compile_definitions(
@@ -251,8 +249,6 @@ if(${TRITON_ENABLE_GPU})
       TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
   )
 
-  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
-
   target_link_libraries(
     memory_test
     PRIVATE
@@ -262,7 +258,7 @@ if(${TRITON_ENABLE_GPU})
       GTest::gtest
       GTest::gtest_main
       protobuf::libprotobuf
-      ${CNMEM_LIBRARY}
+      cnmem::cnmem
       CUDA::cudart
   )
 
@@ -307,7 +303,6 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/..
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
-      ${CNMEM_PATH}/include
   )
 
   target_compile_definitions(
@@ -318,8 +313,6 @@ if(${TRITON_ENABLE_GPU})
       TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
   )
 
-  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
-
   target_link_libraries(
     pinned_memory_manager_test
     PRIVATE
@@ -329,7 +322,7 @@ if(${TRITON_ENABLE_GPU})
       GTest::gtest
       GTest::gtest_main
       protobuf::libprotobuf
-      ${CNMEM_LIBRARY}
+      cnmem::cnmem
       CUDA::cudart
   )
 
@@ -500,7 +493,7 @@ if(${TRITON_ENABLE_METRICS})
     target_link_libraries(
       metrics_api_test
       PRIVATE
-        ${CNMEM_LIBRARY}
+        cnmem::cnmem
         CUDA::cudart
     )
   endif()
@@ -657,7 +650,6 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/..
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
-      ${CNMEM_PATH}/include
   )
 
   target_compile_definitions(
@@ -667,8 +659,6 @@ if(${TRITON_ENABLE_GPU})
       TRITON_ENABLE_GPU=1
       TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
   )
-
-  find_library(CNMEM_LIBRARY NAMES cnmem PATHS ${CNMEM_PATH}/lib)
 
   target_link_libraries(
     input_byte_size_test
@@ -683,7 +673,7 @@ if(${TRITON_ENABLE_GPU})
       GTest::gmock
       protobuf::libprotobuf
       CUDA::cudart
-      ${CNMEM_LIBRARY}
+      cnmem::cnmem
   )
 else()
   add_executable(

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -432,6 +432,7 @@ target_link_libraries(
     GTest::gtest
     GTest::gtest_main
     protobuf::libprotobuf
+    re2::re2
 )
 
 install(


### PR DESCRIPTION
<sup>
Resolves: TRI-122<br/>
triton-inference-server/backend#123<br/>
triton-inference-server/common#154<br/>
triton-inference-server/server#8734<br/>
triton-inference-server/third_party#74
</sup>

## Description

Introduces Conan 2 package manager and CMakePresets-based build system for dependency management in the core repository, as part of the broader Triton CMake/Conan migration (TRI-122).

## Changes

- build: add Conan 2 + CMakePresets build system

## Affected Files

- CMakeLists.txt
- CMakePresets.json
- cmake/CMakePresets.json
- conanfile.py
- profiles/linux-gcc13-debug
- profiles/linux-gcc13-release
- src/CMakeLists.txt
- src/test/CMakeLists.txt