### PR TITLE
Fix implicit sequence state output mapping

### DIFF
--- a/src/sequence_state.cc
+++ b/src/sequence_state.cc
@@ -35,14 +35,18 @@
 
 namespace triton { namespace core {
 
-SequenceState::SequenceState() : data_(new MemoryReference) {}
+SequenceState::SequenceState()
+    : data_(new MemoryReference), other_state_(nullptr)
+{
+}
 
 SequenceState::SequenceState(
     const std::string& name, const inference::DataType datatype,
     const int64_t* shape, const uint64_t dim_count, bool use_single_buffer,
     bool use_growable_memory)
     : name_(name), datatype_(datatype), shape_(shape, shape + dim_count),
-      data_(new MemoryReference), use_single_buffer_(use_single_buffer),
+      data_(new MemoryReference), other_state_(nullptr),
+      use_single_buffer_(use_single_buffer),
       use_growable_memory_(use_growable_memory)
 {
 }
@@ -52,7 +56,8 @@ SequenceState::SequenceState(
     const std::vector<int64_t>& shape, bool use_single_buffer,
     bool use_growable_memory)
     : name_(name), datatype_(datatype), shape_(shape),
-      data_(new MemoryReference), use_single_buffer_(use_single_buffer),
+      data_(new MemoryReference), other_state_(nullptr),
+      use_single_buffer_(use_single_buffer),
       use_growable_memory_(use_growable_memory)
 {
 }
@@ -294,36 +299,37 @@ SequenceStates::OutputState(
   }
 
   std::vector<int64_t> new_shape(shape, shape + dim_count);
-  *output_states_[name]->MutableDType() = datatype;
-  *output_states_[name]->MutableShape() = new_shape;
+  auto& output_state_r = output_state_itr->second;
+  *output_state_r->MutableDType() = datatype;
+  *output_state_r->MutableShape() = new_shape;
 
-  auto& output_state_r = output_states_[name];
-  size_t iter_advance =
-      std::distance(output_states_.begin(), output_states_.find(name));
-
-  // Find the input state corresponding to this output state.
-  auto input_states_itr = input_states_.begin();
-  std::advance(input_states_itr, iter_advance);
-  auto& input_state_r = input_states_[input_states_itr->first];
-  bool use_single_buffer = output_states_[name]->UseSingleBuffer();
-
-  if (output_state != nullptr) {
-    *output_state = output_states_[name].get();
+  SequenceState* input_state = output_state_r->OtherState();
+  if (input_state == nullptr) {
+    return Status(
+        Status::Code::INTERNAL,
+        "state '" + name + "' does not have a corresponding input state.");
   }
 
-  output_state_r->SetStateUpdateCallback(
-      [&output_state_r, &input_state_r, use_single_buffer]() {
+  SequenceState* output_state_ptr = output_state_r.get();
+  bool use_single_buffer = output_state_r->UseSingleBuffer();
+
+  if (output_state != nullptr) {
+    *output_state = output_state_ptr;
+  }
+
+  output_state_ptr->SetStateUpdateCallback(
+      [output_state_ptr, input_state, use_single_buffer]() {
         // Swap the internal memory if the size of the input and output state is
         // equal
 
         if (!use_single_buffer) {
-          if (output_state_r->Data()->TotalByteSize() ==
-              input_state_r->Data()->TotalByteSize()) {
-            std::shared_ptr<Memory> temp_memory = input_state_r->Data();
-            RETURN_IF_ERROR(input_state_r->RemoveAllData());
-            RETURN_IF_ERROR(input_state_r->SetData(output_state_r->Data()));
-            RETURN_IF_ERROR(output_state_r->RemoveAllData());
-            RETURN_IF_ERROR(output_state_r->SetData(temp_memory));
+          if (output_state_ptr->Data()->TotalByteSize() ==
+              input_state->Data()->TotalByteSize()) {
+            std::shared_ptr<Memory> temp_memory = input_state->Data();
+            RETURN_IF_ERROR(input_state->RemoveAllData());
+            RETURN_IF_ERROR(input_state->SetData(output_state_ptr->Data()));
+            RETURN_IF_ERROR(output_state_ptr->RemoveAllData());
+            RETURN_IF_ERROR(output_state_ptr->SetData(temp_memory));
           } else {
             // If the size of output state is different from the input state,
             // allocate a new memory for the input state with the same size as
@@ -333,27 +339,27 @@ SequenceStates::OutputState(
 
             const std::shared_ptr<MutableMemory>& input_memory =
                 reinterpret_cast<const std::shared_ptr<MutableMemory>&>(
-                    input_state_r->Data());
+                    input_state->Data());
 
             input_memory->MutableBuffer(&memory_type, &memory_type_id);
             std::shared_ptr<AllocatedMemory> memory =
                 std::make_shared<AllocatedMemory>(
-                    output_state_r->Data()->TotalByteSize(), memory_type,
+                    output_state_ptr->Data()->TotalByteSize(), memory_type,
                     memory_type_id);
-            RETURN_IF_ERROR(input_state_r->RemoveAllData());
-            RETURN_IF_ERROR(input_state_r->SetData(output_state_r->Data()));
-            RETURN_IF_ERROR(output_state_r->RemoveAllData());
-            RETURN_IF_ERROR(output_state_r->SetData(memory));
+            RETURN_IF_ERROR(input_state->RemoveAllData());
+            RETURN_IF_ERROR(input_state->SetData(output_state_ptr->Data()));
+            RETURN_IF_ERROR(output_state_ptr->RemoveAllData());
+            RETURN_IF_ERROR(output_state_ptr->SetData(memory));
           }
 
           // Update the shape and data type of the output state if it doesn't
           // match the input state.
-          if (input_state_r->Shape() != output_state_r->Shape()) {
-            *input_state_r->MutableShape() = output_state_r->Shape();
+          if (input_state->Shape() != output_state_ptr->Shape()) {
+            *input_state->MutableShape() = output_state_ptr->Shape();
           }
 
-          if (input_state_r->DType() != output_state_r->DType()) {
-            *input_state_r->MutableDType() = output_state_r->DType();
+          if (input_state->DType() != output_state_ptr->DType()) {
+            *input_state->MutableDType() = output_state_ptr->DType();
           }
         }
 
@@ -418,7 +424,7 @@ SequenceStates::CopyAsNull(
 
     for (auto& from_output_state : from->OutputStates()) {
       auto& from_output_state_tensor = from_output_state.second;
-      lsequence_states->output_states_.emplace(
+      const auto& output_pair = lsequence_states->output_states_.emplace(
           std::piecewise_construct,
           std::forward_as_tuple(from_output_state.first),
           std::forward_as_tuple(new SequenceState(
@@ -426,6 +432,18 @@ SequenceStates::CopyAsNull(
               from_output_state_tensor->DType(),
               from_output_state_tensor->Shape(), false /* reused_buffer */,
               false /* use_growable_memory */)));
+
+      SequenceState* from_input_state = from_output_state_tensor->OtherState();
+      if (from_input_state != nullptr) {
+        const auto& input_itr =
+            lsequence_states->input_states_.find(from_input_state->Name());
+        if (input_itr != lsequence_states->input_states_.end()) {
+          auto& output_tensor = output_pair.first->second;
+          auto& input_tensor = input_itr->second;
+          output_tensor->SetOtherState(input_tensor.get());
+          input_tensor->SetOtherState(output_tensor.get());
+        }
+      }
     }
   }
   *to = std::move(lsequence_states);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -208,6 +208,46 @@ install(
 )
 
 #
+# Unit test for Sequence State
+#
+add_executable(
+  sequence_state_test
+  sequence_state_test.cc
+  )
+
+set_target_properties(
+  sequence_state_test
+  PROPERTIES
+    SKIP_BUILD_RPATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH_USE_LINK_PATH FALSE
+    INSTALL_RPATH ""
+)
+
+target_include_directories(
+  sequence_state_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+    ${GTEST_INCLUDE_DIRS}
+)
+
+target_link_libraries(
+  sequence_state_test
+  PRIVATE
+    triton-common-error # from repo-common
+    triton-core
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+)
+
+install(
+  TARGETS sequence_state_test
+  RUNTIME DESTINATION bin
+)
+
+#
 # Unit test for Memory
 #
 if(${TRITON_ENABLE_GPU})

--- a/src/test/sequence_state_test.cc
+++ b/src/test/sequence_state_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "sequence_state.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "triton/common/model_config.h"
+#include "triton/core/tritonserver.h"
+
+namespace tc = triton::core;
+
+namespace {
+
+using StateConfig = inference::ModelSequenceBatching_State;
+
+StateConfig
+CreateStateConfig(
+    const std::string& input_name, const std::string& output_name,
+    inference::DataType data_type, const std::vector<int64_t>& dims)
+{
+  StateConfig state;
+  state.set_input_name(input_name);
+  state.set_output_name(output_name);
+  state.set_data_type(data_type);
+  for (const auto dim : dims) {
+    state.add_dims(dim);
+  }
+  return state;
+}
+
+TEST(SequenceStatesTest, OutputStateUsesConfiguredInputMapping)
+{
+  std::vector<StateConfig> state_configs;
+  state_configs.emplace_back(CreateStateConfig(
+      "cache_last_channel_len", "cache_last_channel_len_next",
+      inference::DataType::TYPE_INT64, {1}));
+  state_configs.emplace_back(CreateStateConfig(
+      "cache_last_channel", "cache_last_channel_next",
+      inference::DataType::TYPE_FP32, {4}));
+
+  std::unordered_map<std::string, const StateConfig&> state_config_map;
+  for (const auto& state_config : state_configs) {
+    state_config_map.emplace(state_config.output_name(), state_config);
+  }
+
+  tc::SequenceStates states;
+  auto status = states.Initialize(
+      state_config_map, 0 /* max_batch_size */, {} /* initial_state */,
+      TRITONSERVER_INSTANCEGROUPKIND_CPU, 0 /* device_id */,
+      {} /* cuda_virtual_address_size */);
+  ASSERT_TRUE(status.IsOk()) << status.Message();
+
+  tc::SequenceState* output_state = nullptr;
+  const std::vector<int64_t> channel_update_shape{8};
+  status = states.OutputState(
+      "cache_last_channel_next", inference::DataType::TYPE_FP32,
+      channel_update_shape, &output_state);
+  ASSERT_TRUE(status.IsOk()) << status.Message();
+  ASSERT_NE(output_state, nullptr);
+
+  auto output_memory = std::make_shared<tc::AllocatedMemory>(
+      sizeof(float) * channel_update_shape[0], TRITONSERVER_MEMORY_CPU, 0);
+  status = output_state->SetData(output_memory);
+  ASSERT_TRUE(status.IsOk()) << status.Message();
+
+  status = output_state->Update();
+  ASSERT_TRUE(status.IsOk()) << status.Message();
+
+  const auto& input_states = states.InputStates();
+  const auto& channel_state = input_states.at("cache_last_channel");
+  const auto& len_state = input_states.at("cache_last_channel_len");
+
+  EXPECT_EQ(channel_state->DType(), inference::DataType::TYPE_FP32);
+  EXPECT_EQ(channel_state->Shape(), channel_update_shape);
+  EXPECT_EQ(len_state->DType(), inference::DataType::TYPE_INT64);
+  EXPECT_EQ(len_state->Shape(), std::vector<int64_t>({1}));
+}
+
+}  // namespace


### PR DESCRIPTION
#### What this PR does
Fixes implicit sequence state updates when configured input and output state names sort differently.

`SequenceStates::OutputState()` previously found the output state by `output_name`, computed its index in `output_states_`, and advanced to that same index in `input_states_`. Both containers are `std::map`s keyed by different names, so the index only works when input and output names happen to have the same lexicographic order.

This PR uses the configured `SequenceState::OtherState()` pairing established during initialization instead, and preserves that pairing when null sequence states are copied.

#### Why
For names such as:

- input: `cache_last_channel`, output: `cache_last_channel_next`
- input: `cache_last_channel_len`, output: `cache_last_channel_len_next`

`cache_last_channel_len_next` sorts before `cache_last_channel_next`, while the input names sort in the opposite order. The old index-based lookup can update the wrong cached input state and inject the wrong tensor on the next sequence request.

#### Tests
Added `sequence_state_test` covering mismatched input/output lexicographic ordering.

Local validation:

- `clang-format -i src/sequence_state.cc src/test/sequence_state_test.cc`
- `git diff --check`
- `cmake -S . -B build-codex -DTRITON_CORE_HEADERS_ONLY=OFF -DTRITON_ENABLE_GPU=OFF -DTRITON_ENABLE_METRICS_GPU=OFF -DTRITON_ENABLE_S3=OFF -DTRITON_ENABLE_GCS=OFF -DTRITON_ENABLE_AZURE_STORAGE=OFF`
- `cmake --build build-codex --target triton-core -j4` could not complete on this Apple Silicon host because third-party Abseil is built with `-msse4.1`, which AppleClang rejects for `arm64-apple-darwin`. The failure happens before compiling Triton core sources.

Fixes triton-inference-server/server#8586.
