### PR TITLE
build: Update C++ standard from c++17 to c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(TRITON_CORE_HEADERS_ONLY "Build only headers and stub" ON)
 #
 # Specifying min required C++ standard
 #
-set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+set(TRITON_MIN_CXX_STANDARD 20 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 #
 # Triton Server API

--- a/python/tritonserver/CMakeLists.txt
+++ b/python/tritonserver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ target_link_libraries(
   triton-core-serverapi           # from repo-core
   triton-core-serverstub          # from repo-core
 )
-target_compile_features(python-bindings PRIVATE cxx_std_17)
+target_compile_features(python-bindings PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 
 set_property(TARGET python-bindings PROPERTY OUTPUT_NAME triton_bindings)
 # Add Triton library default path in 'rpath' for runtime library lookup

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,7 +133,7 @@ set(
   infer_trace.cc
   instance_queue.cc
   label_provider.cc
-  memory.cc
+  triton_memory.cc
   metric_model_reporter.cc
   metrics.cc
   metric_family.cc
@@ -180,7 +180,7 @@ set(
   infer_trace.h
   instance_queue.h
   label_provider.h
-  memory.h
+  triton_memory.h
   metric_model_reporter.h
   metrics.h
   metric_family.h

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -682,7 +682,7 @@ TritonModel::PrepareInstances(
 
         // Note that the local variables should be captured by value
         creation_results.emplace_back(
-            std::async(launch_policy, [=, &instance_mu]() {
+            std::async(launch_policy, [=, this, &instance_mu]() {
               // The requested instance did not match an existing instance.
               // Create a new instance.
               std::shared_ptr<TritonModelInstance> new_instance;

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -33,13 +33,13 @@
 #include <thread>
 
 #include "constants.h"
-#include "memory.h"
 #include "metric_model_reporter.h"
 #include "model_config.pb.h"
 #include "model_config_utils.h"
 #include "server_message.h"
 #include "status.h"
 #include "triton/common/sync_queue.h"
+#include "triton_memory.h"
 
 namespace triton { namespace core {
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -34,12 +34,12 @@
 #include "infer_response.h"
 #include "infer_stats.h"
 #include "infer_trace.h"
-#include "memory.h"
 #include "response_allocator.h"
 #include "sequence_state.h"
 #include "status.h"
 #include "triton/common/logging.h"
 #include "triton/common/model_config.h"
+#include "triton_memory.h"
 #include "tritonserver_apis.h"
 
 namespace triton { namespace core {

--- a/src/sequence_state.cc
+++ b/src/sequence_state.cc
@@ -29,9 +29,9 @@
 #include <cstdint>
 
 #include "cuda_utils.h"
-#include "memory.h"
 #include "model_config_utils.h"
 #include "triton/common/logging.h"
+#include "triton_memory.h"
 
 namespace triton { namespace core {
 

--- a/src/sequence_state.h
+++ b/src/sequence_state.h
@@ -28,9 +28,9 @@
 #include <map>
 #include <memory>
 
-#include "memory.h"
 #include "status.h"
 #include "triton/common/model_config.h"
+#include "triton_memory.h"
 
 #pragma once
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -75,13 +75,13 @@ set(
 set(
   MEMORY_SRCS
   ../buffer_attributes.cc
-  ../memory.cc
+  ../triton_memory.cc
 )
 
 set(
   MEMORY_HDRS
   ../buffer_attributes.h
-  ../memory.h
+  ../triton_memory.h
 )
 
 #

--- a/src/test/memory_test.cc
+++ b/src/test/memory_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -23,8 +23,6 @@
 // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "memory.h"
-
 #include <cuda_runtime_api.h>
 
 #include "cuda_block_manager.h"
@@ -33,6 +31,7 @@
 #include "gtest/gtest.h"
 #include "pinned_memory_manager.h"
 #include "triton/core/tritonserver.h"
+#include "triton_memory.h"
 
 namespace tc = triton::core;
 

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,8 +29,8 @@
 #include "cache_manager.h"
 #include "gtest/gtest-spi.h"
 #include "gtest/gtest.h"
-#include "memory.h"
 #include "triton/common/logging.h"
+#include "triton_memory.h"
 
 namespace tc = triton::core;
 

--- a/src/triton_memory.cc
+++ b/src/triton_memory.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -24,7 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "memory.h"
+#include "triton_memory.h"
 
 #include "pinned_memory_manager.h"
 #include "triton/common/logging.h"

--- a/src/triton_memory.h
+++ b/src/triton_memory.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
#### What does the PR do?
- Upstream PyTorch raised ATen's minimum required C++ standard from 17 to 20 (pytorch/pytorch#178150), breaking the pytorch_backend build.
- Bumps this repo's C++ standard default from 17 to 20 for consistency across the Triton stack.
- Also fixes a genuine C++20 compile break surfaced by the bump: explicit `this` capture in a lambda in `src/backend_model.cc` (implicit capture via `[=]` is deprecated in C++20, and this repo builds with -Werror=deprecated).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/pytorch_backend#210
- triton-inference-server/backend#129
- triton-inference-server/checksum_repository_agent#16
- triton-inference-server/identity_backend#38
- triton-inference-server/local_cache#18
- triton-inference-server/openvino_backend#123
- triton-inference-server/redis_cache#26
- triton-inference-server/repeat_backend#21
- triton-inference-server/square_backend#24
- triton-inference-server/tensorrt_backend#128
- triton-inference-server/third_party#82
- triton-inference-server/common#166
- triton-inference-server/client#922
- triton-inference-server/onnxruntime_backend#359
- triton-inference-server/server#8962
- triton-inference-server/python_backend#455
- triton-inference-server/fil_backend#461
- triton-inference-server/dali_backend#311

#### Where should the reviewer start?
- `CMakeLists.txt` - `src/backend_model.cc`

#### Test plan:
- CI Pipeline ID: 67062220

#### Caveats:
This repo's own build broke under C++20 (see the fix commit) — the deprecated-lambda-capture error was found and fixed as part of this same change, not a separate follow-up.

#### Background
Part of a coordinated C++17->C++20 bump across ~18 Triton component repos (TRI-1877), triggered by upstream PyTorch's ATen.h now requiring C++20.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1877
