### PR TITLE
build: Remove Windows from core build (TRI-725)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,22 +126,11 @@ add_library(
 )
 target_compile_features(triton-core-serverstub PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  message("Using MSVC as compiler, default target on Windows 10. "
-		  "If the target system is not Windows 10, please update _WIN32_WINNT "
-		  "to corresponding value.")
-  target_compile_options(
-    triton-core-serverstub
-    PRIVATE
-      /Wall /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-  )
-else()
-  target_compile_options(
-    triton-core-serverstub
-    PRIVATE
-      -Wall -Wextra -Wno-unused-parameter -Werror
-  )
-endif()
+target_compile_options(
+  triton-core-serverstub
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter -Werror
+)
 
 set_target_properties(
   triton-core-serverstub
@@ -255,13 +244,8 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
     set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}")
   endif()
 
-  # Location where protobuf-config.cmake will be installed varies by
-  # platform
-  if (WIN32)
-    set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/cmake")
-  else()
-    set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/protobuf")
-  endif()
+  # Location where protobuf-config.cmake will be installed
+  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/protobuf")
 
   if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(TRITON_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,28 +246,17 @@ add_library(
 )
 
 target_compile_features(triton-core PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  message("Using MSVC as compiler, default target on Windows 10. "
-		  "If the target system is not Windows 10, please update _WIN32_WINNT "
-		  "to corresponding value.")
-  target_compile_options(
-    triton-core
-    PRIVATE
-      /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-  )
-else()
-  target_compile_options(
-    triton-core
-    PRIVATE
-      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
-  )
-  set_target_properties(
-    triton-core
-    PROPERTIES
-      LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtritonserver.ldscript
-      LINK_FLAGS "-Wl,--version-script libtritonserver.ldscript"
-  )
-endif()
+target_compile_options(
+  triton-core
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
+)
+set_target_properties(
+  triton-core
+  PROPERTIES
+    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtritonserver.ldscript
+    LINK_FLAGS "-Wl,--version-script libtritonserver.ldscript"
+)
 
 set_target_properties(
   triton-core
@@ -309,14 +298,11 @@ if(${TRITON_ENABLE_GCS})
     triton-core
     PRIVATE $<TARGET_PROPERTY:google-cloud-cpp::storage,INTERFACE_INCLUDE_DIRECTORIES>
   )
-  if (NOT WIN32)
-    # [WIP] still needed?
-    set_source_files_properties(
-      filesystem/api.cc
-      PROPERTIES
-        COMPILE_FLAGS -Wno-missing-field-initializers
-    )
-  endif() # NOT WIN32
+  set_source_files_properties(
+    filesystem/api.cc
+    PROPERTIES
+      COMPILE_FLAGS -Wno-missing-field-initializers
+  )
 endif() # TRITON_ENABLE_GCS
 
 if(${TRITON_ENABLE_S3})
@@ -467,14 +453,12 @@ target_link_libraries(
     re2::re2
 )
 
-if (NOT WIN32)
-  target_link_libraries(
-    triton-core
-    PRIVATE
-      dl
-      numa
-  )
-endif()
+target_link_libraries(
+  triton-core
+  PRIVATE
+    dl
+    numa
+)
 
 if(${TRITON_ENABLE_METRICS})
   target_link_libraries(
@@ -535,7 +519,4 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-# Currently unit tests do not build for windows...
-if (NOT WIN32)
-  add_subdirectory(test test)
-endif() # NOT WIN32
+add_subdirectory(test test)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -154,14 +154,12 @@ if(${TRITON_ENABLE_GPU})
       CUDA::cudart
   )
 
-  if (NOT WIN32)
-    target_link_libraries(
-      response_cache_test
-      PRIVATE
-        dl
-        numa
-    )
-  endif()
+  target_link_libraries(
+    response_cache_test
+    PRIVATE
+      dl
+      numa
+  )
 
   install(
     TARGETS response_cache_test
@@ -266,14 +264,12 @@ if(${TRITON_ENABLE_GPU})
       CUDA::cudart
   )
 
-  if (NOT WIN32)
-    target_link_libraries(
-      memory_test
-      PRIVATE
-        dl
-        numa
-    )
-  endif()
+  target_link_libraries(
+    memory_test
+    PRIVATE
+      dl
+      numa
+  )
 
   install(
     TARGETS memory_test
@@ -333,14 +329,12 @@ if(${TRITON_ENABLE_GPU})
       CUDA::cudart
   )
 
-  if (NOT WIN32)
-    target_link_libraries(
-      pinned_memory_manager_test
-      PRIVATE
-        dl
-        numa
-    )
-  endif()
+  target_link_libraries(
+    pinned_memory_manager_test
+    PRIVATE
+      dl
+      numa
+  )
 
   install(
     TARGETS pinned_memory_manager_test
@@ -504,14 +498,12 @@ if(${TRITON_ENABLE_METRICS})
     )
   endif()
 
-  if (NOT WIN32)
-    target_link_libraries(
-      metrics_api_test
-      PRIVATE
-        dl
-        numa
-    )
-  endif()
+  target_link_libraries(
+    metrics_api_test
+    PRIVATE
+      dl
+      numa
+  )
 
   install(
     TARGETS metrics_api_test


### PR DESCRIPTION
## Summary

Removes Windows-specific logic from Triton Core's build system as part of TRI-725, following the Windows build removal in `server` (TRI-723).

This change is limited to CMake/build files and removes obsolete Windows-only build paths (`WIN32`, `NOT WIN32`, and `MSVC` conditionals) while preserving existing Linux build behavior.

## Changes

* Removed MSVC-specific compile option blocks from:

  * `core/CMakeLists.txt`
  * `core/src/CMakeLists.txt`
* Removed Windows-specific protobuf config selection and kept the Linux protobuf path.
* Removed `NOT WIN32` wrappers around:

  * Linux-only compile options for `filesystem/api.cc`
  * `dl` and `numa` linking
  * `core/src/test` subdirectory inclusion
  * Test target links for `response_cache_test`, `memory_test`, `pinned_memory_manager_test`, and `metrics_api_test`

## Verification

* No Windows-specific build references remain under `core/` build files.
* Changes are contained to:

  * `core/CMakeLists.txt`
  * `core/src/CMakeLists.txt`
  * `core/src/test/CMakeLists.txt`

## Notes

This PR only removes Windows support from the build system. Source-level Windows code remains unchanged and will be handled separately if needed.
