### PR TITLE
feat: check request cancellation before backend dispatch

### DIFF
--- a/src/backend_model_instance.cc
+++ b/src/backend_model_instance.cc
@@ -565,10 +565,58 @@ TritonModelInstance::PrepareRequestsOrRespond(
   return status;
 }
 
+void
+TritonModelInstance::FinishCancelledRequests(
+    std::vector<std::unique_ptr<InferenceRequest>>& requests)
+{
+  // Batch positions map to sequence slots, so requests cannot be removed. The
+  // sequence batcher cancels its own requests while they are queued.
+  if (model_->Config().has_sequence_batching()) {
+    return;
+  }
+
+  const static Status cancelled_status = Status(Status::Code::CANCELLED);
+
+  size_t next = 0;
+  for (size_t idx = 0; idx < requests.size(); ++idx) {
+    std::unique_ptr<InferenceRequest>& request = requests[idx];
+
+    if ((request != nullptr) && request->IsCancelled()) {
+      InferenceRequest::RespondIfError(
+          request, cancelled_status, true /* release_requests */,
+          FailureReason::CANCELED);
+
+      if (request != nullptr) {
+        LOG_ERROR << request->LogRequest()
+                  << "failed to release cancelled request";
+      }
+      continue;
+    }
+
+    if (next != idx) {
+      requests[next] = std::move(request);
+    }
+    ++next;
+  }
+
+  requests.resize(next);
+}
+
 Status
 TritonModelInstance::Schedule(
     std::vector<std::unique_ptr<InferenceRequest>>&& requests)
 {
+  // Drop requests cancelled while waiting for an execution slot.
+  // Last point of control before the backend is invoked and is
+  // common to every scheduler.
+  FinishCancelledRequests(requests);
+
+  // Every request may have been cancelled. The backend must not be invoked
+  // with an empty batch.
+  if (requests.empty()) {
+    return Status::Success;
+  }
+
   // Prepare requests for execution, respond to requests if any error occur.
   RETURN_IF_ERROR(PrepareRequestsOrRespond(requests));
 

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -223,6 +223,10 @@ class TritonModelInstance {
       std::vector<std::unique_ptr<InferenceRequest>>& requests);
   Status PrepareRequestsOrRespond(
       std::vector<std::unique_ptr<InferenceRequest>>& requests);
+  // Respond to cancelled requests with a cancelled status and remove them from
+  // 'requests'. No-op for models using sequence batching.
+  void FinishCancelledRequests(
+      std::vector<std::unique_ptr<InferenceRequest>>& requests);
   void Execute(std::vector<TRITONBACKEND_Request*>& triton_requests);
 
   std::shared_ptr<TritonBackendThread> triton_backend_thread_;

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -682,13 +682,17 @@ DynamicBatchScheduler::DelegateResponse(
   request->SetResponseDelegator(
       [this, key, is_key_set, lookup_end_ns, lookup_start_ns](
           std::unique_ptr<InferenceResponse>&& response, const uint32_t flags) {
-        if (response_cache_enabled_) {
+        if (response_cache_enabled_ && !is_key_set) {
           // Logical error, the key should be set if caching is enabled
           // for this model
-          if (!is_key_set) {
-            LOG_ERROR << "Request cache key was not set correctly.";
-          }
+          LOG_ERROR << "Request cache key was not set correctly.";
+        }
 
+        // Error and cancelled responses carry no outputs. Caching one would
+        // serve an empty response as a hit to the next matching request.
+        const bool cacheable =
+            (response != nullptr) && response->ResponseStatus().IsOk();
+        if (response_cache_enabled_ && cacheable) {
           // Cache insertion happens here because we need the backend to have
           // computed the inference response first in the case of cache miss
           auto cache = model_->Server()->CacheManager()->Cache();


### PR DESCRIPTION
A request cancelled while waiting for an execution slot is no longer passed to the backend. The check sits in `TritonModelInstance::Schedule`, the single point every scheduler routes through on the way to `TRITONBACKEND_ModelInstanceExecute`...
