### PR TITLE
fix: Validate and reject duplicate output names in inference requests

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -842,7 +842,13 @@ InferenceRequest::AddOverrideInput(
 Status
 InferenceRequest::AddOriginalRequestedOutput(const std::string& name)
 {
-  original_requested_outputs_.insert(name);
+  const auto& pr = original_requested_outputs_.emplace(name);
+  if (!pr.second) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        LogRequest() + "output '" + name + "' already exists in request");
+  }
+
   needs_normalization_ = true;
   return Status::Success;
 }


### PR DESCRIPTION
This PR adds request-level validation to reject duplicate output tensor names in inference requests, to resolve the following issue:
- When a user sends inference requests containing duplicate output tensor names, Triton allocates heap memory for each output but fails to release it when a name collision occurs, resulting in a linear memory leak.

CI: https://github.com/triton-inference-server/server/pull/8741