### PR TITLE
build: migrate tritonserver wheel to hatchling with PEP 639 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,13 @@
 name = "tritonserver"
 authors = [{ name = "NVIDIA Inc.", email = "sw-dl-triton@nvidia.com" }]
 description = "Triton Inference Server In-Process Python API"
-license = { file = "LICENSE.txt" }
+readme = { content-type = "text/markdown", text = """See the [Triton Inference Server](https://github.com/triton-inference-server/server) repository for package details. `tritonserver` provides the in-process Python API for embedding Triton directly in a Python application.""" }
+# PEP 639 SPDX expression, emitted as License-Expression at
+# Metadata-Version 2.4. The matching "License ::" trove classifier must stay
+# removed: declaring both is rejected outright by the build backend.
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
+requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = ["numpy<2"]
 classifiers = [
@@ -41,43 +47,41 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
     "Environment :: Console",
     "Natural Language :: English",
-    "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
 ]
 
-[tool.setuptools]
-include-package-data = true
+[project.urls]
+Homepage = "https://developer.nvidia.com/nvidia-triton-inference-server"
 
-[tool.setuptools.dynamic]
+[tool.hatch.version]
 # Resolve the `dynamic = ["version"]` declaration above from the
 # TRITON_VERSION file shipped alongside the wheel build directory.
-# build_wheel.py copies TRITON_VERSION into the wheel build root so this
+# build_wheel.py writes TRITON_VERSION into the wheel build root so this
 # lookup succeeds at build time and the wheel is versioned with the
 # Triton release (e.g. 2.68.0) instead of falling back to 0.0.0.
-version = {file = "TRITON_VERSION"}
+path = "TRITON_VERSION"
+pattern = "(?P<version>.+)"
 
-[tool.setuptools.package-data]
-tritonserver = ["_c/triton_bindings.*.so"]
+[tool.hatch.build.targets.wheel]
+packages = ["tritonserver"]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+# Tags the wheel platform-specific and generates the _c type stubs --
+# see python/hatch_build.py.
+path = "hatch_build.py"
 
 [build-system]
 requires = [
-    # setuptools>=77.0.0 is required for PEP 639 license-file support at
-    # Metadata-Version 2.4; 75.3.0 writes a License-File field while still
-    # declaring Metadata-Version 2.1, which PyPI/Kitmaker's Warehouse
-    # validation rejects ("license-file introduced in metadata version
-    # 2.4, not 2.1"). See TRI-1775.
-    "setuptools==77.0.1",
-    "wheel==0.44.0",
-    # For stubgen:
+    "hatchling==1.27.0",
+    # For stubgen, run from the build hook:
     "mypy==1.11.0",
     "numpy<2",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 GPU = ["cupy-cuda13x"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,12 @@ tritonserver = ["_c/triton_bindings.*.so"]
 
 [build-system]
 requires = [
-    "setuptools==75.3.0",
+    # setuptools>=77.0.0 is required for PEP 639 license-file support at
+    # Metadata-Version 2.4; 75.3.0 writes a License-File field while still
+    # declaring Metadata-Version 2.1, which PyPI/Kitmaker's Warehouse
+    # validation rejects ("license-file introduced in metadata version
+    # 2.4, not 2.1"). See TRI-1775.
+    "setuptools==77.0.1",
     "wheel==0.44.0",
     # For stubgen:
     "mypy==1.11.0",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,14 +29,14 @@ add_subdirectory(tritonserver)
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/TRITON_VERSION ${TRITON_VERSION})
 configure_file(../LICENSE LICENSE.txt COPYONLY)
-configure_file(setup.py setup.py @ONLY)
+configure_file(hatch_build.py hatch_build.py COPYONLY)
 configure_file(../pyproject.toml pyproject.toml COPYONLY)
 file(COPY test/  DESTINATION ./test/.)
 
 set(WHEEL_DEPENDS
       ${CMAKE_CURRENT_BINARY_DIR}/TRITON_VERSION
       ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt
-      ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+      ${CMAKE_CURRENT_BINARY_DIR}/hatch_build.py
       ${CMAKE_CURRENT_BINARY_DIR}/tritonserver
       python-bindings
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -36,6 +36,7 @@ file(COPY test/  DESTINATION ./test/.)
 set(WHEEL_DEPENDS
       ${CMAKE_CURRENT_BINARY_DIR}/TRITON_VERSION
       ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt
+      ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml
       ${CMAKE_CURRENT_BINARY_DIR}/hatch_build.py
       ${CMAKE_CURRENT_BINARY_DIR}/tritonserver
       python-bindings

--- a/python/build_wheel.py
+++ b/python/build_wheel.py
@@ -507,7 +507,11 @@ if __name__ == "__main__":
     if os.path.isdir(_dist):
         shutil.rmtree(_dist)
     print("=== Building wheel")
-    args = ["python3", "-m", "build"]
+    # --wheel: only the wheel is consumed downstream (auditwheel repair +
+    # dist copy). Without it `build` makes an sdist first and builds the
+    # wheel from it, so generated inputs such as TRITON_VERSION must also
+    # be inside the sdist for dynamic version resolution to work.
+    args = ["python3", "-m", "build", "--wheel"]
 
     # Release-semantic X.Y.Z -> PyPI-clean (no variant label).
     # Anything else -> PEP 817 variant label. The pipeline id is already

--- a/python/build_wheel.py
+++ b/python/build_wheel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/python/build_wheel.py
+++ b/python/build_wheel.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
     )
 
     shutil.copyfile("LICENSE.txt", os.path.join(FLAGS.whl_dir, "LICENSE.txt"))
-    shutil.copyfile("setup.py", os.path.join(FLAGS.whl_dir, "setup.py"))
+    shutil.copyfile("hatch_build.py", os.path.join(FLAGS.whl_dir, "hatch_build.py"))
     shutil.copyfile("pyproject.toml", os.path.join(FLAGS.whl_dir, "pyproject.toml"))
     # pyproject.toml resolves the wheel version from the TRITON_VERSION file
     # next to it. Write the chosen version into the wheel build root; do NOT

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -1,4 +1,4 @@
-# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,43 +24,34 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 import subprocess
 
-from setuptools import Distribution, setup
-from setuptools.command.build_py import build_py
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
-class BuildPyCommand(build_py):
-    def run(self):
-        build_py.run(self)
-        # Generate stub files:
-        package_name = self.distribution.metadata.name
+class CustomBuildHook(BuildHookInterface):
+    """Tag the tritonserver wheel as platform-specific and emit type stubs.
+
+    The wheel ships an arch-specific CPython extension
+    (tritonserver/_c/triton_bindings.cpython-<xy>-<arch>-linux-gnu.so) that
+    build_wheel.py stages into the package rather than having the backend
+    compile it. Hatchling therefore sees only data files and would emit a
+    pure-Python "py3-none-any" wheel, which auditwheel rejects.
+
+    pure_python=False plus infer_tag=True makes hatchling derive the
+    cp<XY>-cp<XY>-linux_<arch> tag from the running interpreter, reproducing
+    what the setuptools BinaryDistribution shim did. See TRI-983.
+
+    stubgen regenerates the _c type stubs next to the extension so they are
+    collected into the wheel, replacing the setuptools build_py subclass.
+    """
+
+    def initialize(self, version, build_data):
+        build_data["pure_python"] = False
+        build_data["infer_tag"] = True
+        # Written into the package tree (self.root is the wheel build root)
+        # so hatchling collects the stubs alongside the extension.
         subprocess.run(
-            ["stubgen", "-p", f"{package_name}._c", "-o", f"{self.build_lib}"],
+            ["stubgen", "-p", "tritonserver._c", "-o", self.root],
             check=True,
         )
-
-
-# The wheel ships an arch-specific CPython extension
-# (tritonserver/_c/triton_bindings.cpython-<xy>-<arch>-linux-gnu.so)
-# that is copied into the package_data at build time rather than
-# declared via setup(ext_modules=...). Without a declared ext_module
-# setuptools treats the distribution as pure-Python and emits
-# "Root-Is-Purelib: true" in the WHEEL metadata + a "py3-none-any"
-# tag, which auditwheel rightly rejects.
-#
-# Signaling has_ext_modules()=True via a custom Distribution subclass
-# is the canonical way to tell setuptools the wheel is binary without
-# triggering a fake compilation step. setuptools then:
-#   - sets Root-Is-Purelib to false (required for auditwheel repair),
-#   - auto-derives the correct cp<XY>-cp<XY>-linux_<arch> tag from
-#     the current interpreter and sysconfig.get_platform().
-# See TRI-983.
-class BinaryDistribution(Distribution):
-    def has_ext_modules(self):
-        return True
-
-
-if __name__ == "__main__":
-    setup(distclass=BinaryDistribution, cmdclass={"build_py": BuildPyCommand})


### PR DESCRIPTION
#### What does the PR do?

- Pins the build backend so wheel metadata no longer depends on whatever the build image ships.
- `setuptools` <77 wrote a `License-File` field while still declaring `Metadata-Version: 2.1` — the combination PyPI/Kitmaker Warehouse rejects. The wheel now emits 2.4.
- Migrates to hatchling; the `BinaryDistribution` shim and the `stubgen` `build_py` subclass move to `python/hatch_build.py`.
- `license` becomes SPDX `BSD-3-Clause` + `license-files`; adds `requires-python = ">=3.12"`.

#### Where should the reviewer start?
`pyproject.toml` and `python/hatch_build.py`.

#### Test plan:
Verified against a staged build tree: correct `cp312-cp312-linux_<arch>` tag, Metadata-Version 2.4, `License-Expression`, `License-File`, `Requires-Python`, `_api`/`_c` packages and `py.typed` all present, `twine check` passes.

#### Caveats:
`stubgen` **output content** needs the real compiled extension, so only the mechanism was verified locally — it must be confirmed in CI.

#### Related PRs:
- triton-inference-server/server#8970
- triton-inference-server/client#927
- triton-inference-server/model_analyzer#1038
- triton-inference-server/perf_analyzer#469
- triton-inference-server/triton_cli#130

#### Related Issues:
- Resolves: TRI-1775
<sup>
CI (internal): [#67460724](http://tritonserver.local/ci/pipelines/67460724)<br/>
</sup>
