### PR TITLE
fix: restore ready=false for unresolved model in TRITONSERVER_ServerModelIsReady (#508)

### DIFF
--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2730,8 +2730,15 @@ TRITONSERVER_ServerModelIsReady(
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
 
+  // A model that cannot be resolved (never loaded, unloaded, or unregistered)
+  // is simply not ready. Before the ModelIdentifier readiness refactor the
+  // lookup failure was swallowed and this returned ready=false; preserve that
+  // public contract instead of surfacing the lookup error to the caller.
   std::shared_ptr<tc::Model> model;
-  RETURN_IF_STATUS_ERROR(lserver->GetModel(model_name, model_version, &model));
+  if (!lserver->GetModel(model_name, model_version, &model).IsOk()) {
+    *ready = false;
+    return nullptr;  // Success -- not ready, not an error
+  }
   RETURN_IF_STATUS_ERROR(lserver->ModelIsReady(*model, ready));
   return nullptr;  // Success
 }


### PR DESCRIPTION
Cherry-pick of triton-inference-server/core#508 into `r26.07`.

## Description

#502 refactored `ModelIsReady` to take an already-resolved `Model`, moving the `GetModel()` lookup into `TRITONSERVER_ServerModelIsReady` with `RETURN_IF_STATUS_ERROR`. This changed the public contract: a model that was never loaded, was unloaded, or is unregistered now returns a `NOT_FOUND` error instead of `ready=false`. Before #502 the lookup failure was swallowed and the call returned `ready=false` with a success status.

The regression surfaced as a failure in `test_binding.py::test_server_explicit` (and affects every `model_is_ready` caller, incl. KServe `/ready` endpoints and the Python in-process API). Treat an unresolvable model as not-ready again while keeping #502's resolved-`Model` path for the found case.

## Changes

- `src/tritonserver.cc`: when `GetModel()` cannot resolve the model, set `*ready = false` and return success instead of surfacing the lookup error.

## Affected Files

- `src/tritonserver.cc`

#### Related Issues:

- Resolves: TRI-1529

#### Related PRs:

- triton-inference-server/core#508
