### PR TITLE
fix: reserve completion-queue slot at enqueue to restore preserve_ordering (#520)

### DIFF
--- a/src/dynamic_batch_scheduler.cc
+++ b/src/dynamic_batch_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -673,6 +673,23 @@ void
 DynamicBatchScheduler::DelegateResponse(
     std::unique_ptr<InferenceRequest>& request)
 {
+  // Reserve this request's slot in the completion queue now, while we are
+  // still in scheduler-receive order. FinalizeResponses() stalls on an empty
+  // front slot, which is what holds later responses back until earlier ones
+  // are ready. Filling the slot only at completion time would order the queue
+  // by completion instead, defeating preserve_ordering.
+  //
+  // Only reserve when ordering is required: when just the response cache is
+  // enabled the delegator sends directly and would never fill the slot,
+  // leaking it for the lifetime of the model.
+  std::vector<std::pair<std::unique_ptr<InferenceResponse>, uint32_t>>*
+      queue_slot = nullptr;
+  if (preserve_ordering_) {
+    std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+    completion_queue_.emplace_back();
+    queue_slot = &completion_queue_.back();
+  }
+
   // Cache plumbing
   const std::string& key = request->CacheKey();
   const bool is_key_set = request->CacheKeyIsSet();
@@ -680,7 +697,7 @@ DynamicBatchScheduler::DelegateResponse(
   const uint64_t lookup_start_ns = request->CacheLookupStartNs();
 
   request->SetResponseDelegator(
-      [this, key, is_key_set, lookup_end_ns, lookup_start_ns](
+      [this, queue_slot, key, is_key_set, lookup_end_ns, lookup_start_ns](
           std::unique_ptr<InferenceResponse>&& response, const uint32_t flags) {
         if (response_cache_enabled_) {
           // Logical error, the key should be set if caching is enabled
@@ -731,8 +748,6 @@ DynamicBatchScheduler::DelegateResponse(
         if (preserve_ordering_) {
           {
             std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            completion_queue_.emplace_back();
-            auto queue_slot = &completion_queue_.back();
             queue_slot->emplace_back(std::move(response), flags);
           }
           FinalizeResponses();


### PR DESCRIPTION
#### What does the PR do?
- Carries the `preserve_ordering` fix forward from `r26.08` onto `main`.
- Straight cherry-pick of `3aa9fdf9`; no edits beyond the original.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/client#920
- triton-inference-server/common#164
- triton-inference-server/onnxruntime_backend#358
- triton-inference-server/python_backend#453
- triton-inference-server/pytorch_backend#209
- triton-inference-server/tutorials#168
- triton-inference-server/server#8949

#### Where should the reviewer start?
`src/dynamic_batch_scheduler.cc` — the enqueue-time slot reservation.

#### Test plan:
- Full CI run on the internal pipeline at `TRITON_CONTAINER_VERSION=26.09dev_user`, with `TRITON_NIGHTLY=1` and `TRITON_SBSA=1`.
- Local verification: per-repo `pre-commit run --files <changed>` passes with no auto-fixes.

- CI Pipeline ID:
<!-- pipeline not yet triggered; fill in after the _user run starts -->

#### Caveats:
- Do not merge before the model-repository mount point is rotated: `TRITON_SERVER_MODEL_REPO_VERSION` derives from `TRITON_CONTAINER_VERSION`, so `26.09dev` must exist on the share first.

#### Background
Post-release step of the 26.08 train: the default branches move onto the same upstream containers as the just-released `r26.08`, and pick up the fixes that landed only on the release branch while it stabilised.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-1691
