### PR TITLE
fix: validate ensemble composing model names against path traversal

### DIFF
--- a/src/model_repository_manager/model_repository_manager.cc
+++ b/src/model_repository_manager/model_repository_manager.cc
@@ -1086,6 +1086,11 @@ ModelRepositoryManager::PollModels(
         const auto& config = info.second->model_config_;
         if (config.has_ensemble_scheduling()) {
           for (const auto& step : config.ensemble_scheduling().step()) {
+            // Composing model names are joined onto the repository path and
+            // passed to the filesystem during polling, so they must be
+            // validated for path-traversal characters just like the
+            // top-level model name in LoadUnloadModel().
+            RETURN_IF_ERROR(ValidateModelName(step.model_name()));
             next_models.emplace(step.model_name());
           }
         }


### PR DESCRIPTION
This PR validates ensemble composing model names against path traversal, extending the existing top-level model-name check to the composing models an ensemble references.

**Previously, `ValidateModelName()` (which rejects `..` and `/`) was applied only to the top-level requested model in `LoadUnloadModel()`. An ensemble's composing model names are read from the model config and fed into the polling loop, where each name is joined onto the repository path (`JoinPath`) and passed to `FileExists()` / `ReadTextProto()`. A composing name such as `../../etc` therefore escaped the model repository root: a model-load request could make the server read `config.pbtxt` files outside the repository and probe arbitrary host paths through the differing load response.**

_This change validates every composing step model name with `ValidateModelName()` before it is polled, matching the existing top-level check. Legitimate composing names are ordinary model names and are unaffected._

Reproduced on `nvcr.io/nvidia/tritonserver:26.04-py3` (CPU, `--model-control-mode=explicit`): loading an ensemble whose step `model_name` was `../secret` made the server read and parse `/secret/config.pbtxt` (a path mounted outside the repository), and a step `../../../../etc` made it enumerate `/etc`; the load response distinguished existing from non-existing targets. After this change the load is rejected with "model name must not contain path traversal characters".

Relates to the model-name validation hardening in #472 / #481.
