### PR TITLE
fix: child path test

### DIFF
--- a/src/filesystem/api.cc
+++ b/src/filesystem/api.cc
@@ -434,7 +434,7 @@ IsChildPathEscapingParentPath(
   // Ensure that the paths are identical or the first mismatch character in the
   // child path is a path separator ('/') to avoid partial matching
   // (i.e. "/parent" and "/parent_dir").
-  if (canonical_parent_path.find(canonical_child_path, 0) == 0 &&
+  if (canonical_child_path.find(canonical_parent_path, 0) == 0 &&
       ((canonical_child_path.size() > canonical_parent_path.size() &&
         canonical_child_path[canonical_parent_path.size()] == '/') ||
        (canonical_child_path.size() == canonical_parent_path.size()))) {


### PR DESCRIPTION
This change fixes a rather embarrasing mistake.

Fixes https://github.com/triton-inference-server/core/pull/497