### PR TITLE
fix: return non-availability errors from TRITONSERVER_ServerModelIsReady

### DIFF
--- a/include/triton/core/tritonserver.h
+++ b/include/triton/core/tritonserver.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -2377,7 +2377,10 @@ TRITONSERVER_DECLSPEC struct TRITONSERVER_Error* TRITONSERVER_ServerIsReady(
 /// \param model_version The version of the model to get readiness
 /// for.  If -1 then the server will choose a version based on the
 /// model's policy.
-/// \param ready Returns true if server is ready, false otherwise.
+/// \param ready Returns true if the model is ready, false otherwise. A model
+/// that cannot be found, or that is unavailable because the server is not
+/// ready, is reported as not ready (false) rather than as an error; any other
+/// lookup failure is returned as an error.
 /// \return a TRITONSERVER_Error indicating success or failure.
 TRITONSERVER_DECLSPEC struct TRITONSERVER_Error*
 TRITONSERVER_ServerModelIsReady(

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2730,16 +2730,18 @@ TRITONSERVER_ServerModelIsReady(
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
 
-  // When the server is not ready the model cannot be ready either, so report
-  // ready=false without treating it as an error. Any other lookup failure is a
-  // real error and is surfaced to the caller.
   std::shared_ptr<tc::Model> model;
   tc::Status get_model_status =
       lserver->GetModel(model_name, model_version, &model);
   if (!get_model_status.IsOk()) {
-    if (get_model_status.StatusCode() == tc::Status::Code::UNAVAILABLE) {
+    // When the server is not ready or the model cannot be found, the model
+    // cannot be ready either, so report ready=false without treating it as an
+    // error. Any other lookup failure is a real error and is surfaced to the
+    // caller.
+    if (get_model_status.StatusCode() == tc::Status::Code::UNAVAILABLE ||
+        get_model_status.StatusCode() == tc::Status::Code::NOT_FOUND) {
       *ready = false;
-      return nullptr;  // Success -- server not ready, so model not ready
+      return nullptr;
     }
     RETURN_IF_STATUS_ERROR(get_model_status);
   }

--- a/src/tritonserver.cc
+++ b/src/tritonserver.cc
@@ -2730,14 +2730,18 @@ TRITONSERVER_ServerModelIsReady(
 {
   tc::InferenceServer* lserver = reinterpret_cast<tc::InferenceServer*>(server);
 
-  // A model that cannot be resolved (never loaded, unloaded, or unregistered)
-  // is simply not ready. Before the ModelIdentifier readiness refactor the
-  // lookup failure was swallowed and this returned ready=false; preserve that
-  // public contract instead of surfacing the lookup error to the caller.
+  // When the server is not ready the model cannot be ready either, so report
+  // ready=false without treating it as an error. Any other lookup failure is a
+  // real error and is surfaced to the caller.
   std::shared_ptr<tc::Model> model;
-  if (!lserver->GetModel(model_name, model_version, &model).IsOk()) {
-    *ready = false;
-    return nullptr;  // Success -- not ready, not an error
+  tc::Status get_model_status =
+      lserver->GetModel(model_name, model_version, &model);
+  if (!get_model_status.IsOk()) {
+    if (get_model_status.StatusCode() == tc::Status::Code::UNAVAILABLE) {
+      *ready = false;
+      return nullptr;  // Success -- server not ready, so model not ready
+    }
+    RETURN_IF_STATUS_ERROR(get_model_status);
   }
   RETURN_IF_STATUS_ERROR(lserver->ModelIsReady(*model, ready));
   return nullptr;  // Success


### PR DESCRIPTION
#### What does the PR do?
Fixes a logic error in `TRITONSERVER_ServerModelIsReady`. `GetModel` returns `UNAVAILABLE` (server not ready) or `NOT_FOUND` (model not found) only when the server itself is not ready; it may return other error codes in the future for genuine lookup failures. The previous code swallowed *every* `GetModel` failure and reported `ready=false`, hiding real errors from the caller. Now only the server-not-ready (`UNAVAILABLE`) and model-not-found (`NOT_FOUND`) cases are reported as not-ready; any other error is surfaced.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:
https://github.com/triton-inference-server/core/pull/502
https://github.com/triton-inference-server/core/pull/508

#### Test plan:
- CI Pipeline ID: 57341501