### PR TITLE
fix: remove distutils dependency

### DIFF
--- a/python/build_wheel.py
+++ b/python/build_wheel.py
@@ -33,7 +33,6 @@ import shutil
 import subprocess
 import sys
 import zipfile
-from distutils.dir_util import copy_tree
 from tempfile import mkdtemp, mkstemp
 
 # ANSI colors for CI log readability (rendered by GitLab CI, harmlessly
@@ -66,7 +65,7 @@ def touch(path):
 
 
 def cpdir(src, dest):
-    copy_tree(src, dest, preserve_symlinks=1)
+    shutil.copytree(src, dest, symlinks=True, dirs_exist_ok=True)
 
 
 def sed(pattern, replace, source, dest=None):


### PR DESCRIPTION
Replace `copy_tree` from `distutils` with `shutil.copytree`. Fixes build failures with Python 3.13 where `distutils` is no longer available.