### PR TITLE
build: build core in-tree against Conan-resolved dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,151 +199,20 @@ if(NOT TRITON_CORE_HEADERS_ONLY)
     message(FATAL_ERROR "TRITON_ENABLE_METRICS_GPU=ON requires TRITON_ENABLE_GPU=ON")
   endif()
 
-  include(FetchContent)
-  FetchContent_Declare(
-    repo-third-party
-    GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/third_party.git
-    GIT_TAG ${TRITON_THIRD_PARTY_REPO_TAG}
-  )
-  FetchContent_MakeAvailable(repo-third-party)
-
-  # Some libs are installed to ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib64 instead
-  # of ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib on Centos
-  set (LIB_DIR "lib")
-  if(LINUX)
-    file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
-    if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
-      set (LIB_DIR "lib64")
-    endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
-  endif(LINUX)
-  set(TRITON_CORE_HEADERS_ONLY OFF)
-
-  # Need to use ExternalProject for our builds so that we can get the
-  # correct dependencies between Triton shared library components and
-  # the ExternalProject dependencies (found in the third_party repo)
-  include(ExternalProject)
-
-  # If CMAKE_TOOLCHAIN_FILE is set, propagate that hint path to the external
-  # projects.
-  set(_CMAKE_ARGS_CMAKE_TOOLCHAIN_FILE "")
-  if (CMAKE_TOOLCHAIN_FILE)
-    set(_CMAKE_ARGS_CMAKE_TOOLCHAIN_FILE "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}")
-  endif()
-
-  # If VCPKG_TARGET_TRIPLET is set, propagate that hint path to the external
-  # projects.
-  set(_CMAKE_ARGS_VCPKG_TARGET_TRIPLET "")
-  if (VCPKG_TARGET_TRIPLET)
-    set(_CMAKE_ARGS_VCPKG_TARGET_TRIPLET "-DVCPKG_TARGET_TRIPLET:STRING=${VCPKG_TARGET_TRIPLET}")
-  endif()
-
-  # If OPENSSL_ROOT_DIR is set, propagate that hint path to the external
-  # projects with OpenSSL dependency.
-  set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "")
-  if (OPENSSL_ROOT_DIR)
-    set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}")
-  endif()
-
-  # Location where protobuf-config.cmake will be installed
-  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/protobuf")
-  set(_FINDPACKAGE_UTF8_RANGE_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/utf8_range")
-
-  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(TRITON_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install)
-  else()
-    set(TRITON_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-  endif()
-
-  set(TRITON_DEPENDS googletest protobuf re2)
-  if(${TRITON_ENABLE_GCS})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} google-cloud-cpp)
-  endif() # TRITON_ENABLE_GCS
-  if(${TRITON_ENABLE_S3})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} aws-sdk-cpp)
-    # Add where to find all S3 dependencies to CMAKE_PREFIX_PATH
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}
-      ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/cmake
-      ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib)
-  endif() # TRITON_ENABLE_S3
-  if(${TRITON_ENABLE_AZURE_STORAGE})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} azure-sdk)
-    set(TRITON_AZURE_STORAGE_PACKAGE_DIRS
-      -Dazure-storage-blobs-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/azure-sdk/share/azure-storage-blobs-cpp
-      -Dazure-storage-common-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/azure-sdk/share/azure-storage-common-cpp
-      -Dazure-core-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/azure-sdk/share/azure-core-cpp
-      -Dazure-identity-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/azure-sdk/share/azure-identity-cpp
-    )
-  endif() # TRITON_ENABLE_AZURE_STORAGE
-  if(${TRITON_ENABLE_METRICS})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} prometheus-cpp)
-  endif() # TRITON_ENABLE_METRICS
-  if(${TRITON_ENABLE_GPU})
-    set(TRITON_DEPENDS ${TRITON_DEPENDS} cnmem)
-  endif() # TRITON_ENABLE_GPU
-
-  ExternalProject_Add(triton-core
-    PREFIX triton-core
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/triton-core"
-    CMAKE_CACHE_ARGS
-      -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
-      -Dutf8_range_DIR:PATH=${_FINDPACKAGE_UTF8_RANGE_CONFIG_DIR}
-      ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
-      ${_CMAKE_ARGS_CMAKE_TOOLCHAIN_FILE}
-      ${_CMAKE_ARGS_VCPKG_TARGET_TRIPLET}
-      -DGTEST_ROOT:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/googletest
-      -DgRPC_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/grpc/lib/cmake/grpc
-      -Dc-ares_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/c-ares/${LIB_DIR}/cmake/c-ares
-      -Dabsl_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/absl/${LIB_DIR}/cmake/absl
-      -Dre2_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/re2/${LIB_DIR}/cmake/re2
-      -Dnlohmann_json_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/nlohmann_json/share/cmake/nlohmann_json
-      -Dprometheus-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/prometheus-cpp/${LIB_DIR}/cmake/prometheus-cpp
-      -Dgoogle_cloud_cpp_storage_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/google-cloud-cpp/${LIB_DIR}/cmake/google_cloud_cpp_storage
-      -Dgoogle_cloud_cpp_rest_internal_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/google-cloud-cpp/${LIB_DIR}/cmake/google_cloud_cpp_rest_internal
-      -Dgoogle_cloud_cpp_common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/google-cloud-cpp/${LIB_DIR}/cmake/google_cloud_cpp_common
-      ${TRITON_AZURE_STORAGE_PACKAGE_DIRS}
-      -DCrc32c_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/crc32c/${LIB_DIR}/cmake/Crc32c
-      -DAWSSDK_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/cmake/AWSSDK
-      -Daws-cpp-sdk-core_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/cmake/aws-cpp-sdk-core
-      -Daws-cpp-sdk-s3_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/cmake/aws-cpp-sdk-s3
-      -Daws-c-event-stream_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-event-stream/cmake
-      -Daws-c-common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-common/cmake
-      -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-checksums/cmake
-      -Daws-crt-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-crt-cpp/cmake
-      -Daws-c-http_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-http/cmake
-      -Daws-c-io_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-io/cmake
-      -Ds2n_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/s2n/cmake
-      -Daws-c-cal_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-cal/cmake
-      -Daws-c-s3_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-s3/cmake
-      -Daws-c-auth_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-auth/cmake
-      -Daws-c-compression_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-compression/cmake
-      -Daws-c-mqtt_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-mqtt/cmake
-      -Daws-c-sdkutils_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/${LIB_DIR}/aws-c-sdkutils/cmake
-      -DCMAKE_PREFIX_PATH:PATH=${CMAKE_PREFIX_PATH}
-      -DCNMEM_PATH:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/cnmem
-      -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION}
-      -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
-      -DTRITON_EXTRA_LIB_PATHS:PATH=${TRITON_EXTRA_LIB_PATHS}
-      -DTRITON_ENABLE_NVTX:BOOL=${TRITON_ENABLE_NVTX}
-      -DTRITON_ENABLE_TRACING:BOOL=${TRITON_ENABLE_TRACING}
-      -DTRITON_ENABLE_LOGGING:BOOL=${TRITON_ENABLE_LOGGING}
-      -DTRITON_ENABLE_STATS:BOOL=${TRITON_ENABLE_STATS}
-      -DTRITON_ENABLE_GPU:BOOL=${TRITON_ENABLE_GPU}
-      -DTRITON_ENABLE_MALI_GPU:BOOL=${TRITON_ENABLE_MALI_GPU}
-      -DTRITON_MIN_COMPUTE_CAPABILITY:STRING=${TRITON_MIN_COMPUTE_CAPABILITY}
-      -DTRITON_ENABLE_METRICS:BOOL=${TRITON_ENABLE_METRICS}
-      -DTRITON_ENABLE_METRICS_GPU:BOOL=${TRITON_ENABLE_METRICS_GPU}
-      -DTRITON_ENABLE_METRICS_CPU:BOOL=${TRITON_ENABLE_METRICS_CPU}
-      -DTRITON_ENABLE_GCS:BOOL=${TRITON_ENABLE_GCS}
-      -DTRITON_ENABLE_AZURE_STORAGE:BOOL=${TRITON_ENABLE_AZURE_STORAGE}
-      -DTRITON_ENABLE_S3:BOOL=${TRITON_ENABLE_S3}
-      -DTRITON_ENABLE_ENSEMBLE:BOOL=${TRITON_ENABLE_ENSEMBLE}
-      -DTRITON_MIN_CXX_STANDARD:STRING=${TRITON_MIN_CXX_STANDARD}
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_INSTALL_PREFIX}
-      -DTRITON_VERSION:STRING=${TRITON_VERSION}
-    DEPENDS ${TRITON_DEPENDS}
-  )
+  # core/src is built in this scope rather than as an ExternalProject.
+  #
+  # It used to be an ExternalProject fed by third_party: a separate CMake cache
+  # meant every dependency path had to be forwarded by hand
+  # (-DProtobuf_DIR, -DgRPC_DIR, -Dabsl_DIR, ...), each pointing into
+  # TRITON_THIRD_PARTY_INSTALL_PREFIX. As a subdirectory it inherits
+  # CMAKE_PREFIX_PATH and the <Pkg>_DIR cache entries the caller already
+  # published, so those forwards are unnecessary rather than merely updated --
+  # and third_party is no longer fetched at all.
+  #
+  # Building standalone still works: whoever configures this tree is responsible
+  # for making the packages in src/CMakeLists.txt findable, exactly as for any
+  # other CMake project.
+  add_subdirectory(src)
 endif() # NOT TRITON_CORE_HEADERS_ONLY
 
 #

--- a/python/build_wheel.py
+++ b/python/build_wheel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@ import shutil
 import subprocess
 import sys
 import zipfile
-from distutils.dir_util import copy_tree
 from tempfile import mkdtemp, mkstemp
 
 # ANSI colors for CI log readability (rendered by GitLab CI, harmlessly
@@ -66,7 +65,7 @@ def touch(path):
 
 
 def cpdir(src, dest):
-    copy_tree(src, dest, preserve_symlinks=1)
+    shutil.copytree(src, dest, symlinks=True, dirs_exist_ok=True)
 
 
 def sed(pattern, replace, source, dest=None):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,10 @@ endif() # TRITON_ENABLE_GCS
 #
 if(${TRITON_ENABLE_S3})
   find_package(ZLIB REQUIRED)
+  # AWSSDK is the config name either way, but the component target it exports is
+  # not: upstream's own build installs aws-cpp-sdk-s3, while ConanCenter names
+  # its components after the package and exports AWS::aws-sdk-cpp-s3. The
+  # namespaced form is what is linked below.
   find_package(AWSSDK REQUIRED COMPONENTS s3)
   message(STATUS "Using aws-sdk-cpp ${AWSSDK_VERSION}")
 endif()
@@ -323,7 +327,7 @@ endif() # TRITON_ENABLE_GCS
 if(${TRITON_ENABLE_S3})
   target_include_directories(
     triton-core
-    PRIVATE $<TARGET_PROPERTY:aws-cpp-sdk-s3,INTERFACE_INCLUDE_DIRECTORIES>
+    PRIVATE $<TARGET_PROPERTY:AWS::aws-sdk-cpp-s3,INTERFACE_INCLUDE_DIRECTORIES>
   )
 endif()
 
@@ -494,7 +498,7 @@ if(${TRITON_ENABLE_S3})
   target_link_libraries(
     triton-core
     PRIVATE
-      aws-cpp-sdk-s3
+      AWS::aws-sdk-cpp-s3
   )
 endif() # TRITON_ENABLE_S3
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,10 +60,18 @@ endif() # TRITON_ENABLE_GPU
 #
 # Boost
 #
-# Minimum of 1.78 required for use of boost::span. This can eventually be
-# relaxed and replaced with std::span in C++20.
-cmake_policy (SET CMP0167 OLD)
-find_package(Boost 1.78 REQUIRED COMPONENTS)
+# Only header-only libraries are used -- algorithm/string, core/span,
+# functional/hash and interprocess -- hence the empty COMPONENTS list.
+#
+# No minimum version is declared here. boost::span needs 1.78 or newer, but the
+# version is pinned by whoever provides the package (TRITON_BOOST_VERSION in the
+# server build), so repeating a floor here would just be a second place to
+# update. boost::span can go away entirely once this builds as C++20 and
+# std::span is available.
+#
+# CMP0167 is deliberately left at its default (NEW from CMake 3.30), so Boost's
+# own BoostConfig.cmake is used rather than CMake's deprecated FindBoost module.
+find_package(Boost REQUIRED COMPONENTS)
 message(STATUS "Using Boost ${Boost_VERSION}")
 
 #
@@ -245,7 +253,7 @@ add_library(
   TritonCore::triton-core ALIAS triton-core
 )
 
-target_compile_features(triton-core PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_features(triton-core PRIVATE cxx_std_${CMAKE_CXX_STANDARD})
 target_compile_options(
   triton-core
   PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,11 @@ endif() # TRITON_ENABLE_METRICS
 # GCS
 #
 if(${TRITON_ENABLE_GCS})
+  # Upstream installs a config per component, so this is the storage client's
+  # own google_cloud_cpp_storageConfig.cmake. ConanCenter's packaging instead
+  # consolidates everything into google-cloud-cpp-config.cmake, which is why
+  # this name has to match whoever provides the package -- Triton's recipe
+  # (server/conan/recipes/google-cloud-cpp) preserves the upstream layout.
   find_package(google_cloud_cpp_storage REQUIRED)
   message(STATUS "Using google-cloud-cpp ${google_cloud_cpp_storage_VERSION}")
 endif() # TRITON_ENABLE_GCS
@@ -110,11 +115,13 @@ endif()
 # Azure Storage
 #
 if(${TRITON_ENABLE_AZURE_STORAGE})
-  find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
-  message(STATUS "Using Azure storage blobs ${azure-storage-blobs-cpp_VERSION}")
-
-  find_package(azure-identity-cpp CONFIG REQUIRED)
-  message(STATUS "Using Azure identity ${azure-identity-cpp_VERSION}")
+  # azure-sdk-for-cpp ships a single AzureSDKConfig.cmake covering every
+  # component, rather than the separate azure-storage-blobs-cpp and
+  # azure-identity-cpp configs the individual upstream repos install. Both
+  # Azure::azure-storage-blobs and Azure::azure-identity, linked below, come
+  # from this one package.
+  find_package(AzureSDK CONFIG REQUIRED)
+  message(STATUS "Using Azure SDK ${AzureSDK_VERSION}")
 endif()
 
 configure_file(libtritonserver.ldscript libtritonserver.ldscript COPYONLY)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -588,12 +588,16 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${GTEST_INCLUDE_DIRS}
+    # instance_queue.h -> payload.h -> backend_model_instance.h includes
+    # boost/core/span.hpp, so the headers have to be reachable here.
+    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(
   instance_queue_test
   PRIVATE
     triton-common-error        # from repo-common
+    triton-common-json         # from repo-common, carries rapidjson
     triton-common-logging      # from repo-common
     triton-common-model-config # from repo-common
     proto-library              # from repo-common

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -127,6 +127,10 @@ if(${TRITON_ENABLE_GPU})
       ${GTEST_INCLUDE_DIRS}
       ${CNMEM_PATH}/include
       ${Boost_INCLUDE_DIRS}
+      # These tests compile core sources directly rather than consuming them
+      # through triton-core, whose include paths are PRIVATE. re2 comes in via
+      # filesystem/implementations/common.h.
+      $<TARGET_PROPERTY:re2::re2,INTERFACE_INCLUDE_DIRECTORIES>
   )
 
   target_compile_definitions(
@@ -143,6 +147,7 @@ if(${TRITON_ENABLE_GPU})
     response_cache_test
     PRIVATE
       triton-common-error        # from repo-common
+      triton-common-json         # from repo-common, carries rapidjson
       triton-common-logging      # from repo-common
       triton-common-model-config # from repo-common
       proto-library              # from repo-common
@@ -239,6 +244,9 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
       ${CNMEM_PATH}/include
+      # pinned_memory_manager.h includes boost/interprocess, as
+      # response_cache_test and repo_agent_test already account for.
+      ${Boost_INCLUDE_DIRS}
   )
 
   target_compile_definitions(
@@ -304,6 +312,7 @@ if(${TRITON_ENABLE_GPU})
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
       ${CNMEM_PATH}/include
+      ${Boost_INCLUDE_DIRS}
   )
 
   target_compile_definitions(
@@ -413,6 +422,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include
     ${GTEST_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
+    $<TARGET_PROPERTY:re2::re2,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_link_libraries(
@@ -466,6 +476,9 @@ if(${TRITON_ENABLE_METRICS})
       ${CMAKE_CURRENT_SOURCE_DIR}/..
       ${CMAKE_CURRENT_SOURCE_DIR}/../../include
       ${GTEST_INCLUDE_DIRS}
+      # metrics.cc and pinned_memory_manager.cc both reach boost/interprocess
+      # through pinned_memory_manager.h.
+      ${Boost_INCLUDE_DIRS}
   )
 
   target_compile_definitions(


### PR DESCRIPTION
## Summary
- Part of the cross-repo effort (server/core/common) to replace the `third_party` ExternalProject superbuild with Conan-resolved dependencies.
- Builds `core/src` in-tree via `add_subdirectory` instead of as a `third_party` ExternalProject; matches cloud package config names to what actually provides them; names dependencies that the old shared `third_party` prefix used to supply implicitly.
- Replaces `distutils.dir_util.copy_tree` (removed in Python 3.12) with `shutil.copytree`, unrelated to Conan but found while testing this build path.
- Declares `instance_queue_test`'s Boost and rapidjson dependencies explicitly — it compiles `instance_queue.cc` directly rather than through `triton-core`, whose include paths are PRIVATE, so per-target (Conan) builds need them declared. This gap is invisible under the old shared-prefix superbuild, which is why upstream CI didn't catch it.

## Test plan
- [x] Builds cleanly as part of the full `server` Conan configure + `cmake --build -t install` (cold `CONAN_HOME`, see TRI-1611 notes).
- [x] `instance_queue_test` compiles and links.
- [ ] `instance_queue_test` not yet executed; no `L0_*` suite run against this branch.

Companion PRs: triton-inference-server/common, triton-inference-server/server.