### PR TITLE
fix: reserve completion-queue slot at enqueue to restore preserve_ordering

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -673,6 +673,23 @@ void
 DynamicBatchScheduler::DelegateResponse(
     std::unique_ptr<InferenceRequest>& request)
 {
+  // Reserve this request's slot in the completion queue now, while we are
+  // still in scheduler-receive order. FinalizeResponses() stalls on an empty
+  // front slot, which is what holds later responses back until earlier ones
+  // are ready. Filling the slot only at completion time would order the queue
+  // by completion instead, defeating preserve_ordering.
+  //
+  // Only reserve when ordering is required: when just the response cache is
+  // enabled the delegator sends directly and would never fill the slot,
+  // leaking it for the lifetime of the model.
+  std::vector<std::pair<std::unique_ptr<InferenceResponse>, uint32_t>>*
+      queue_slot = nullptr;
+  if (preserve_ordering_) {
+    std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+    completion_queue_.emplace_back();
+    queue_slot = &completion_queue_.back();
+  }
+
   // Cache plumbing
   const std::string& key = request->CacheKey();
   const bool is_key_set = request->CacheKeyIsSet();
@@ -680,7 +697,7 @@ DynamicBatchScheduler::DelegateResponse(
   const uint64_t lookup_start_ns = request->CacheLookupStartNs();
 
   request->SetResponseDelegator(
-      [this, key, is_key_set, lookup_end_ns, lookup_start_ns](
+      [this, queue_slot, key, is_key_set, lookup_end_ns, lookup_start_ns](
           std::unique_ptr<InferenceResponse>&& response, const uint32_t flags) {
         if (response_cache_enabled_) {
           // Logical error, the key should be set if caching is enabled
@@ -731,8 +748,6 @@ DynamicBatchScheduler::DelegateResponse(
         if (preserve_ordering_) {
           {
             std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            completion_queue_.emplace_back();
-            auto queue_slot = &completion_queue_.back();
             queue_slot->emplace_back(std::move(response), flags);
           }
           FinalizeResponses();


### PR DESCRIPTION
## Problem

`preserve_ordering` in the dynamic batcher does not preserve ordering. Responses
are returned in completion order, not in the order requests reached the
scheduler.

`model_config.proto` is explicit that the guarantee is scheduler-wide:

> Should the dynamic batcher preserve the ordering of responses to match the
> order of requests received by the scheduler. [...] If true, the responses will
> be returned in the same order as the order of requests sent to the scheduler.

Since one dynamic batcher feeds all instances of a model, ordering must hold
across instances. It currently does not.

## Root cause

`b06d69b` ("fix: Response Cache Memory Leak", #449) moved the completion-queue
slot reservation out of `DelegateResponse()` and into the response delegator:

```cpp
// before -- reserved at enqueue, in arrival order
std::lock_guard<std::mutex> lock(completion_queue_mtx_);
completion_queue_.emplace_back();
auto queue_slot = &completion_queue_.back();

// after -- created inside the delegator, at completion time
completion_queue_.emplace_back();
auto queue_slot = &completion_queue_.back();
queue_slot->emplace_back(std::move(response), flags);
```

`FinalizeResponses()` drains with:

```cpp
while (!completion_queue_.empty() && !completion_queue_.front().empty()) {
```

The `!front().empty()` test is the ordering mechanism: it stalls the drain while
the head slot is reserved but unfilled. Once slots are created already-filled,
`front()` is never empty, the guard becomes dead code, and the drain simply
re-emits in completion order.

## Evidence

Two instances of one model (100 ms and 400 ms delay), 12 requests batched 4+4+4,
`preserve_ordering: true` confirmed in the server log. From the trace:

| Trace ids | Batch | compute span | response sent |
|-----------|-------|--------------|---------------|
| 1-4       | A     | 100 ms       | t0 + 100 ms   |
| 5-8       | B     | 400 ms       | t0 + 400 ms   |
| 9-12      | C     | 100 ms       | t0 + 200 ms   |

Requests 9-12 reached the scheduler after 5-8 but were answered ~200 ms earlier.
`INFER_RESPONSE_COMPLETE` is captured in the frontend response callback
(`server/src/http_server.cc`), so it reflects response-send time.

`qa/L0_batcher/verify_timestamps.py -p` requires at least 4 responses after the
slow batch and measures 0.

## Fix

Reserve the slot in `DelegateResponse()` again, but only when
`preserve_ordering_` is set.

The leak `b06d69b` fixed came from reserving *unconditionally*: with only the
response cache enabled, the delegator takes the `else` branch and sends
directly, so the slot was never filled and never popped, growing
`completion_queue_` for the lifetime of the model. Guarding the reservation
keeps that path allocation-free and restores ordering.

`std::deque` does not invalidate references to existing elements on insertion at
either end, and a slot is only `pop_front`ed after its `FINAL` flag is seen,
after which the delegator cannot fire again -- the invariant the original code
relied on.

## Test coverage

`qa/L0_batcher` `test_multi_batch_preserve_ordering` covers this. It has not run
in CI since server `838966ae0` (2024-12-16), which gated it on `TEST_WINDOWS`
without initialising the variable on Linux, so `[ $TEST_WINDOWS -eq 0 ]` errored
and took the else branch. With that gate repaired, the test fails deterministically
on **10 GPU platforms** (A100, A30, H100, B200, GB200, GB300, RTX50, DGX-Spark,
AGX-Thor, IGX-Orin) across RHEL and Ubuntu, in plain, `_shm` and `_cudashm`
variants -- 23 CI jobs. It also reproduced on a same-job retry.

## Validation status

- [x] `clang-format` (v16.0.5) and `codespell` pass
- [ ] **Not yet built or run.** The fix is derived from the diff and the
      surrounding invariants. `L0_batcher` `test_multi_batch_preserve_ordering`
      going green is the real proof and still needs a CI run.
