### PR TITLE
fix: Model readiness for namespaced models

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -452,14 +452,21 @@ InferenceServer::IsReady(bool* ready)
         // backend has become unhealthy at runtime (e.g., Python backend
         // stub process died).
         if (vs.second.first == ModelReadyState::READY) {
-          bool model_ready = false;
-          Status status = ModelIsReady(mv.first.name_, vs.first, &model_ready);
-          if (!status.IsOk() || !model_ready) {
-            LOG_VERBOSE(1) << "Model '" << mv.first.name_ << "' version "
-                           << vs.first
+          std::shared_ptr<Model> model;
+          if (!GetModel(mv.first, vs.first, &model).IsOk()) {
+            LOG_VERBOSE(1) << "Model '" << mv.first << "' version " << vs.first
+                           << " failed model lookup during server readiness "
+                              "evaluation";
+            *ready = false;
+            goto strict_done;
+          }
+          Status status = model->IsReady();
+          if (!status.IsOk()) {
+            LOG_VERBOSE(1) << "Model '" << mv.first << "' version " << vs.first
                            << " is in READY lifecycle state but failed "
                               "runtime readiness check during server "
-                              "readiness evaluation";
+                              "readiness evaluation: "
+                           << status.Message();
             *ready = false;
             goto strict_done;
           }
@@ -473,8 +480,7 @@ InferenceServer::IsReady(bool* ready)
 }
 
 Status
-InferenceServer::ModelIsReady(
-    const std::string& model_name, const int64_t model_version, bool* ready)
+InferenceServer::ModelIsReady(const Model& model, bool* ready)
 {
   *ready = false;
 
@@ -484,22 +490,17 @@ InferenceServer::ModelIsReady(
 
   ScopedAtomicIncrement inflight(inflight_request_counter_);
 
-  std::shared_ptr<Model> model;
-  if (GetModel(model_name, model_version, &model).IsOk()) {
-    ModelReadyState state;
-    if (model_repository_manager_
-            ->ModelState(model_name, model->Version(), &state)
-            .IsOk()) {
-      *ready = (state == ModelReadyState::READY);
-      if (*ready) {
-        Status status = model->IsReady();
-        if (!status.IsOk()) {
-          *ready = false;
-          LOG_VERBOSE(1) << "Model '" << model_name << "' version "
-                         << model->Version()
-                         << " is not ready: " << status.Message();
-        }
-      }
+  ModelReadyState state;
+  if (model_repository_manager_
+          ->ModelState(model.Name(), model.Version(), &state)
+          .IsOk() &&
+      (state == ModelReadyState::READY)) {
+    const Status status = model.IsReady();
+    *ready = status.IsOk();
+    if (!*ready) {
+      LOG_VERBOSE(1) << "Model '" << model.Name() << "' version "
+                     << model.Version()
+                     << " is not ready: " << status.Message();
     }
   }
 

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -99,8 +99,7 @@ class InferenceServer {
   Status IsReady(bool* ready);
 
   // Model health
-  Status ModelIsReady(
-      const std::string& model_name, const int64_t model_version, bool* ready);
+  Status ModelIsReady(const Model& model, bool* ready);
 
   // Return the ready versions of specific model
   Status ModelReadyVersions(
@@ -289,6 +288,11 @@ class InferenceServer {
   void SetRepoAgentDir(const std::string& d) { repoagent_dir_ = d; }
 
   // Return the requested model object.
+  //
+  // WARNING: This overload resolves by model name only. When model namespacing
+  // is enabled and the same model name exists in multiple namespaces, lookup
+  // fails with an ambiguity error. Use the ModelIdentifier overload below to
+  // specify namespace and name explicitly.
   Status GetModel(
       const std::string& model_name, const int64_t model_version,
       std::shared_ptr<Model>* model)

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -2730,8 +2730,9 @@ TRITONSERVER_ServerModelIsReady(
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
 
-  RETURN_IF_STATUS_ERROR(
-      lserver->ModelIsReady(model_name, model_version, ready));
+  std::shared_ptr<tc::Model> model;
+  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
+  RETURN_IF_STATUS_ERROR(lserver->ModelIsReady(*model, ready));
   return nullptr;  // Success
 }
 


### PR DESCRIPTION
#### What does the PR do?
Fixes the `L0_model_namespacing--base` and `L0_metrics--base` tests. Strict server readiness (`InferenceServer::IsReady`) and `InferenceServer::ModelIsReady` resolved models by name only, which is ambiguous when model namespacing is enabled and the same model name exists in multiple namespaces — the lookup fails and the server is reported not-ready. Readiness now resolves models by the full `ModelIdentifier`.

This regression was introduced by #473 (`fix: /v2/health/ready returns 200 when Python backend stub is dead (#8604)`, commit 53fc26e), which added the runtime backend readiness check in the strict-readiness path using name-only model lookup.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:
- #473 — introduced the regression this PR fixes.

#### Where should the reviewer start?
- `src/server.cc` / `src/server.h`: `IsReady` strict-readiness loop now resolves each model via the full `ModelIdentifier` (`GetModel(mv.first, ...)`); `ModelIsReady` takes an already-resolved `Model&`.
- `src/tritonserver.cc`: `TRITONSERVER_ServerModelIsReady` resolves the model (name-based, matching the public C-API contract) and calls the new `ModelIsReady` overload.

#### Test plan:
- `L0_model_namespacing--base`
- `L0_metrics--base`

- CI Pipeline ID: 53863861

#### Caveats:
The public C-API `TRITONSERVER_ServerModelIsReady` still resolves by name (no namespace parameter in the API contract); namespaced readiness resolution applies to the internal strict-readiness path.

#### Background

#### Related Issues:
N/A