### PR TITLE
build: Update C++ standard from c++17 to c++20 (#525)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(TRITON_CORE_HEADERS_ONLY "Build only headers and stub" ON)
 #
 # Specifying min required C++ standard
 #
-set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+set(TRITON_MIN_CXX_STANDARD 20 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 #
 # Triton Server API

--- a/python/tritonserver/CMakeLists.txt
+++ b/python/tritonserver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ target_link_libraries(
   triton-core-serverapi           # from repo-core
   triton-core-serverstub          # from repo-core
 )
-target_compile_features(python-bindings PRIVATE cxx_std_17)
+target_compile_features(python-bindings PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 
 set_property(TARGET python-bindings PROPERTY OUTPUT_NAME triton_bindings)
 # Add Triton library default path in 'rpath' for runtime library lookup

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,7 +133,7 @@ set(
   infer_trace.cc
   instance_queue.cc
   label_provider.cc
-  memory.cc
+  triton_memory.cc
   metric_model_reporter.cc
   metrics.cc
   metric_family.cc
@@ -180,7 +180,7 @@ set(
   infer_trace.h
   instance_queue.h
   label_provider.h
-  memory.h
+  triton_memory.h
   metric_model_reporter.h
   metrics.h
   metric_family.h

--- a/src/backend_model.cc
+++ b/src/backend_model.cc
@@ -682,7 +682,7 @@ TritonModel::PrepareInstances(
 
         // Note that the local variables should be captured by value
         creation_results.emplace_back(
-            std::async(launch_policy, [=, &instance_mu]() {
+            std::async(launch_policy, [=, this, &instance_mu]() {
               // The requested instance did not match an existing instance.
               // Create a new instance.
               std::shared_ptr<TritonModelInstance> new_instance;

--- a/src/backend_model_instance.h
+++ b/src/backend_model_instance.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -33,13 +33,13 @@
 #include <thread>
 
 #include "constants.h"
-#include "memory.h"
 #include "metric_model_reporter.h"
 #include "model_config.pb.h"
 #include "model_config_utils.h"
 #include "server_message.h"
 #include "status.h"
 #include "triton/common/sync_queue.h"
+#include "triton_memory.h"
 
 namespace triton { namespace core {
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -34,12 +34,12 @@
 #include "infer_response.h"
 #include "infer_stats.h"
 #include "infer_trace.h"
-#include "memory.h"
 #include "response_allocator.h"
 #include "sequence_state.h"
 #include "status.h"
 #include "triton/common/logging.h"
 #include "triton/common/model_config.h"
+#include "triton_memory.h"
 #include "tritonserver_apis.h"
 
 namespace triton { namespace core {

--- a/src/sequence_state.cc
+++ b/src/sequence_state.cc
@@ -29,9 +29,9 @@
 #include <cstdint>
 
 #include "cuda_utils.h"
-#include "memory.h"
 #include "model_config_utils.h"
 #include "triton/common/logging.h"
+#include "triton_memory.h"
 
 namespace triton { namespace core {
 

--- a/src/sequence_state.h
+++ b/src/sequence_state.h
@@ -28,9 +28,9 @@
 #include <map>
 #include <memory>
 
-#include "memory.h"
 #include "status.h"
 #include "triton/common/model_config.h"
+#include "triton_memory.h"
 
 #pragma once
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -75,13 +75,13 @@ set(
 set(
   MEMORY_SRCS
   ../buffer_attributes.cc
-  ../memory.cc
+  ../triton_memory.cc
 )
 
 set(
   MEMORY_HDRS
   ../buffer_attributes.h
-  ../memory.h
+  ../triton_memory.h
 )
 
 #

--- a/src/test/memory_test.cc
+++ b/src/test/memory_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -23,8 +23,6 @@
 // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "memory.h"
-
 #include <cuda_runtime_api.h>
 
 #include "cuda_block_manager.h"
@@ -33,6 +31,7 @@
 #include "gtest/gtest.h"
 #include "pinned_memory_manager.h"
 #include "triton/core/tritonserver.h"
+#include "triton_memory.h"
 
 namespace tc = triton::core;
 

--- a/src/test/response_cache_test.cc
+++ b/src/test/response_cache_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,8 +29,8 @@
 #include "cache_manager.h"
 #include "gtest/gtest-spi.h"
 #include "gtest/gtest.h"
-#include "memory.h"
 #include "triton/common/logging.h"
+#include "triton_memory.h"
 
 namespace tc = triton::core;
 

--- a/src/triton_memory.cc
+++ b/src/triton_memory.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -24,7 +24,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "memory.h"
+#include "triton_memory.h"
 
 #include "pinned_memory_manager.h"
 #include "triton/common/logging.h"

--- a/src/triton_memory.h
+++ b/src/triton_memory.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
Cherry-pick of the C++17->C++20 standard bump (TRI-1877) onto `r26.09`.

* build: Update C++ standard from c++17 to c++20

Upstream PyTorch raised ATen's minimum required C++ standard from 17
to 20 (pytorch/pytorch#178150), which broke the pytorch_backend build.
Align this repo's TRITON_MIN_CXX_STANDARD/CMAKE_CXX_STANDARD default
with that floor for consistency across the stack.

TRI-1877

* fix: explicitly capture 'this' in backend_model.cc lambda

C++20 deprecates implicit capture of 'this' via a bare '[=]' default
capture (CWG2211); with -Werror=deprecated this now fails the build
after the C++17->20 bump. List 'this' explicitly alongside the
existing by-value default and '&instance_mu' reference capture.

TRI-1877

* fix: rename memory.h/.cc to avoid colliding with <memory>

Same class of bug just fixed in tensorrt_backend's semaphore.h and
filesystem.h: a project header sharing a name with a C++ standard
library header, combined with a project include directory preceding
the system include path, risks a future internal #include <memory>
from libstdc++ silently resolving to this project's own header. Not
currently triggering a build failure (core built successfully with
TRITON_MIN_CXX_STANDARD=20 in the observed CI runs), but renamed
proactively given the same repo family already proved this exact
pattern live once.

TRI-1877

* fix: update test/CMakeLists.txt reference after memory.cc rename

Missed in the prior memory.h/.cc -> triton_memory.h/.cc rename commit:
src/test/CMakeLists.txt lists ../memory.cc/../memory.h directly as
MEMORY_SRCS/MEMORY_HDRS (not via #include), which is a distinct
reference path my earlier sed pass over #include statements and
src/CMakeLists.txt didn't touch. Broke CMake configure with "Cannot
find source file: ../memory.cc" for response_cache_test.

TRI-1877

* fix: use TRITON_MIN_CXX_STANDARD for python-bindings instead of hardcoded cxx_std_17

(cherry picked from commit 4809f7d96aef0acd2263da51f2edc02cbe349510)